### PR TITLE
Allow Adding External Linkage through Target Context

### DIFF
--- a/numba_cuda/numba/cuda/compiler.py
+++ b/numba_cuda/numba/cuda/compiler.py
@@ -299,6 +299,14 @@ def compile_cuda(pyfunc, return_type, args, debug=False, lineinfo=False,
     library = cres.library
     library.finalize()
 
+    # External linking information that cannot be inferred from
+    # typing/lowering. e.g. Numbast bindings cannot persist information in
+    # state dictionary.
+    for obj in targetctx._external_linkage:
+        library.add_linking_file(obj)
+    # Immediately clear the external linkage info to avoid leakage
+    targetctx._external_linkage.clear()
+
     return cres
 
 

--- a/numba_cuda/numba/cuda/dispatcher.py
+++ b/numba_cuda/numba/cuda/dispatcher.py
@@ -89,6 +89,9 @@ def get_cres_link_objects(cres):
         for obj in v.typing_key.link:
             link_objects.add(obj)
 
+    for obj in cres.target_context._external_linkage:
+        link_objects.add(obj)
+
     return link_objects
 
 
@@ -1058,6 +1061,7 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
             if not self._can_compile:
                 raise RuntimeError("Compilation disabled")
 
+            get_context()._external_linkage.clear()
             kernel = _Kernel(self.py_func, argtypes, **self.targetoptions)
             # We call bind to force codegen, so that there is a cubin to cache
             kernel.bind()

--- a/numba_cuda/numba/cuda/dispatcher.py
+++ b/numba_cuda/numba/cuda/dispatcher.py
@@ -89,9 +89,6 @@ def get_cres_link_objects(cres):
         for obj in v.typing_key.link:
             link_objects.add(obj)
 
-    for obj in cres.target_context._external_linkage:
-        link_objects.add(obj)
-
     return link_objects
 
 
@@ -1061,7 +1058,6 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
             if not self._can_compile:
                 raise RuntimeError("Compilation disabled")
 
-            get_context()._external_linkage.clear()
             kernel = _Kernel(self.py_func, argtypes, **self.targetoptions)
             # We call bind to force codegen, so that there is a cubin to cache
             kernel.bind()

--- a/numba_cuda/numba/cuda/target.py
+++ b/numba_cuda/numba/cuda/target.py
@@ -73,6 +73,7 @@ class CUDATargetContext(BaseContext):
         self.data_model_manager = cuda_data_manager.chain(
             datamodel.default_manager
         )
+        self._external_linkage = set()
 
     @property
     def enable_nrt(self):


### PR DESCRIPTION
After a few iterations offline, we discovered that Numbast cannot pass the external information by either overriding typing or lowering behavior. We discovered that the simplest to unblock Numbast from compilation based on inferred usage is by adding them to the target context at lower time. 