### PR TITLE
Make block, thread, and warp indices unsigned

### DIFF
--- a/numba_cuda/numba/cuda/cudadecl.py
+++ b/numba_cuda/numba/cuda/cudadecl.py
@@ -10,7 +10,7 @@ from numba.core.typing.npydecl import (parse_dtype, parse_shape,
 from numba.core.typing.templates import (AttributeTemplate, ConcreteTemplate,
                                          AbstractTemplate, CallableTemplate,
                                          signature, Registry)
-from numba.cuda.types import dim3
+from numba.cuda.types import dim3, tid
 from numba.core.typeconv import Conversion
 from numba import cuda
 from numba.cuda.compiler import declare_device_function_template
@@ -525,13 +525,13 @@ class Dim3_attrs(AttributeTemplate):
     key = dim3
 
     def resolve_x(self, mod):
-        return types.int32
+        return tid
 
     def resolve_y(self, mod):
-        return types.int32
+        return tid
 
     def resolve_z(self, mod):
-        return types.int32
+        return tid
 
 
 @register_attr
@@ -720,7 +720,7 @@ class CudaModuleTemplate(AttributeTemplate):
         return dim3
 
     def resolve_laneid(self, mod):
-        return types.int32
+        return tid
 
     def resolve_shared(self, mod):
         return types.Module(cuda.shared)

--- a/numba_cuda/numba/cuda/intrinsics.py
+++ b/numba_cuda/numba/cuda/intrinsics.py
@@ -7,6 +7,7 @@ from numba.core.typing import signature
 from numba.core.extending import overload_attribute, overload_method
 from numba.cuda import nvvmutils
 from numba.cuda.extending import intrinsic
+from numba.cuda.types import tid
 
 
 #-------------------------------------------------------------------------------
@@ -105,7 +106,7 @@ def gridsize(typingctx, ndim):
 
 @intrinsic
 def _warpsize(typingctx):
-    sig = signature(types.int32)
+    sig = signature(tid)
 
     def codegen(context, builder, sig, args):
         return nvvmutils.call_sreg(builder, 'warpsize')

--- a/numba_cuda/numba/cuda/models.py
+++ b/numba_cuda/numba/cuda/models.py
@@ -5,7 +5,7 @@ from llvmlite import ir
 from numba.core.datamodel.registry import DataModelManager, register
 from numba.core.extending import models
 from numba.core import types
-from numba.cuda.types import Dim3, GridGroup, CUDADispatcher
+from numba.cuda.types import tid, Dim3, GridGroup, CUDADispatcher
 
 
 cuda_data_manager = DataModelManager()
@@ -17,9 +17,9 @@ register_model = functools.partial(register, cuda_data_manager)
 class Dim3Model(models.StructModel):
     def __init__(self, dmm, fe_type):
         members = [
-            ('x', types.int32),
-            ('y', types.int32),
-            ('z', types.int32)
+            ('x', tid),
+            ('y', tid),
+            ('z', tid)
         ]
         super().__init__(dmm, fe_type, members)
 


### PR DESCRIPTION
This ports numba/numba#6112 to numba-cuda, as outlined in #109.

Note that for this patch, we don't change the type of `grid()` and `gridsize()` because these need to be 64 bit (as discovered in numba/numba#9229 and fixed in numba/numba#9235).

We need to patch the `as_dtype()` function, which is a little unfortunate, but there's no API for extending its behaviour at present.

Current status: in progress, as items from the original PR need to be addressed (as per [this comment](https://github.com/numba/numba/pull/6112#issuecomment-1164302941)):
- Audit whether type widening still occurs
- Examine the cases of increased register usage (which is likely due to policies in the PTX -> SASS compiler rather than anything changed in numba-cuda). 

We still allow unsafe promotion of `tid` to 64 bits, because without it, comparisons with other 64-bit operands cannot occur.
<!--

Thank you for contributing to numba-cuda :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
