### PR TITLE
Search for nvdisasm in the conda environment / `CUDA_HOME` / default CUDA install location in addition to the path

### DIFF
--- a/numba_cuda/numba/cuda/codegen.py
+++ b/numba_cuda/numba/cuda/codegen.py
@@ -4,6 +4,7 @@ from numba.core import config, serialize
 from numba.core.codegen import Codegen, CodeLibrary
 from .cudadrv import devices, driver, nvvm, runtime
 from numba.cuda.cudadrv.libs import get_cudalib
+from numba.cuda.cuda_paths import get_cuda_paths
 
 import os
 import subprocess
@@ -24,7 +25,8 @@ def run_nvdisasm(cubin, flags):
             f.write(cubin)
 
         try:
-            cp = subprocess.run(['nvdisasm', *flags, fname], check=True,
+            nvdisasm = get_cuda_paths()['nvdisasm'].info
+            cp = subprocess.run([nvdisasm, *flags, fname], check=True,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
         except FileNotFoundError as e:

--- a/numba_cuda/numba/cuda/dispatcher.py
+++ b/numba_cuda/numba/cuda/dispatcher.py
@@ -247,7 +247,7 @@ class _Kernel(serialize.ReduceMixin):
         '''
         Returns the CFG of the SASS for this kernel.
 
-        Requires nvdisasm to be available on the PATH.
+        Requires nvdisasm to be available.
         '''
         return self._codelibrary.get_sass_cfg()
 
@@ -255,7 +255,7 @@ class _Kernel(serialize.ReduceMixin):
         '''
         Returns the SASS code for this kernel.
 
-        Requires nvdisasm to be available on the PATH.
+        Requires nvdisasm to be available.
         '''
         return self._codelibrary.get_sass()
 
@@ -995,7 +995,7 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
 
         The CFG for the device in the current context is returned.
 
-        Requires nvdisasm to be available on the PATH.
+        Requires nvdisasm to be available.
         '''
         if self.targetoptions.get('device'):
             raise RuntimeError('Cannot get the CFG of a device function')
@@ -1017,7 +1017,7 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
 
         SASS for the device in the current context is returned.
 
-        Requires nvdisasm to be available on the PATH.
+        Requires nvdisasm to be available.
         '''
         if self.targetoptions.get('device'):
             raise RuntimeError('Cannot inspect SASS of a device function')

--- a/numba_cuda/numba/cuda/testing.py
+++ b/numba_cuda/numba/cuda/testing.py
@@ -3,7 +3,7 @@ import platform
 import shutil
 
 from numba.tests.support import SerialMixin
-from numba.cuda.cuda_paths import get_conda_ctk
+from numba.cuda.cuda_paths import get_cuda_paths, get_conda_ctk
 from numba.cuda.cudadrv import driver, devices, libs
 from numba.core import config
 from numba.tests.support import TestCase
@@ -97,12 +97,12 @@ def skip_under_cuda_memcheck(reason):
 
 
 def skip_without_nvdisasm(reason):
-    nvdisasm_path = shutil.which('nvdisasm')
+    nvdisasm_path = get_cuda_paths()['nvdisasm'].info
     return unittest.skipIf(nvdisasm_path is None, reason)
 
 
 def skip_with_nvdisasm(reason):
-    nvdisasm_path = shutil.which('nvdisasm')
+    nvdisasm_path = get_cuda_paths()['nvdisasm'].info
     return unittest.skipIf(nvdisasm_path is not None, reason)
 
 


### PR DESCRIPTION
Fixes #9.

I'm not sure how good the unit test coverage is for this, or the other path search functionality. Ideally we'd need contained tests that cover:
- Conda
- A default CUDA install (e.g. `/usr/local/cuda`):
  - With the full toolkit.
  - With only libraries, no `nvdisasm` etc.
  - With only libraries, but `nvdisasm` in PATH.
- CUDA_HOME:
   - With the full toolkit.
  - With only libraries, no `nvdisasm` etc.
  - With only libraries, but `nvdisasm` in PATH.