### PR TITLE
Fix `test_external_cooperative_func()`

### DIFF
--- a/numba_cuda/numba/cuda/tests/cudapy/test_cooperative_groups.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_cooperative_groups.py
@@ -171,12 +171,13 @@ class TestCudaCooperativeGroups(CUDATestCase):
             "cta_barrier", sig=sig, link=[src], use_cooperative=True
         )
 
-        @cuda.jit
+        @cuda.jit("void()")
         def kernel():
             cta_barrier()
 
+        overload = kernel.overloads[()]
         block_size = 32
-        grid_size = 1024
+        grid_size = overload.max_cooperative_grid_blocks(block_size)
 
         kernel[grid_size, block_size]()
 


### PR DESCRIPTION
Using a fixed grid size is unsafe for a test that uses a cooperative launch, because the maximum launch size differs across devices.

This change ensures the test can always run by using the computed maximum grid size to launch the kernel.

<!--

Thank you for contributing to numba-cuda :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
