### PR TITLE
Support default stream APIs in the simulator

### DIFF
--- a/numba_cuda/numba/cuda/simulator/api.py
+++ b/numba_cuda/numba/cuda/simulator/api.py
@@ -35,6 +35,20 @@ class stream(object):
         pass
 
 
+# Default stream APIs. Since execution from the perspective of the host is
+# synchronous in the simulator, these can be the same as the stream class.
+default_stream = stream
+legacy_default_stream = stream
+per_thread_default_stream = stream
+
+
+# There is no way to use external streams with the simulator. Since the
+# implementation is not really using streams, we can't meaningfully interact
+# with external ones.
+def external_stream(ptr):
+    raise RuntimeError("External streams are unsupported in the simulator")
+
+
 def synchronize():
     pass
 

--- a/numba_cuda/numba/cuda/tests/cudapy/test_stream_api.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_stream_api.py
@@ -1,0 +1,48 @@
+from numba.cuda.testing import (skip_on_cudasim, skip_unless_cudasim, unittest,
+                                CUDATestCase)
+from numba import cuda
+
+# Basic tests that stream APIs execute on the hardware and in the simulator.
+#
+# Correctness of semantics is exercised elsewhere in the test suite (though we
+# could improve the comprehensiveness of testing by adding more correctness
+# tests here in future).
+
+
+class TestStreamAPI(CUDATestCase):
+    def test_stream_create_and_sync(self):
+        s = cuda.stream()
+        s.synchronize()
+
+    def test_default_stream_create_and_sync(self):
+        s = cuda.default_stream()
+        s.synchronize()
+
+    def test_legacy_default_stream_create_and_sync(self):
+        s = cuda.legacy_default_stream()
+        s.synchronize()
+
+    def test_ptd_stream_create_and_sync(self):
+        s = cuda.per_thread_default_stream()
+        s.synchronize()
+
+    @skip_on_cudasim("External streams are unsupported on the simulator")
+    def test_external_stream_create(self):
+        #  A dummy pointer value
+        ptr = 0x12345678
+        s = cuda.external_stream(ptr)
+        # We don't test synchronization on the stream because it's not a real
+        # stream - we used a dummy pointer for testing the API, so we just
+        # ensure that the stream handle matches the external stream pointer.
+        self.assertEqual(ptr, s.handle.value)
+
+    @skip_unless_cudasim("External streams are usable with hardware")
+    def test_external_stream_simulator_unavailable(self):
+        ptr = 0x12345678
+        msg = "External streams are unsupported in the simulator"
+        with self.assertRaisesRegex(RuntimeError, msg):
+            cuda.external_stream(ptr)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Also raise an error in the simulator when attempting to use an external stream (this is not possible), and add basic tests for stream APIs.

Fixes #71.