### PR TITLE
Use dynamic address of global and closure variables

### DIFF
--- a/numba_cuda/numba/cuda/cudadrv/devicearray.py
+++ b/numba_cuda/numba/cuda/cudadrv/devicearray.py
@@ -119,21 +119,10 @@ class DeviceNDArrayBase(_devicearray.DeviceArray):
 
     @property
     def __cuda_array_interface__(self):
-        if _driver.USE_NV_BINDING:
-            if self.device_ctypes_pointer is not None:
-                ptr = int(self.device_ctypes_pointer)
-            else:
-                ptr = 0
-        else:
-            if self.device_ctypes_pointer.value is not None:
-                ptr = self.device_ctypes_pointer.value
-            else:
-                ptr = 0
-
         return {
             'shape': tuple(self.shape),
             'strides': None if is_contiguous(self) else tuple(self.strides),
-            'data': (ptr, False),
+            'data': (self.dataptr, False),
             'typestr': self.dtype.str,
             'stream': int(self.stream) if self.stream != 0 else None,
             'version': 3,
@@ -208,6 +197,21 @@ class DeviceNDArrayBase(_devicearray.DeviceArray):
                 return c_void_p(0)
         else:
             return self.gpu_data.device_ctypes_pointer
+
+    @property
+    def dataptr(self):
+        if _driver.USE_NV_BINDING:
+            if self.device_ctypes_pointer is not None:
+                ptr = int(self.device_ctypes_pointer)
+            else:
+                ptr = 0
+        else:
+            if self.device_ctypes_pointer.value is not None:
+                ptr = self.device_ctypes_pointer.value
+            else:
+                ptr = 0
+
+        return ptr
 
     @devices.require_context
     def copy_to_device(self, ary, stream=0):

--- a/numba_cuda/numba/cuda/cudadrv/devicearray.py
+++ b/numba_cuda/numba/cuda/cudadrv/devicearray.py
@@ -122,7 +122,7 @@ class DeviceNDArrayBase(_devicearray.DeviceArray):
         return {
             'shape': tuple(self.shape),
             'strides': None if is_contiguous(self) else tuple(self.strides),
-            'data': (self.dataptr, False),
+            'data': (self.dynamic_address, False),
             'typestr': self.dtype.str,
             'stream': int(self.stream) if self.stream != 0 else None,
             'version': 3,
@@ -199,7 +199,7 @@ class DeviceNDArrayBase(_devicearray.DeviceArray):
             return self.gpu_data.device_ctypes_pointer
 
     @property
-    def dataptr(self):
+    def dynamic_address(self):
         if _driver.USE_NV_BINDING:
             if self.device_ctypes_pointer is not None:
                 ptr = int(self.device_ctypes_pointer)


### PR DESCRIPTION
Fixes https://github.com/numba/numba/issues/9084.

Subtasks:
- [x] change `make_constant_array` for CUDATarget: Copied from Graham's POC and guided it by `USE_NV_BINDING`.
- [x] Making copies of data to ~~/ from~~ the device at launch time for global and closure variables on the host needs to be considered.
- [ ] CUDA documentation should clarify that const copies are never automatically made, and indicate the const array constructor for their explicit construction.
- [ ] Tests need to be added for both global and closure variable cases

Subtasks need to discuss before writing the code:
- [x] ~~related to Point 2 above, allowing users to write this global or closure variables in kernel function or not? Since POC stills use `make_constant_array`, it enforces the underlying array is `read-only`.~~
- [ ] Any other memory management considerations as required (e.g. across multiple devices, avoidance of leaks when making implicit copies from the host, etc.)

Subtasks should be handled in numba core: 
- [ ] https://github.com/numba/numba/pull/9642
- [ ] Caching needs to be disabled for kernels with references to globals and closure variables. The docstring for BaseContext.add_dynamic_addr() suggests that addition of a dynamic address will disable caching, but this does not seem to be the case for CUDA at least.
- [ ] a Numba bug in the lower registry order between `builtin_registry` and `cudaimpl.registry`