### PR TITLE
Debug improvements

### DIFF
--- a/numba_cuda/numba/cuda/compiler.py
+++ b/numba_cuda/numba/cuda/compiler.py
@@ -497,6 +497,9 @@ def compile(pyfunc, sig, debug=None, lineinfo=False, device=True,
         'opt': 3 if opt else 0
     }
 
+    if debug:
+        nvvm_options['g'] = None
+
     if lto:
         nvvm_options['gen-lto'] = None
 

--- a/numba_cuda/numba/cuda/compiler.py
+++ b/numba_cuda/numba/cuda/compiler.py
@@ -206,6 +206,7 @@ def compile_cuda(pyfunc, return_type, args, debug=False, lineinfo=False,
 
     if debug:
         flags.error_model = 'python'
+        flags.dbg_extend_lifetimes = True
     else:
         flags.error_model = 'numpy'
 

--- a/numba_cuda/numba/cuda/dispatcher.py
+++ b/numba_cuda/numba/cuda/dispatcher.py
@@ -95,6 +95,9 @@ class _Kernel(serialize.ReduceMixin):
             'opt': 3 if opt else 0
         }
 
+        if debug:
+            nvvm_options['g'] = None
+
         cc = get_current_device().compute_capability
         cres = compile_cuda(self.py_func, types.void, self.argtypes,
                             debug=self.debug,
@@ -917,6 +920,9 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
                     'opt': 3 if self.targetoptions.get('opt') else 0,
                     'fastmath': fastmath
                 }
+
+                if debug:
+                    nvvm_options['g'] = None
 
                 cc = get_current_device().compute_capability
                 cres = compile_cuda(self.py_func, return_type, args,


### PR DESCRIPTION
1. Passes the `-g` flag to NVVM when `debug=True` in the `@cuda.jit` decorator
2. Extends variable lifetimes when debug is enabled.