### PR TITLE
Fix `cuda.is_available` when cuda libs aren't present

### DIFF
--- a/numba_cuda/numba/cuda/cuda_paths.py
+++ b/numba_cuda/numba/cuda/cuda_paths.py
@@ -201,6 +201,8 @@ def _get_nvrtc_wheel():
 
 def _get_libdevice_paths():
     by, libdir = _get_libdevice_path_decision()
+    if not libdir:
+        return _env_path_tuple(by, None)
     out = os.path.join(libdir, "libdevice.10.bc")
     return _env_path_tuple(by, out)
 


### PR DESCRIPTION
Closes https://github.com/NVIDIA/numba-cuda/issues/233.

This could use some kind of test, perhaps one that patches out the finder functions to return None just for the duration of that test. 