### PR TITLE
Update workflows to always use proxy cache.

### DIFF
--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -146,8 +146,6 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         continue-on-error: true
-        # Skip the cache on RDS Lab nodes
-        if: ${{ matrix.GPU != 'v100' }}
       - name: Python tests
         run: ${{ inputs.script }}
         env:

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -68,8 +68,6 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         continue-on-error: true
-        # Skip the cache on RDS Lab nodes
-        if: ${{ matrix.GPU != 'v100' }}
       - name: Docs build
         run: ${{ inputs.script }}
         env:


### PR DESCRIPTION
Aligns numba-cuda with https://github.com/rapidsai/shared-workflows/pull/325.
