### PR TITLE
Implement debuginfo bool name fix (numba/numba#9888) in numba-cuda

### DIFF
--- a/numba_cuda/numba/cuda/tests/cudapy/test_debuginfo.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_debuginfo.py
@@ -76,12 +76,13 @@ class TestCudaDebugInfo(CUDATestCase):
         # Compiler created symbol should not be emitted in DILocalVariable
         # See Numba Issue #9888 https://github.com/numba/numba/pull/9888
         sig = (types.boolean,)
+
         @cuda.jit(sig, debug=True, opt=False)
         def f(cond):
             if cond:
-                x = 1
+                x = 1  # noqa: F841
             else:
-                x = 0
+                x = 0  # noqa: F841
 
         llvm_ir = f.inspect_llvm(sig)
         # A varible name starting with "bool" in the debug metadata


### PR DESCRIPTION
As a workaround until numba/numba#9888 is merged and available in an upstream Numba release, we interject our own modified bytecode translation pass that names bools correctly (`$bool<N>` as oppoosed to `bool<N>`).

To avoid duplicating the whole untyped pipeline definition, we take the definition from upstream Numba and modify it to use our pass.