### PR TITLE
Fix editable wheels and redirector inclusion in sdist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,23 @@ class build_py_with_redirector(build_py):  # noqa: N801
         self.copy_redirector_file(site_packages / "_numba_cuda_redirector.pth")
         self.copy_redirector_file(site_packages / "_numba_cuda_redirector.py")
 
+    def get_source_files(self):
+        src = super().get_source_files()
+        site_packages = pathlib.Path("site-packages")
+        src.extend([
+            str(site_packages / "_numba_cuda_redirector.pth"),
+            str(site_packages / "_numba_cuda_redirector.py"),
+        ])
+        return src
+
+    def get_output_mapping(self):
+        mapping = super().get_output_mapping()
+        build_lib = pathlib.Path(self.build_lib)
+        mapping[str(build_lib / "_numba_cuda_redirector.pth")] = \
+            "_numba_cuda_redirector.pth"
+        mapping[str(build_lib / "_numba_cuda_redirector.py")] = \
+            "_numba_cuda_redirector.py"
+        return mapping
+
 
 setup(cmdclass={"build_py": build_py_with_redirector})


### PR DESCRIPTION
Fixes some packaging issues:

- Ensures the redirector is added to the sdist by adding it to the source files and output mapping
- Fixes the redirector for editable installs by adding the redirector files to the editable wheel. This is not ideal in the sense that the redirector is not editable, but it at least makes it possible to use the rest of the package in an editable fashion. The redirector itself wouldn't normally be edited during the development cycle.

Fixes #20.