### PR TITLE
Use less GPU memory in test_managed_alloc_driver_undersubscribe.

### DIFF
--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -72,19 +72,19 @@ jobs:
             pull-request:
               # amd64
               - { ARCH: 'amd64', PY_VER: '3.9',  CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8', GPU: 'l4',   DRIVER: 'earliest', DEPENDENCIES: 'oldest' }
-              # TODO: Use CUDA 12.8.0 and h100 below.
-              - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '12.5.1', LINUX_VER: 'ubuntu24.04', GPU: 'l4',   DRIVER: 'latest',   DEPENDENCIES: 'latest' }
+              # TODO: Use CUDA 12.8.0 below.
+              - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '12.5.1', LINUX_VER: 'ubuntu24.04', GPU: 'h100', DRIVER: 'latest',   DEPENDENCIES: 'latest' }
               # arm64
               - { ARCH: 'arm64', PY_VER: '3.11', CUDA_VER: '12.0.1', LINUX_VER: 'ubuntu20.04', GPU: 'a100', DRIVER: 'latest',   DEPENDENCIES: 'latest' }
             nightly:
               # amd64
               # TODO: Use CUDA 11.4.3 below.
               - { ARCH: 'amd64', PY_VER: '3.9',  CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8', GPU: 'l4',   DRIVER: 'earliest', DEPENDENCIES: 'oldest' }
-              - { ARCH: 'amd64', PY_VER: '3.10', CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu20.04', GPU: 'l4',   DRIVER: 'latest',   DEPENDENCIES: 'latest' }
+              - { ARCH: 'amd64', PY_VER: '3.10', CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu20.04', GPU: 'h100', DRIVER: 'latest',   DEPENDENCIES: 'latest' }
               - { ARCH: 'amd64', PY_VER: '3.11', CUDA_VER: '12.0.1', LINUX_VER: 'rockylinux8', GPU: 'l4',   DRIVER: 'latest',   DEPENDENCIES: 'latest' }
               - { ARCH: 'amd64', PY_VER: '3.12', CUDA_VER: '12.2.2', LINUX_VER: 'ubuntu22.04', GPU: 'l4',   DRIVER: 'latest',   DEPENDENCIES: 'latest' }
-              # TODO: Use CUDA 12.8.0 and h100 below.
-              - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '12.5.1', LINUX_VER: 'ubuntu24.04', GPU: 'l4',   DRIVER: 'latest',   DEPENDENCIES: 'latest' }
+              # TODO: Use CUDA 12.8.0 below.
+              - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '12.5.1', LINUX_VER: 'ubuntu24.04', GPU: 'h100', DRIVER: 'latest',   DEPENDENCIES: 'latest' }
               # arm64
               # TODO: Use CUDA 11.4.3 below.
               - { ARCH: 'arm64', PY_VER: '3.9',  CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu20.04', GPU: 'a100', DRIVER: 'latest',   DEPENDENCIES: 'oldest' }

--- a/numba_cuda/numba/cuda/tests/cudadrv/test_managed_alloc.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_managed_alloc.py
@@ -48,7 +48,9 @@ class TestManagedAlloc(ContextResettingTestCase):
     def test_managed_alloc_driver_undersubscribe(self):
         msg = "Managed memory unsupported prior to CC 3.0"
         self.skip_if_cc_major_lt(3, msg)
-        self._test_managed_alloc_driver(0.5)
+        # We keep the allocation small so that it doesn't hang on GPUs
+        # with large memory (H100)
+        self._test_managed_alloc_driver(0.1)
 
     # This test is skipped by default because it is easy to hang the machine
     # for a very long time or get OOM killed if the GPU memory size is >50% of


### PR DESCRIPTION
Resolves #184.

`(numba.cuda.tests.cudadrv.test_managed_alloc.TestManagedAlloc.test_managed_alloc_driver_undersubscribe)` allocates 50% of managed h100 memory (40GB), which causes the test process to be killed.

AFAIS, there's no specific reason why we need to allocate that much for the under-subscribed test. Reducing to 10% of gpu memory fixes the issue.