### PR TITLE
Fix `__array__()` method for NumPy 2 and remove Numba pin

### DIFF
--- a/conda/recipes/numba-cuda/meta.yaml
+++ b/conda/recipes/numba-cuda/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - setuptools
   run:
     - python
-    - numba >=0.59.1,<0.61.0a0
+    - numba >=0.59.1
 
 about:
   home: {{ project_urls["Homepage"] }}

--- a/numba_cuda/numba/cuda/cudadrv/devicearray.py
+++ b/numba_cuda/numba/cuda/cudadrv/devicearray.py
@@ -570,10 +570,13 @@ class DeviceNDArray(DeviceNDArrayBase):
         '''
         return self._dummy.is_c_contig
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=None):
         """
         :return: an `numpy.ndarray`, so copies to the host.
         """
+        if copy is False:
+            msg = "`copy=False` is not supported. A copy is always created."
+            raise ValueError(msg)
         if dtype:
             return self.copy_to_host().__array__(dtype)
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ authors = [
 ]
 license = { text = "BSD 2-clause" }
 requires-python = ">=3.9"
-dependencies = ["numba>=0.59.1,<0.61.0a0"]
+dependencies = ["numba>=0.59.1"]
 
 [project.urls]
 Homepage = "https://github.com/rapidsai/numba-cuda"


### PR DESCRIPTION
This fixes the `__array__()` method by implementing the `copy` kwarg. Numba pins are now removed, as this should fix the compatibility issue first addressed in #112 and described in #114.