### PR TITLE
Fix package installation for wheels CI 

### DIFF
--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -142,6 +142,7 @@ jobs:
     - name: Run tests
       run: ${{ inputs.script }}
       env:
+        CUDA_VER: ${{ matrix.CUDA_VER }}
         GH_TOKEN: ${{ github.token }}
         RAPIDS_AUX_SECRET_1: ${{ secrets.RAPIDS_AUX_SECRET_1 }}
 

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -9,8 +9,6 @@ python -m pip install \
     psutil \
     cffi \
     cuda-python \
-    nvidia-cuda-cccl-cu12 \
-    nvidia-curand-cu12 \
     pytest
 
 rapids-logger "Install wheel"

--- a/ci/test_wheel_deps_wheels.sh
+++ b/ci/test_wheel_deps_wheels.sh
@@ -3,16 +3,22 @@
 
 set -euo pipefail
 
+# cuRAND versions don't follow the toolkit versions - map toolkit versions to
+# appropriate cuRAND versions
+declare -A CTK_CURAND_VMAP=( ["12.8"]="10.3.9" ["12.9"]="10.3.10")
+CUDA_VER_MAJOR_MINOR=${CUDA_VER%.*}
+CURAND_VER="${CTK_CURAND_VMAP[${CUDA_VER_MAJOR_MINOR}]}"
+
 rapids-logger "Install testing dependencies"
 # TODO: Replace with rapids-dependency-file-generator
 python -m pip install \
     psutil \
     cffi \
-    cuda-python \
-    nvidia-cuda-runtime-cu12 \
-    nvidia-curand-cu12 \
-    nvidia-cuda-nvcc-cu12 \
-    nvidia-cuda-nvrtc-cu12 \
+    "cuda-python==${CUDA_VER_MAJOR_MINOR}.*" \
+    "nvidia-cuda-runtime-cu12==${CUDA_VER_MAJOR_MINOR}.*" \
+    "nvidia-curand-cu12==${CURAND_VER}.*" \
+    "nvidia-cuda-nvcc-cu12==${CUDA_VER_MAJOR_MINOR}.*" \
+    "nvidia-cuda-nvrtc-cu12==${CUDA_VER_MAJOR_MINOR}.*" \
     pynvjitlink-cu12 \
     pytest
 

--- a/ci/test_wheel_pynvjitlink.sh
+++ b/ci/test_wheel_pynvjitlink.sh
@@ -9,7 +9,6 @@ python -m pip install \
     psutil \
     cffi \
     cuda-python \
-    nvidia-curand-cu12 \
     pytest
 
 rapids-logger "Install pynvjitlink"


### PR DESCRIPTION
Normal wheel tests should not install any CUDA pip packages because they should use the toolkit from the container.

The test depending on the toolkit wheels should install the specific toolkit version used for the test (as opposed to just using the latest version, which they were set up to do before).