### PR TITLE
Add CUDA C ABI arg packer ensuring compatibility of argument types with CUDA C ABI 

### DIFF
--- a/numba_cuda/numba/cuda/target.py
+++ b/numba_cuda/numba/cuda/target.py
@@ -302,7 +302,7 @@ class CUDATargetContext(BaseContext):
     def get_arg_packer(self, fe_args):
         return CUDACABIArgPacker(self.data_model_manager, fe_args)
 
-    
+
 class CUDACallConv(MinimalCallConv):
     pass
 

--- a/numba_cuda/numba/cuda/tests/cudadrv/test_packer.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_packer.py
@@ -1,0 +1,98 @@
+import unittest
+
+from numba import types
+
+from llvmlite import ir, binding as ll
+
+from numba.cuda.descriptor import cuda_target
+from numba.cuda.target import CUDACABIArgPacker
+
+from numba.cuda.testing import CUDATestCase
+
+
+class TestArgInfo(CUDATestCase):
+
+    def _test_as_arguments(self, fe_args):
+        """
+        Test round-tripping types *fe_args* through the default data model's
+        argument conversion and unpacking logic.
+        """
+        targetctx = cuda_target.target_context
+        dmm = targetctx.data_model_manager
+        fi = CUDACABIArgPacker(dmm, fe_args)
+
+        module = ir.Module()
+        fnty = ir.FunctionType(ir.VoidType(), [])
+        function = ir.Function(module, fnty, name="test_arguments")
+        builder = ir.IRBuilder()
+        builder.position_at_end(function.append_basic_block())
+
+        args = [ir.Constant(dmm.lookup(t).get_value_type(), None)
+                for t in fe_args]
+
+        # Roundtrip
+        values = fi.as_arguments(builder, args)
+        asargs = fi.from_arguments(builder, values)
+
+        self.assertEqual(len(asargs), len(fe_args))
+        valtys = tuple([v.type for v in values])
+        self.assertEqual(valtys, fi.argument_types)
+
+        expect_types = [a.type for a in args]
+        got_types = [a.type for a in asargs]
+        self.assertEqual(expect_types, got_types)
+
+        # Test that values don't change representation when passed as
+        # parameters
+        self.assertEqual(valtys, tuple(a.type for a in args))
+
+        # Assign names (check this doesn't raise)
+        fi.assign_names(values, ["arg%i" for i in range(len(fe_args))])
+
+        builder.ret_void()
+
+        ll.parse_assembly(str(module))
+
+    def test_int32_array_complex(self):
+        fe_args = [types.int32,
+                   types.Array(types.int32, 1, 'C'),
+                   types.complex64]
+        self._test_as_arguments(fe_args)
+
+    def test_two_arrays(self):
+        fe_args = [types.Array(types.int32, 1, 'C')] * 2
+        self._test_as_arguments(fe_args)
+
+    def test_two_0d_arrays(self):
+        fe_args = [types.Array(types.int32, 0, 'C')] * 2
+        self._test_as_arguments(fe_args)
+
+    def test_tuples(self):
+        fe_args = [types.UniTuple(types.int32, 2),
+                   types.UniTuple(types.int32, 3)]
+        self._test_as_arguments(fe_args)
+        # Tuple of struct-likes
+        arrty = types.Array(types.int32, 1, 'C')
+        fe_args = [types.UniTuple(arrty, 2),
+                   types.UniTuple(arrty, 3)]
+        self._test_as_arguments(fe_args)
+        # Nested tuple
+        fe_args = [types.UniTuple(types.UniTuple(types.int32, 2), 3)]
+        self._test_as_arguments(fe_args)
+
+    def test_empty_tuples(self):
+        # Empty tuple
+        fe_args = [types.UniTuple(types.int16, 0),
+                   types.Tuple(()),
+                   types.int32]
+        self._test_as_arguments(fe_args)
+
+    def test_nested_empty_tuples(self):
+        fe_args = [types.int32,
+                   types.UniTuple(types.Tuple(()), 2),
+                   types.int64]
+        self._test_as_arguments(fe_args)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #175.

This PR introduces `CUDACABIArgPacker` - a subclass of [`ArgPacker`](https://github.com/numba/numba/blob/c21aa9273ef4298392695b1f4613d29456b53e5c/numba/core/datamodel/packer.py#L60) that ensures arguments are packed according to the C ABI calling convention. Largely, it does this simply by invoking the data model's `get_data_type()` as opposed to `get_value_type()`.  

<!--

Thank you for contributing to numba-cuda :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
