### PR TITLE
#48 rebased: "Allow JIT Compile to, and Link from, LTOIR for cuda source input"

### DIFF
--- a/numba_cuda/numba/cuda/codegen.py
+++ b/numba_cuda/numba/cuda/codegen.py
@@ -203,17 +203,17 @@ class CUDACodeLibrary(serialize.ReduceMixin, CodeLibrary):
             linker = driver.Linker.new(
                 max_registers=self._max_registers,
                 cc=cc,
-                additional_flags=["-ptx"]
+                additional_flags=["-ptx"],
+                lto=True
             )
             self._link_all(linker, cc)
             ptx = linker.get_linked_ptx().decode('utf-8')
 
-            if config.DUMP_ASSEMBLY:
-                print(("ASSEMBLY (AFTER LTO) %s" % self._name).center(80, '-'))
-                print(ptx)
-                print('=' * 80)
+            print(("ASSEMBLY (AFTER LTO) %s" % self._name).center(80, '-'))
+            print(ptx)
+            print('=' * 80)
 
-        linker = driver.Linker.new(max_registers=self._max_registers, cc=cc)
+        linker = driver.Linker.new(max_registers=self._max_registers, cc=cc, lto=True)
         self._link_all(linker, cc)
         cubin = linker.complete()
 

--- a/numba_cuda/numba/cuda/cudadrv/driver.py
+++ b/numba_cuda/numba/cuda/cudadrv/driver.py
@@ -3065,6 +3065,32 @@ class PyNvJitLinker(Linker):
         name = pathlib.Path(path).name
         self.add_data(data, kind, name)
 
+    def add_cu(self, cu, name):
+        """Add CUDA source in a string to the link. The name of the source
+        file should be specified in `name`."""
+        with driver.get_active_context() as ac:
+            dev = driver.get_device(ac.devnum)
+            cc = dev.compute_capability
+
+        program, log = nvrtc.compile(cu, name, cc, ltoir=self.lto)
+
+        if not self.lto and config.DUMP_ASSEMBLY:
+            # TODO: when linker is configured to generate LTOIR, assembly is not
+            # directly visible via the Linker API. We should provide `-ptx` as
+            # an additional flag to nvjitlink to generate PTX. However, this
+            # could break the linking pipeline. We need to investigate this further.
+            print(("ASSEMBLY %s" % name).center(80, "-"))
+            print(program)
+            print("=" * 80)
+
+        suffix = ".ltoir" if self.lto else ".ptx"
+        program_name = os.path.splitext(name)[0] + suffix
+        # Link the program's PTX or LTOIR using the normal linker mechanism
+        if self.lto:
+            self.add_ltoir(program, program_name)
+        else:
+            self.add_ptx(program.encode(), program_name)
+
     def add_data(self, data, kind, name):
         if kind == FILE_EXTENSION_MAP["cubin"]:
             fn = self._linker.add_cubin

--- a/numba_cuda/numba/cuda/cudadrv/driver.py
+++ b/numba_cuda/numba/cuda/cudadrv/driver.py
@@ -3075,10 +3075,6 @@ class PyNvJitLinker(Linker):
         program, log = nvrtc.compile(cu, name, cc, ltoir=self.lto)
 
         if not self.lto and config.DUMP_ASSEMBLY:
-            # TODO: when linker is configured to generate LTOIR, assembly is not
-            # directly visible via the Linker API. We should provide `-ptx` as
-            # an additional flag to nvjitlink to generate PTX. However, this
-            # could break the linking pipeline. We need to investigate this further.
             print(("ASSEMBLY %s" % name).center(80, "-"))
             print(program)
             print("=" * 80)
@@ -3109,6 +3105,12 @@ class PyNvJitLinker(Linker):
 
         try:
             fn(data, name)
+        except NvJitLinkError as e:
+            raise LinkerError from e
+
+    def get_linked_ptx(self):
+        try:
+            return self._linker.get_linked_ptx()
         except NvJitLinkError as e:
             raise LinkerError from e
 


### PR DESCRIPTION
Following the merge of #23 / #56, this is #48 rebased on `main` for review.

The changes here should be the same as those in #48, except:

- Merge base is `main`
- No commits from the original #23 PR, the content of which is now in `main`.
- Removed the style churn to simplify reading the diff.

cc @isVoid