### PR TITLE
Improve debug info for kernel arguments

### DIFF
--- a/numba_cuda/numba/cuda/debuginfo.py
+++ b/numba_cuda/numba/cuda/debuginfo.py
@@ -81,9 +81,9 @@ class CUDADIBuilder(DIBuilder):
 
         return self.module.add_debug_info(
             "DISubroutineType",
-             {
+            {
                 "types": self.module.add_metadata(md),
-             },
+            },
         )
 
     def mark_variable(

--- a/numba_cuda/numba/cuda/debuginfo.py
+++ b/numba_cuda/numba/cuda/debuginfo.py
@@ -79,9 +79,12 @@ class CUDADIBuilder(DIBuilder):
             mdtype = self._var_type(lltype, size, datamodel=datamodel)
             md.append(mdtype)
 
-        return self.module.add_debug_info('DISubroutineType', {
-            'types': self.module.add_metadata(md),
-        })
+        return self.module.add_debug_info(
+            "DISubroutineType",
+             {
+                "types": self.module.add_metadata(md),
+             },
+        )
 
     def mark_variable(
         self,

--- a/numba_cuda/numba/cuda/target.py
+++ b/numba_cuda/numba/cuda/target.py
@@ -290,7 +290,16 @@ class CUDATargetContext(BaseContext):
 
 
 class CUDACallConv(MinimalCallConv):
-    pass
+    def decorate_function(self, fn, args, fe_argtypes, noalias=False):
+        """
+        Set names and attributes of function arguments.
+        """
+        assert not noalias
+        arginfo = self._get_arg_packer(fe_argtypes)
+        # Do not prefix "arg." on argument name, so that nvvm compiler
+        # can track debug info of argument more accurately
+        arginfo.assign_names(self.get_arguments(fn), args)
+        fn.args[0].name = ".ret"
 
 
 class CUDACABICallConv(BaseCallConv):


### PR DESCRIPTION
In order to leverage more accurate debug info tracking from the nvvm compiler, kernel argument name need to be exact matching the name from the metadata, which is using source level user symbol.

(1) Change the CUDACallConv on CUDA target to not prefix "arg." on argument name;
(2) Call CUDA DIBuilder to build up customized DISubroutineType which is different than the parent method;
(3) Add a debug info unit test to guard this change.

This fixes nvbug#5027369.