### PR TITLE
Fix the debug info of GridGroup type

### DIFF
--- a/numba_cuda/numba/cuda/tests/cudapy/test_debuginfo.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_debuginfo.py
@@ -110,6 +110,19 @@ class TestCudaDebugInfo(CUDATestCase):
         match = re.compile(pat).search(llvm_ir)
         self.assertIsNotNone(match, msg=llvm_ir)
 
+    def test_grid_group_type(self):
+        sig = (types.int32,)
+
+        @cuda.jit(sig, debug=True, opt=False)
+        def f(x):
+            grid = cuda.cg.this_grid()  # noqa: F841
+
+        llvm_ir = f.inspect_llvm(sig)
+
+        pat = r'!DIBasicType\(.*DW_ATE_unsigned, name: "GridGroup", size: 64'
+        match = re.compile(pat).search(llvm_ir)
+        self.assertIsNotNone(match, msg=llvm_ir)
+
     @unittest.skip("Wrappers no longer exist")
     def test_wrapper_has_debuginfo(self):
         sig = (types.int32[::1],)


### PR DESCRIPTION
The customized CUDA front end type 'GridGroup' maps to the back end type 'ir.IntType(64)' which is defined in numba.cuda.models.

The numba DIBuilder emit variable types for simple numeric types by looking into back end type which falls through the 'DW_ATE_float' because the 'datamodel.fe_type' is not 'types.Integer'.

So emitting this type through the CUDADIBuilder is needed. Since the type represents the handle of a group object, giving it the encoding of 'DW_ATE_unsigned' should be reasonable.

A test is also added in this change.

This change addresses https://github.com/NVIDIA/numba-cuda/issues/107

<!--

Thank you for contributing to numba-cuda :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
