### PR TITLE
Feature: cuda specific make_attribute_wrapper

### DIFF
--- a/numba_cuda/numba/cuda/extending.py
+++ b/numba_cuda/numba/cuda/extending.py
@@ -5,7 +5,6 @@ Added for symmetry with the core API
 from numba.core.extending import intrinsic as _intrinsic
 from numba.cuda.models import register_model  # noqa: F401
 from numba.cuda import models  # noqa: F401
-from numba.cuda.cudaimpl import lower  # noqa: F401
 
 intrinsic = _intrinsic(target="cuda")
 

--- a/numba_cuda/numba/cuda/extending.py
+++ b/numba_cuda/numba/cuda/extending.py
@@ -38,7 +38,7 @@ def make_attribute_wrapper(typeclass, struct_attr, python_attr):
         model = data_model_manager.lookup(typ)
         if not isinstance(model, StructModel):
             raise TypeError(
-                f"make_struct_attribute_wrapper() needs a type with a StructModel, but got {model}"
+                f"make_attribute_wrapper() needs a type with a StructModel, but got {model}"
             )
         return model.get_member_fe_type(struct_attr)
 

--- a/numba_cuda/numba/cuda/extending.py
+++ b/numba_cuda/numba/cuda/extending.py
@@ -3,5 +3,57 @@ Added for symmetry with the core API
 """
 
 from numba.core.extending import intrinsic as _intrinsic
+from numba.cuda.models import register_model  # noqa: F401
+from numba.cuda import models  # noqa: F401
+from numba.cuda.cudaimpl import lower  # noqa: F401
 
 intrinsic = _intrinsic(target="cuda")
+
+
+def make_attribute_wrapper(typeclass, struct_attr, python_attr):
+    """
+    Make an automatic attribute wrapper exposing member named *struct_attr*
+    as a read-only attribute named *python_attr*.
+    The given *typeclass*'s model must be a StructModel subclass.
+    """
+    from numba.core.typing.templates import AttributeTemplate
+
+    from numba.core.datamodel import default_manager
+    from numba.core.datamodel.models import StructModel
+    from numba.core.imputils import impl_ret_borrowed
+    from numba.core import cgutils, types
+
+    from numba.cuda.models import cuda_data_manager
+    from numba.cuda.cudadecl import registry as cuda_registry
+    from numba.cuda.cudaimpl import registry as cuda_impl_registry
+
+    data_model_manager = cuda_data_manager.chain(default_manager)
+
+    if not isinstance(typeclass, type) or not issubclass(typeclass, types.Type):
+        raise TypeError(f"typeclass should be a Type subclass, got {typeclass}")
+
+    def get_attr_fe_type(typ):
+        """
+        Get the Numba type of member *struct_attr* in *typ*.
+        """
+        model = data_model_manager.lookup(typ)
+        if not isinstance(model, StructModel):
+            raise TypeError(
+                f"make_struct_attribute_wrapper() needs a type with a StructModel, but got {model}"
+            )
+        return model.get_member_fe_type(struct_attr)
+
+    @cuda_registry.register_attr
+    class StructAttribute(AttributeTemplate):
+        key = typeclass
+
+        def generic_resolve(self, typ, attr):
+            if attr == python_attr:
+                return get_attr_fe_type(typ)
+
+    @cuda_impl_registry.lower_getattr(typeclass, python_attr)
+    def struct_getattr_impl(context, builder, typ, val):
+        val = cgutils.create_struct_proxy(typ)(context, builder, value=val)
+        attrty = get_attr_fe_type(typ)
+        attrval = getattr(val, struct_attr)
+        return impl_ret_borrowed(context, builder, attrty, attrval)

--- a/numba_cuda/numba/cuda/extending.py
+++ b/numba_cuda/numba/cuda/extending.py
@@ -14,6 +14,9 @@ def make_attribute_wrapper(typeclass, struct_attr, python_attr):
     Make an automatic attribute wrapper exposing member named *struct_attr*
     as a read-only attribute named *python_attr*.
     The given *typeclass*'s model must be a StructModel subclass.
+
+    Vendored from numba.core.extending with a change to consider the CUDA data
+    model manager.
     """
     from numba.core.typing.templates import AttributeTemplate
 

--- a/numba_cuda/numba/cuda/tests/cudapy/extensions_usecases.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/extensions_usecases.py
@@ -20,10 +20,12 @@ if not config.ENABLE_CUDASIM:
     from numba import int32
     from numba.core.extending import (
         models,
-        register_model,
-        make_attribute_wrapper,
         typeof_impl,
         type_callable,
+    )
+    from numba.cuda.extending import (
+        register_model,
+        make_attribute_wrapper,
     )
     from numba.cuda.cudaimpl import lower
     from numba.core import cgutils

--- a/numba_cuda/numba/cuda/tests/cudapy/test_extending.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_extending.py
@@ -35,15 +35,17 @@ if not config.ENABLE_CUDASIM:
     from numba.core import cgutils
     from numba.core.extending import (
         lower_builtin,
-        make_attribute_wrapper,
         models,
-        register_model,
         type_callable,
         typeof_impl,
     )
     from numba.core.typing.templates import AttributeTemplate
     from numba.cuda.cudadecl import registry as cuda_registry
     from numba.cuda.cudaimpl import lower_attr as cuda_lower_attr
+    from numba.cuda.extending import (
+        register_model,
+        make_attribute_wrapper,
+    )
 
     class IntervalType(types.Type):
         def __init__(self):

--- a/numba_cuda/numba/cuda/vector_types.py
+++ b/numba_cuda/numba/cuda/vector_types.py
@@ -5,13 +5,15 @@ from typing import List, Tuple, Dict
 
 from numba import types
 from numba.core import cgutils
-from numba.core.extending import make_attribute_wrapper, models, register_model
+from numba.core.extending import models
 from numba.core.imputils import Registry as ImplRegistry
 from numba.core.typing.templates import ConcreteTemplate
 from numba.core.typing.templates import Registry as TypingRegistry
 from numba.core.typing.templates import signature
 from numba.cuda import stubs
 from numba.cuda.errors import CudaLoweringError
+from numba.cuda.extending import make_attribute_wrapper, register_model
+
 
 typing_registry = TypingRegistry()
 impl_registry = ImplRegistry()


### PR DESCRIPTION
Vendor numba's `make_attribute_wrapper` until it supports `cuda` target. Vendored function was changed to use cuda specific data model manager chained with a default data model manager. That makes it possible to wrap array attributes that are not supported by `numba`, but supported by `numba-cuda` (like `fp16` arrays).
