### PR TITLE
Report NVRTC builtin operation failures to the user

### DIFF
--- a/numba_cuda/numba/cuda/cudadrv/error.py
+++ b/numba_cuda/numba/cuda/cudadrv/error.py
@@ -32,5 +32,9 @@ class NvrtcCompilationError(NvrtcError):
     pass
 
 
+class NvrtcBuiltinOperationFailure(NvrtcError):
+    pass
+
+
 class NvrtcSupportError(ImportError):
     pass

--- a/numba_cuda/numba/cuda/cudadrv/nvrtc.py
+++ b/numba_cuda/numba/cuda/cudadrv/nvrtc.py
@@ -2,6 +2,7 @@ from ctypes import byref, c_char, c_char_p, c_int, c_size_t, c_void_p, POINTER
 from enum import IntEnum
 from numba.cuda.cudadrv.error import (
     NvrtcError,
+    NvrtcBuiltinOperationFailure,
     NvrtcCompilationError,
     NvrtcSupportError,
 )
@@ -163,6 +164,11 @@ class NVRTC:
                         error = func(*args)
                         if error == NvrtcResult.NVRTC_ERROR_COMPILATION:
                             raise NvrtcCompilationError()
+                        elif (
+                            error
+                            == NvrtcResult.NVRTC_ERROR_BUILTIN_OPERATION_FAILURE
+                        ):
+                            raise NvrtcBuiltinOperationFailure()
                         elif error != NvrtcResult.NVRTC_SUCCESS:
                             try:
                                 error_name = NvrtcResult(error).name
@@ -266,7 +272,7 @@ class NVRTC:
         try:
             self.nvrtcCompileProgram(program.handle, len(options), c_options)
             return False
-        except NvrtcCompilationError:
+        except (NvrtcCompilationError, NvrtcBuiltinOperationFailure):
             return True
 
     def destroy_program(self, program):


### PR DESCRIPTION
If NVRTC could not load its builtins library, then the user would get an error message like:

```
numba.cuda.cudadrv.error.NvrtcError:
  Failed to call nvrtcCompileProgram: NVRTC_ERROR_BUILTIN_OPERATION_FAILURE
```

With this change, we specifically transform this error value into a corresponding exception, and provide the user with the log from NVRTC so they can more easily diagnose the issue.

They will now see an error like:

```
numba.cuda.cudadrv.error.NvrtcError: NVRTC Compilation failure whilst compiling memsys.cu:

nvrtc: error: failed to open libnvrtc-builtins.so.12.8.
  Make sure that libnvrtc-builtins.so.12.8 is installed correctly.
```

which clearly explains the issue.

<!--

Thank you for contributing to numba-cuda :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
