### PR TITLE
Add col/row-major layout to shared and local memory

### DIFF
--- a/numba_cuda/numba/cuda/cudadecl.py
+++ b/numba_cuda/numba/cuda/cudadecl.py
@@ -25,7 +25,7 @@ register_number_classes(register_global)
 
 class Cuda_array_decl(CallableTemplate):
     def generic(self):
-        def typer(shape, dtype):
+        def typer(shape, dtype, layout=None):
 
             # Only integer literals and tuples of integer literals are valid
             # shapes
@@ -38,11 +38,19 @@ class Cuda_array_decl(CallableTemplate):
                     return None
             else:
                 return None
+            
+            # Only string literals are valid layouts
+            if layout in (None, types.none):
+                layout_str = 'C'
+            else:
+                if not isinstance(layout, types.StringLiteral):
+                    return None
+                layout_str = layout.literal_value
 
             ndim = parse_shape(shape)
             nb_dtype = parse_dtype(dtype)
             if nb_dtype is not None and ndim is not None:
-                return types.Array(dtype=nb_dtype, ndim=ndim, layout='C')
+                return types.Array(dtype=nb_dtype, ndim=ndim, layout=layout_str)
 
         return typer
 

--- a/numba_cuda/numba/cuda/stubs.py
+++ b/numba_cuda/numba/cuda/stubs.py
@@ -116,7 +116,7 @@ class shared(Stub):
     _description_ = '<shared>'
 
     @stub_function
-    def array(shape, dtype):
+    def array(shape, dtype, layout='C'):
         '''
         Allocate a shared array of the given *shape* and *type*. *shape* is
         either an integer or a tuple of integers representing the array's
@@ -135,7 +135,7 @@ class local(Stub):
     _description_ = '<local>'
 
     @stub_function
-    def array(shape, dtype):
+    def array(shape, dtype, layout='C'):
         '''
         Allocate a local array of the given *shape* and *type*. The array is
         private to the current thread, and resides in global memory. An


### PR DESCRIPTION
Add support for col/row-major layout for local and shared memory:

```python
cuda.shared.array((10,), dtype=np.int32, layout='F')
```

This will greatly improve user experience for those who work with libraries like cublasdx and function expects col-major inputs:

https://github.com/NVIDIA/nvmath-python/blob/main/examples/device/cublasdx_simple_gemm_fp32.py#L37-L41

```python
# cuBLASDx requires column-major arrays but cuda.shared.array creates row-major
# arrays (only) so we emulate a column-major array by flipping dimensions
smem_a = cuda.shared.array(shape=(a_dim[1], a_dim[0]), dtype=np.float32)
smem_b = cuda.shared.array(shape=(b_dim[1], b_dim[0]), dtype=np.float32)
smem_c = cuda.shared.array(shape=(c_dim[1], c_dim[0]), dtype=np.float32)
...
MM(alpha, smem_a, smem_b, beta, smem_c)
```

I have question about name. Do we want have `layout` or do we want `order` to be compatible with numpy?
