### PR TITLE
Add support for printing bools

### DIFF
--- a/numba_cuda/numba/cuda/printimpl.py
+++ b/numba_cuda/numba/cuda/printimpl.py
@@ -63,6 +63,17 @@ def dim3_print_impl(ty, context, builder, val):
     return rawfmt, [x, y, z]
 
 
+@print_item.register(types.Boolean)
+def bool_print_impl(ty, context, builder, val):
+    true_string = context.insert_string_const_addrspace(builder, "True")
+    false_string = context.insert_string_const_addrspace(builder, "False")
+    res_ptr = cgutils.alloca_once_value(builder, false_string)
+    with builder.if_then(val):
+        builder.store(true_string, res_ptr)
+    rawfmt = "%s"
+    return rawfmt, [builder.load(res_ptr)]
+
+
 @lower(print, types.VarArg(types.Any))
 def print_varargs(context, builder, sig, args):
     """This function is a generic 'print' wrapper for arbitrary types.

--- a/numba_cuda/numba/cuda/tests/cudapy/test_print.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_print.py
@@ -32,6 +32,21 @@ cuda.synchronize()
 """
 
 
+printbool_usecase = """\
+from numba import cuda
+
+@cuda.jit
+def printbool(x):
+    print(True)
+    print(False)
+    print(x == 0)
+
+printbool[1, 1](0)
+printbool[1, 1](1)
+cuda.synchronize()
+"""
+
+
 printstring_usecase = """\
 from numba import cuda
 
@@ -108,6 +123,11 @@ class TestPrint(CUDATestCase):
         # CUDA and the simulator use different formats for float formatting
         expected_cases = ["0 23 34.750000 321", "0 23 34.75 321"]
         self.assertIn(output.strip(), expected_cases)
+
+    def test_bool(self):
+        output, _ = self.run_code(printbool_usecase)
+        expected = "True\nFalse\nTrue\nTrue\nFalse\nFalse"
+        self.assertEqual(output.strip(), expected)
 
     def test_printempty(self):
         output, _ = self.run_code(printempty_usecase)


### PR DESCRIPTION
`Boolean` is not a subclass of `Integer` in Numba's typing (whether intentionally or not, I don't know) so printing of bools doesn't even fall back on the implementation for integers.

This implements support for printing bools in CUDA kernels.