### PR TITLE
Fixes for bugs in test suite and conda include detection in v0.0.19

### DIFF
--- a/numba_cuda/numba/cuda/cuda_paths.py
+++ b/numba_cuda/numba/cuda/cuda_paths.py
@@ -310,7 +310,9 @@ def get_conda_include_dir():
         # though usually it shouldn't.
         include_dir = os.path.join(sys.prefix, 'include')
 
-    if os.path.exists(include_dir):
+    if (os.path.exists(include_dir) and os.path.isdir(include_dir)
+            and os.path.exists(os.path.join(include_dir,
+                                            'cuda_device_runtime_api.h'))):
         return include_dir
     return
 

--- a/numba_cuda/numba/cuda/tests/cudapy/test_debug.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_debug.py
@@ -48,13 +48,11 @@ class TestDebugOutput(CUDATestCase):
                 self.assertRaises(AssertionError, check_meth, out)
 
     def _check_dump_bytecode(self, out):
-        if PYVERSION in ((3, 11), (3, 12)):
+        if PYVERSION > (3, 10):
             # binop with arg=0 is binary add, see CPython dis.py and opcode.py
             self.assertIn('BINARY_OP(arg=0', out)
-        elif PYVERSION in ((3, 9), (3, 10)):
-            self.assertIn('BINARY_ADD', out)
         else:
-            raise NotImplementedError(PYVERSION)
+            self.assertIn('BINARY_ADD', out)
 
     def _check_dump_cfg(self, out):
         self.assertIn('CFG dominators', out)

--- a/numba_cuda/numba/cuda/tests/cudapy/test_stream_api.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_stream_api.py
@@ -1,6 +1,6 @@
 from numba.cuda.testing import (skip_on_cudasim, skip_unless_cudasim, unittest,
                                 CUDATestCase)
-from numba import cuda
+from numba import config, cuda
 
 # Basic tests that stream APIs execute on the hardware and in the simulator.
 #
@@ -34,7 +34,11 @@ class TestStreamAPI(CUDATestCase):
         # We don't test synchronization on the stream because it's not a real
         # stream - we used a dummy pointer for testing the API, so we just
         # ensure that the stream handle matches the external stream pointer.
-        self.assertEqual(ptr, s.handle.value)
+        if config.CUDA_USE_NVIDIA_BINDING:
+            value = int(s.handle)
+        else:
+            value = s.handle.value
+        self.assertEqual(ptr, value)
 
     @skip_unless_cudasim("External streams are usable with hardware")
     def test_external_stream_simulator_unavailable(self):


### PR DESCRIPTION
- Fix tests in `test_debug` when running on Python 3.13 - they did not take that version into account.
- Fix the stream API tests when using the NVIDIA CUDA Python bindings, as they need a different conversion from objects to pointers for stream objects
- Fix conda include dir detection, which could determine that includes were present in the conda environment when they were not, particularly on Windows where the include path would be `$env:CONDA_PREFIX\Library\include`, which is pretty much guaranteed to exist.