### PR TITLE
Allow `link` argument to accept a bitcode file

### DIFF
--- a/numba_cuda/numba/cuda/cudadrv/driver.py
+++ b/numba_cuda/numba/cuda/cudadrv/driver.py
@@ -2658,6 +2658,7 @@ class Linker(metaclass=ABCMeta):
 
         nvvm_options = {}
         arch = nvvm.get_arch_option(*cc)
+        nvvm_options["arch"] = arch
         ptx = nvvm.compile_bitcode(bc, **nvvm_options)
 
         if config.DUMP_ASSEMBLY:
@@ -2668,7 +2669,6 @@ class Linker(metaclass=ABCMeta):
         # Link the program's PTX using the normal linker mechanism
         ptx_name = os.path.splitext(name)[0] + ".ptx"
         self.add_ptx(ptx.encode(), ptx_name)
-
 
     @abstractmethod
     def add_file(self, path, kind):
@@ -3155,8 +3155,9 @@ class PyNvJitLinker(Linker):
 
         nvvm_options = {}
         arch = nvvm.get_arch_option(*cc)
+        nvvm_options['arch'] = arch
         if self.lto:
-            nvvm_options['-gen-lto'] = None
+            nvvm_options['gen-lto'] = None
         program = nvvm.compile_ir(bc, **nvvm_options)
 
         if not self.lto and config.DUMP_ASSEMBLY:
@@ -3171,7 +3172,6 @@ class PyNvJitLinker(Linker):
             self.add_ltoir(program, program_name)
         else:
             self.add_ptx(program.encode(), program_name)
-
 
     def add_data(self, data, kind, name):
         if kind == FILE_EXTENSION_MAP["cubin"]:

--- a/numba_cuda/numba/cuda/cudadrv/nvvm.py
+++ b/numba_cuda/numba/cuda/cudadrv/nvvm.py
@@ -644,7 +644,7 @@ def compile_ir(llvmir, **opts):
 
 
 def compile_bitcode(llvmir_btytes, **opts):
-    if not isintance(llvmir_btytes, bytes):
+    if not isinstance(llvmir_btytes, bytes):
         raise ValueError(f"Expected bytes, got {type(llvmir_btytes)}")
 
     if opts.pop('fastmath', False):
@@ -658,7 +658,7 @@ def compile_bitcode(llvmir_btytes, **opts):
     cu = CompilationUnit()
     libdevice = LibDevice()
 
-    cu.add_module(llvmir)
+    cu.add_module(llvmir_btytes)
     cu.lazy_add_module(libdevice.get())
 
     return cu.compile(**opts)

--- a/numba_cuda/numba/cuda/cudadrv/nvvm.py
+++ b/numba_cuda/numba/cuda/cudadrv/nvvm.py
@@ -643,6 +643,27 @@ def compile_ir(llvmir, **opts):
     return cu.compile(**opts)
 
 
+def compile_bitcode(llvmir_btytes, **opts):
+    if not isintance(llvmir_btytes, bytes):
+        raise ValueError(f"Expected bytes, got {type(llvmir_btytes)}")
+
+    if opts.pop('fastmath', False):
+        opts.update({
+            'ftz': True,
+            'fma': True,
+            'prec_div': False,
+            'prec_sqrt': False,
+        })
+
+    cu = CompilationUnit()
+    libdevice = LibDevice()
+
+    cu.add_module(llvmir)
+    cu.lazy_add_module(libdevice.get())
+
+    return cu.compile(**opts)
+
+
 re_attributes_def = re.compile(r"^attributes #\d+ = \{ ([\w\s]+)\ }")
 
 


### PR DESCRIPTION
This is a PoC on allowing llvm bitcode being linked into Numba.