### PR TITLE
Allow Numba NVRTC Binding Search Additional Paths

### DIFF
--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -132,7 +132,8 @@ target.
    package to be installed. Provides minor version compatibility for driver versions
    greater than 12.0.
 
-.. envvar:: NUMBA_CUDA_RTC_ADDITIONAL_SEARCH_PATHS
+.. envvar:: NUMBA_CUDA_RTC_EXTRA_SEARCH_PATHS
 
    A colon separated list of paths that Numba's NVRTC should search for when compiling
-   external functions.
+   external functions. These folders are searched after the system cudatoolkit search
+   paths and Numba-CUDA's internal search paths.

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -132,7 +132,7 @@ target.
    package to be installed. Provides minor version compatibility for driver versions
    greater than 12.0.
 
-.. envvar:: NUMBA_CUDA_RTC_EXTRA_SEARCH_PATHS
+.. envvar:: NUMBA_CUDA_NVRTC_EXTRA_SEARCH_PATHS
 
    A colon separated list of paths that Numba's NVRTC should search for when compiling
    external functions. These folders are searched after the system cudatoolkit search

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -131,3 +131,8 @@ target.
    Use ``pynvjitlink`` for minor version compatibility. Requires the ``pynvjitlink``
    package to be installed. Provides minor version compatibility for driver versions
    greater than 12.0.
+
+.. envvar:: NUMBA_CUDA_RTC_ADDITIONAL_SEARCH_PATHS
+
+   A colon separated list of paths that Numba's NVRTC should search for when compiling
+   external functions.

--- a/docs/source/user/cuda_ffi.rst
+++ b/docs/source/user/cuda_ffi.rst
@@ -239,7 +239,7 @@ of NVRTC subject to the following considerations:
    separated.
 
 Extra Search Path Example
-*************************
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This example demonstrates calling a foreign function which includes additional
 headers that does not exist in default Numba-CUDA search paths.

--- a/docs/source/user/cuda_ffi.rst
+++ b/docs/source/user/cuda_ffi.rst
@@ -273,7 +273,7 @@ joined with ``:`` before setting ``config.CUDA_NVRTC_EXTRA_SEARCH_PATHS``:
    :caption: from ``test_ex_extra_includes`` in ``numba/cuda/tests/doc_examples/test_ffi.py``
    :start-after: magictoken.ex_extra_search_paths.begin
    :end-before: magictoken.ex_extra_search_paths.end
-   :dedent: 8
+   :dedent: 12
    :linenos:
 
 Next, use ``saxpy`` as intended.
@@ -283,7 +283,7 @@ Next, use ``saxpy`` as intended.
    :caption: from ``test_ex_extra_includes`` in ``numba/cuda/tests/doc_examples/test_ffi.py``
    :start-after: magictoken.ex_extra_search_paths_kernel.begin
    :end-before: magictoken.ex_extra_search_paths_kernel.end
-   :dedent: 8
+   :dedent: 12
    :linenos:
 
 

--- a/docs/source/user/cuda_ffi.rst
+++ b/docs/source/user/cuda_ffi.rst
@@ -238,8 +238,8 @@ of NVRTC subject to the following considerations:
    :envvar:`NUMBA_CUDA_RTC_EXTRA_SEARCH_PATHS`. Multiple paths should be colon
    separated.
 
-Extra Search Path Example
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Extra Search Paths Example
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This example demonstrates calling a foreign function which includes additional
 headers that does not exist in default Numba-CUDA search paths.

--- a/docs/source/user/cuda_ffi.rst
+++ b/docs/source/user/cuda_ffi.rst
@@ -233,7 +233,58 @@ of NVRTC subject to the following considerations:
   on Linux and ``$env:CUDA_PATH\include`` on Windows. It can be modified using
   the environment variable :envvar:`NUMBA_CUDA_INCLUDE_PATH`.
 - The CUDA include directory will be made available to NVRTC on the include
-  path; additional includes are not supported.
+  path.
+- Additional search paths can be set to the environment variable
+   :envvar:`NUMBA_CUDA_RTC_EXTRA_SEARCH_PATHS`. Multiple paths should be colon
+   separated.
+
+Extra Search Path Example
+*************************
+
+This example demonstrates calling a foreign function which includes additional
+headers that does not exist in default Numba-CUDA search paths.
+
+The definition of the C++ template APIs are defined in two different locations:
+
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/ffi/include/mul.cuh
+   :language: C
+   :caption: ``numba/cuda/tests/doc_examples/ffi/include/mul.cuh``
+   :linenos:
+
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/data/include/add.cuh
+   :language: C
+   :caption: ``numba/cuda/tests/data/include/add.cuh``
+   :linenos:
+
+Neither header exists in the default search paths of Numba-CUDA, however, the
+foreign device function ``saxpy`` depends on them:
+
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/ffi/saxpy.cu
+   :language: C
+   :caption: ``numba/cuda/tests/data/doc_examples/ffi/saxpy.cu``
+   :linenos:
+
+In the Python Code, assume ``mul_dir`` and ``add_dir`` are set to the folder that contains
+``mul.cuh`` and ``add.cuh`` respectively. Use ``:`` to join them to a single string and
+set to ``CUDA_RTC_EXTRA_SEARCH_PATHS`` in config.
+
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_ffi.py
+   :language: python
+   :caption: from ``test_ex_extra_includes`` in ``numba/cuda/tests/doc_examples/test_ffi.py``
+   :start-after: magictoken.ex_extra_search_paths.begin
+   :end-before: magictoken.ex_extra_search_paths.end
+   :dedent: 8
+   :linenos:
+
+Next, use ``saxpy`` as intended.
+
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_ffi.py
+   :language: python
+   :caption: from ``test_ex_extra_includes`` in ``numba/cuda/tests/doc_examples/test_ffi.py``
+   :start-after: magictoken.ex_extra_search_paths_kernel.begin
+   :end-before: magictoken.ex_extra_search_paths_kernel.end
+   :dedent: 8
+   :linenos:
 
 
 Complete Example

--- a/docs/source/user/cuda_ffi.rst
+++ b/docs/source/user/cuda_ffi.rst
@@ -235,16 +235,16 @@ of NVRTC subject to the following considerations:
 - The CUDA include directory will be made available to NVRTC on the include
   path.
 - Additional search paths can be set to the environment variable
-   :envvar:`NUMBA_CUDA_RTC_EXTRA_SEARCH_PATHS`. Multiple paths should be colon
-   separated.
+  :envvar:`NUMBA_CUDA_NVRTC_EXTRA_SEARCH_PATHS`. Multiple paths should be colon
+  separated.
 
 Extra Search Paths Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This example demonstrates calling a foreign function which includes additional
-headers that does not exist in default Numba-CUDA search paths.
+This example demonstrates calling a foreign function that includes additional
+headers not in the default Numba-CUDA search paths.
 
-The definition of the C++ template APIs are defined in two different locations:
+The definitions of the C++ template APIs are in two different locations:
 
 .. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/ffi/include/mul.cuh
    :language: C
@@ -256,7 +256,7 @@ The definition of the C++ template APIs are defined in two different locations:
    :caption: ``numba/cuda/tests/data/include/add.cuh``
    :linenos:
 
-Neither header exists in the default search paths of Numba-CUDA, however, the
+Neither of the headers are in the default search paths of Numba-CUDA, but the
 foreign device function ``saxpy`` depends on them:
 
 .. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/ffi/saxpy.cu
@@ -264,9 +264,9 @@ foreign device function ``saxpy`` depends on them:
    :caption: ``numba/cuda/tests/data/doc_examples/ffi/saxpy.cu``
    :linenos:
 
-In the Python Code, assume ``mul_dir`` and ``add_dir`` are set to the folder that contains
-``mul.cuh`` and ``add.cuh`` respectively. Use ``:`` to join them to a single string and
-set to ``CUDA_RTC_EXTRA_SEARCH_PATHS`` in config.
+In the Python code, assume that ``mul_dir`` and ``add_dir`` are set to the
+paths that contain ``mul.cuh`` and ``add.cuh`` respectively. The paths are
+joined with ``:`` before setting ``config.CUDA_NVRTC_EXTRA_SEARCH_PATHS``:
 
 .. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_ffi.py
    :language: python

--- a/numba_cuda/numba/cuda/cudadrv/nvrtc.py
+++ b/numba_cuda/numba/cuda/cudadrv/nvrtc.py
@@ -15,11 +15,11 @@ import os
 import threading
 import warnings
 
-RTC_EXTRA_SEARCH_PATHS = _readenv(
-    "NUMBA_CUDA_RTC_EXTRA_SEARCH_PATHS", str, ""
-) or getattr(config, "NUMBA_CUDA_RTC_EXTRA_SEARCH_PATHS", "")
-if not hasattr(config, "NUMBA_CUDA_RTC_EXTRA_SEARCH_PATHS"):
-    config.CUDA_RTC_EXTRA_SEARCH_PATHS = RTC_EXTRA_SEARCH_PATHS
+NVRTC_EXTRA_SEARCH_PATHS = _readenv(
+    "NUMBA_CUDA_NVRTC_EXTRA_SEARCH_PATHS", str, ""
+) or getattr(config, "NUMBA_CUDA_NVRTC_EXTRA_SEARCH_PATHS", "")
+if not hasattr(config, "NUMBA_CUDA_NVRTC_EXTRA_SEARCH_PATHS"):
+    config.CUDA_NVRTC_EXTRA_SEARCH_PATHS = NVRTC_EXTRA_SEARCH_PATHS
 
 # Opaque handle for compilation unit
 nvrtc_program = c_void_p
@@ -391,8 +391,8 @@ def compile(src, name, cc, ltoir=False):
     else:
         numba_include = f"-I{os.path.join(numba_cuda_path, 'include', '12')}"
 
-    if config.CUDA_RTC_EXTRA_SEARCH_PATHS:
-        extra_search_paths = config.CUDA_RTC_EXTRA_SEARCH_PATHS.split(":")
+    if config.CUDA_NVRTC_EXTRA_SEARCH_PATHS:
+        extra_search_paths = config.CUDA_NVRTC_EXTRA_SEARCH_PATHS.split(":")
         extra_includes = [f"-I{p}" for p in extra_search_paths]
     else:
         extra_includes = []

--- a/numba_cuda/numba/cuda/cudadrv/nvrtc.py
+++ b/numba_cuda/numba/cuda/cudadrv/nvrtc.py
@@ -19,7 +19,7 @@ RTC_ADDITIONAL_SEARCH_PATHS = _readenv(
     "NUMBA_CUDA_RTC_ADDITIONAL_SEARCH_PATHS", str, ""
 ) or getattr(config, "NUMBA_CUDA_RTC_ADDITIONAL_SEARCH_PATHS", "")
 if not hasattr(config, "NUMBA_CUDA_RTC_ADDITIONAL_SEARCH_PATHS"):
-    config.NUMBA_CUDA_RTC_ADDITIONAL_SEARCH_PATHS = RTC_ADDITIONAL_SEARCH_PATHS
+    config.CUDA_RTC_ADDITIONAL_SEARCH_PATHS = RTC_ADDITIONAL_SEARCH_PATHS
 
 # Opaque handle for compilation unit
 nvrtc_program = c_void_p
@@ -391,8 +391,13 @@ def compile(src, name, cc, ltoir=False):
     else:
         numba_include = f"-I{os.path.join(numba_cuda_path, 'include', '12')}"
 
-    additional_search_paths = RTC_ADDITIONAL_SEARCH_PATHS.split(":")
-    additional_includes = [f"-I{p}" for p in additional_search_paths]
+    if config.CUDA_RTC_ADDITIONAL_SEARCH_PATHS:
+        additional_search_paths = config.CUDA_RTC_ADDITIONAL_SEARCH_PATHS.split(
+            ":"
+        )
+        additional_includes = [f"-I{p}" for p in additional_search_paths]
+    else:
+        additional_includes = []
 
     nrt_path = os.path.join(numba_cuda_path, "runtime")
     nrt_include = f"-I{nrt_path}"

--- a/numba_cuda/numba/cuda/cudadrv/nvrtc.py
+++ b/numba_cuda/numba/cuda/cudadrv/nvrtc.py
@@ -15,11 +15,11 @@ import os
 import threading
 import warnings
 
-RTC_ADDITIONAL_SEARCH_PATHS = _readenv(
-    "NUMBA_CUDA_RTC_ADDITIONAL_SEARCH_PATHS", str, ""
-) or getattr(config, "NUMBA_CUDA_RTC_ADDITIONAL_SEARCH_PATHS", "")
-if not hasattr(config, "NUMBA_CUDA_RTC_ADDITIONAL_SEARCH_PATHS"):
-    config.CUDA_RTC_ADDITIONAL_SEARCH_PATHS = RTC_ADDITIONAL_SEARCH_PATHS
+RTC_EXTRA_SEARCH_PATHS = _readenv(
+    "NUMBA_CUDA_RTC_EXTRA_SEARCH_PATHS", str, ""
+) or getattr(config, "NUMBA_CUDA_RTC_EXTRA_SEARCH_PATHS", "")
+if not hasattr(config, "NUMBA_CUDA_RTC_EXTRA_SEARCH_PATHS"):
+    config.CUDA_RTC_EXTRA_SEARCH_PATHS = RTC_EXTRA_SEARCH_PATHS
 
 # Opaque handle for compilation unit
 nvrtc_program = c_void_p
@@ -391,13 +391,11 @@ def compile(src, name, cc, ltoir=False):
     else:
         numba_include = f"-I{os.path.join(numba_cuda_path, 'include', '12')}"
 
-    if config.CUDA_RTC_ADDITIONAL_SEARCH_PATHS:
-        additional_search_paths = config.CUDA_RTC_ADDITIONAL_SEARCH_PATHS.split(
-            ":"
-        )
-        additional_includes = [f"-I{p}" for p in additional_search_paths]
+    if config.CUDA_RTC_EXTRA_SEARCH_PATHS:
+        extra_search_paths = config.CUDA_RTC_EXTRA_SEARCH_PATHS.split(":")
+        extra_includes = [f"-I{p}" for p in extra_search_paths]
     else:
-        additional_includes = []
+        extra_includes = []
 
     nrt_path = os.path.join(numba_cuda_path, "runtime")
     nrt_include = f"-I{nrt_path}"
@@ -407,7 +405,7 @@ def compile(src, name, cc, ltoir=False):
         numba_include,
         *cuda_include,
         nrt_include,
-        *additional_includes,
+        *extra_includes,
         "-rdc",
         "true",
     ]

--- a/numba_cuda/numba/cuda/tests/data/include/add.cuh
+++ b/numba_cuda/numba/cuda/tests/data/include/add.cuh
@@ -1,0 +1,2 @@
+template<typename T>
+__device__ T myadd(T a, T b) { return a + b; }

--- a/numba_cuda/numba/cuda/tests/data/include/add.cuh
+++ b/numba_cuda/numba/cuda/tests/data/include/add.cuh
@@ -1,2 +1,3 @@
-template<typename T>
+// Templated addition function: myadd
+template <typename T>
 __device__ T myadd(T a, T b) { return a + b; }

--- a/numba_cuda/numba/cuda/tests/doc_examples/ffi/include/mul.cuh
+++ b/numba_cuda/numba/cuda/tests/doc_examples/ffi/include/mul.cuh
@@ -1,0 +1,5 @@
+template <typename T>
+__device__ T mymul(T a, T b)
+{
+    return a * b;
+}

--- a/numba_cuda/numba/cuda/tests/doc_examples/ffi/include/mul.cuh
+++ b/numba_cuda/numba/cuda/tests/doc_examples/ffi/include/mul.cuh
@@ -1,5 +1,3 @@
+// Templated multiplication function: mymul
 template <typename T>
-__device__ T mymul(T a, T b)
-{
-    return a * b;
-}
+__device__ T mymul(T a, T b) { return a * b; }

--- a/numba_cuda/numba/cuda/tests/doc_examples/ffi/saxpy.cu
+++ b/numba_cuda/numba/cuda/tests/doc_examples/ffi/saxpy.cu
@@ -1,0 +1,9 @@
+#include <add.cuh> // In numba/cuda/tests/data/include
+#include <mul.cuh> // In numba/cuda/tests/doc_examples/ffi/include
+
+extern "C"
+__device__ int saxpy(float *ret, float a, float x, float y)
+{
+    *ret = myadd(mymul(a, x), y);
+    return 0;
+}

--- a/numba_cuda/numba/cuda/tests/doc_examples/test_ffi.py
+++ b/numba_cuda/numba/cuda/tests/doc_examples/test_ffi.py
@@ -85,7 +85,7 @@ class TestFFI(CUDATestCase):
         actual = r[()]
         np.testing.assert_allclose(expected, actual)
 
-    def test_ex_additional_includes(self):
+    def test_ex_extra_includes(self):
         import numpy as np
         from numba import cuda, config
         import os
@@ -97,10 +97,12 @@ class TestFFI(CUDATestCase):
         testdir = os.path.dirname(basedir)
         add_dir = os.path.join(testdir, "data", "include")
 
+        # magictoken.ex_extra_search_paths.begin
         includedir = ":".join([mul_dir, add_dir])
+        config.CUDA_RTC_EXTRA_SEARCH_PATHS = includedir
+        # magictoken.ex_extra_search_paths.end
 
-        config.CUDA_RTC_ADDITIONAL_SEARCH_PATHS = includedir
-
+        # magictoken.ex_extra_search_paths_kernel.begin
         sig = "float32(float32, float32, float32)"
         saxpy = cuda.declare_device("saxpy", sig=sig, link=saxpy_cu)
 
@@ -109,6 +111,8 @@ class TestFFI(CUDATestCase):
             i = cuda.grid(1)
             if i < len(res):
                 res[i] = saxpy(a, x[i], y[i])
+
+        # magictoken.ex_extra_search_paths_kernel.end
 
         size = 10_000
         a = 3.0

--- a/numba_cuda/numba/cuda/tests/doc_examples/test_ffi.py
+++ b/numba_cuda/numba/cuda/tests/doc_examples/test_ffi.py
@@ -97,13 +97,13 @@ class TestFFI(CUDATestCase):
         testdir = os.path.dirname(basedir)
         add_dir = os.path.join(testdir, "data", "include")
 
-        old_setting = config.CUDA_RTC_EXTRA_SEARCH_PATHS
+        old_setting = config.CUDA_NVRTC_EXTRA_SEARCH_PATHS
 
         # magictoken.ex_extra_search_paths.begin
         from numba import config
 
         includedir = ":".join([mul_dir, add_dir])
-        config.CUDA_RTC_EXTRA_SEARCH_PATHS = includedir
+        config.CUDA_NVRTC_EXTRA_SEARCH_PATHS = includedir
         # magictoken.ex_extra_search_paths.end
 
         # magictoken.ex_extra_search_paths_kernel.begin
@@ -133,7 +133,7 @@ class TestFFI(CUDATestCase):
         np.testing.assert_equal(R, expected)
 
         # Reset config setting
-        config.CUDA_RTC_EXTRA_SEARCH_PATHS = old_setting
+        config.CUDA_NVRTC_EXTRA_SEARCH_PATHS = old_setting
 
 
 if __name__ == "__main__":

--- a/numba_cuda/numba/cuda/tests/doc_examples/test_ffi.py
+++ b/numba_cuda/numba/cuda/tests/doc_examples/test_ffi.py
@@ -97,7 +97,11 @@ class TestFFI(CUDATestCase):
         testdir = os.path.dirname(basedir)
         add_dir = os.path.join(testdir, "data", "include")
 
+        old_setting = config.CUDA_RTC_EXTRA_SEARCH_PATHS
+
         # magictoken.ex_extra_search_paths.begin
+        from numba import config
+
         includedir = ":".join([mul_dir, add_dir])
         config.CUDA_RTC_EXTRA_SEARCH_PATHS = includedir
         # magictoken.ex_extra_search_paths.end
@@ -127,6 +131,9 @@ class TestFFI(CUDATestCase):
 
         expected = a * X + Y
         np.testing.assert_equal(R, expected)
+
+        # Reset config setting
+        config.CUDA_RTC_EXTRA_SEARCH_PATHS = old_setting
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, the nvrtc binding searches a few hardcoded internal paths when looking for headers. This limits the foreign function usage to only depend on standard CUDA libraries. This PR adds `CUDA_RTC_EXTRA_SEARCH_PATHS` entry, a colon separated path list, which defines additional search paths when compiling external functions.

Note that these search paths are placed *after* the standard cudatookit and numba-cuda internal search paths.

closes https://github.com/NVIDIA/numba-cuda/issues/46