### PR TITLE
Pin numba version to `<0.61.0a0`

### DIFF
--- a/conda/recipes/numba-cuda/meta.yaml
+++ b/conda/recipes/numba-cuda/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - setuptools
   run:
     - python
-    - numba >=0.59.1
+    - numba >=0.59.1,<0.61.0a0
 
 about:
   home: {{ project_urls["Homepage"] }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ authors = [
 ]
 license = { text = "BSD 2-clause" }
 requires-python = ">=3.9"
-dependencies = ["numba>=0.59.1,<0.61.0"]
+dependencies = ["numba>=0.59.1,<0.61.0a0"]
 
 [project.urls]
 Homepage = "https://github.com/rapidsai/numba-cuda"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ authors = [
 ]
 license = { text = "BSD 2-clause" }
 requires-python = ">=3.9"
-dependencies = ["numba>=0.59.1"]
+dependencies = ["numba>=0.59.1,<0.61.0"]
 
 [project.urls]
 Homepage = "https://github.com/rapidsai/numba-cuda"


### PR DESCRIPTION
Numba recently had a major release: https://numba.readthedocs.io/en/stable/release/0.61.0-notes.html

Which now has breaking changes:

- Within the new type system, Python and NumPy scalars will be treated and returned separately as different entities through JIT compiled functions.

- The minimum supported Python and NumPy versions have been bumped to 3.10 and 1.24 respectively.


Until `numba-cuda` can support these changes, and to unblock down-stream CIs in RAPIDS repositories, this pinning is required.
