### PR TITLE
Don't verify libdevice

### DIFF
--- a/numba_cuda/numba/cuda/cudadrv/nvvm.py
+++ b/numba_cuda/numba/cuda/cudadrv/nvvm.py
@@ -615,7 +615,7 @@ def llvm_replace(llvmir):
     for decl, fn in replacements:
         llvmir = llvmir.replace(decl, fn)
 
-    llvmir = llvm140_to_70_ir(llvmir)
+    llvmir = llvm150_to_70_ir(llvmir)
 
     return llvmir
 
@@ -646,9 +646,9 @@ def compile_ir(llvmir, **opts):
 re_attributes_def = re.compile(r"^attributes #\d+ = \{ ([\w\s]+)\ }")
 
 
-def llvm140_to_70_ir(ir):
+def llvm150_to_70_ir(ir):
     """
-    Convert LLVM 14.0 IR for LLVM 7.0.
+    Convert LLVM 15.0 IR for LLVM 7.0.
     """
     buf = []
     for line in ir.splitlines():

--- a/numba_cuda/numba/cuda/tests/cudadrv/test_nvjitlink.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_nvjitlink.py
@@ -261,7 +261,8 @@ class TestLinker(CUDATestCase):
 
 
 @unittest.skipIf(
-    not PYNVJITLINK_INSTALLED, reason="Pynvjitlink is not installed"
+    not PYNVJITLINK_INSTALLED or not TEST_BIN_DIR,
+    reason="pynvjitlink not enabled"
 )
 class TestLinkerUsage(CUDATestCase):
     """Test that whether pynvjitlink can be enabled by both environment variable


### PR DESCRIPTION
Libdevice should not be subject to the verifier's requirements. To implement this change, we make a small refactor to `CompilationUnit` so that it can be verified separately from compilation.

This also includes a couple of small changes:

- Linker usage tests are skipped if the test binaries are not present. This makes no difference on CI, but saves errors occurring for local users who run the test suite without building the linker test binaries.
- The name of the function that downgrades the LLVM IR is updated to match the currently-used LLVM version (15).