### PR TITLE
Fix linking of external code from callees

### DIFF
--- a/ci/build_conda.sh
+++ b/ci/build_conda.sh
@@ -13,7 +13,7 @@ rapids-print-env
 
 rapids-logger "Begin py build"
 
-rapids-conda-retry mambabuild conda/recipes/numba-cuda
+rapids-conda-retry build conda/recipes/numba-cuda
 
 package_path=(/tmp/conda-bld-output/noarch/numba-cuda-*.tar.bz2)
 echo "package_path=$package_path" >> $GITHUB_ENV

--- a/numba_cuda/numba/cuda/dispatcher.py
+++ b/numba_cuda/numba/cuda/dispatcher.py
@@ -43,15 +43,33 @@ reshape_funcs = ['nocopy_empty_reshape', 'numba_attempt_nocopy_reshape']
 
 
 def get_cres_link_objects(cres):
+    """Given a compile result, return a set of all linkable code objects that
+    are required for it to be fully linked."""
+
     link_objects = set()
+
+    # The typemap of the function includes calls, so we can traverse it to find
+    # the references we need.
     for name, v in cres.fndesc.typemap.items():
+
+        # CUDADispatchers represent a call to a device function, so we need to
+        # look up the linkable code for those recursively.
         if isinstance(v, cuda_types.CUDADispatcher):
+            # We need to locate the signature of the call so we can find the
+            # correct overload.
             for call, sig in cres.fndesc.calltypes.items():
                 if isinstance(call, ir.Expr) and call.op == 'call':
+                    # There will likely be multiple calls in the typemap; we
+                    # can uniquely identify the relevant one using its SSA
+                    # name.
                     if call.func.name == name:
                         called_cres = v.dispatcher.overloads[sig.args]
                         called_link_objects = get_cres_link_objects(called_cres)
                         link_objects.update(called_link_objects)
+
+        # From this point onwards, we are only interested in ExternFunction
+        # declarations - these are the calls made directly in this function to
+        # them.
 
         if not isinstance(v, Function):
             continue

--- a/numba_cuda/numba/cuda/dispatcher.py
+++ b/numba_cuda/numba/cuda/dispatcher.py
@@ -69,6 +69,7 @@ def get_cres_link_objects(cres):
     for name, sig in call_signatures:
         call_signature_d[name].append(sig)
 
+    # Add the link objects from the current function's callees
     for name, v in device_func_calls:
         for sig in call_signature_d.get(name, []):
             called_cres = v.dispatcher.overloads[sig.args]


### PR DESCRIPTION
The original linking implementation for linkable code in device declarations did not consider calls inside callees; this change recurses through the typing to find all calls requiring linkable code.
