### PR TITLE
dont launch extra kernels when stats counting is disabled

### DIFF
--- a/numba_cuda/numba/cuda/dispatcher.py
+++ b/numba_cuda/numba/cuda/dispatcher.py
@@ -256,7 +256,11 @@ class _Kernel(serialize.ReduceMixin):
         """
         cufunc = self._codelibrary.get_cufunc()
 
-        if hasattr(self, "target_context") and self.target_context.enable_nrt:
+        if (
+            hasattr(self, "target_context")
+            and self.target_context.enable_nrt
+            and config.CUDA_NRT_STATS
+        ):
             rtsys.ensure_initialized()
             rtsys.set_memsys_to_module(cufunc.module)
             # We don't know which stream the kernel will be launched on, so

--- a/numba_cuda/numba/cuda/tests/nrt/test_nrt.py
+++ b/numba_cuda/numba/cuda/tests/nrt/test_nrt.py
@@ -171,7 +171,10 @@ class TestNrtStatistics(CUDATestCase):
             arr = cuda_arange(5 * tmp[0]) # noqa: F841
             return None
 
-        with override_config('CUDA_ENABLE_NRT', True):
+        with (
+            override_config('CUDA_ENABLE_NRT', True),
+            override_config('CUDA_NRT_STATS', True)
+        ):
             # Switch on stats
             rtsys.memsys_enable_stats()
             # check the stats are on

--- a/numba_cuda/numba/cuda/tests/nrt/test_nrt_refct.py
+++ b/numba_cuda/numba/cuda/tests/nrt/test_nrt_refct.py
@@ -18,7 +18,10 @@ class TestNrtRefCt(EnableNRTStatsMixin, CUDATestCase):
         super(TestNrtRefCt, self).tearDown()
 
     def run(self, result=None):
-        with override_config("CUDA_ENABLE_NRT", True):
+        with (
+            override_config("CUDA_ENABLE_NRT", True),
+            override_config('CUDA_NRT_STATS', True)
+        ):
             super(TestNrtRefCt, self).run(result)
 
     def test_no_return(self):


### PR DESCRIPTION
Currently we're launching a few extraneous kernels related to stats counting without stats being explicitly enabled. These should be off by default for optimal performance in production conditions.