### PR TITLE
Use specific `cuCtxGetCurrent` API version

### DIFF
--- a/numba_cuda/numba/cuda/cudadrv/driver.py
+++ b/numba_cuda/numba/cuda/cudadrv/driver.py
@@ -381,7 +381,7 @@ class Driver(object):
         else:
             variants = ("_v2", "")
 
-        if fname in ("cuCtxGetDevice", "cuCtxSynchronize"):
+        if fname in ("cuCtxGetCurrent", "cuCtxGetDevice", "cuCtxSynchronize"):
             return getattr(self.lib, fname)
 
         for variant in variants:


### PR DESCRIPTION
May be required in some setups to ensure the correct API version is selected.