### PR TITLE
Always enable pynvjitlink if available

### DIFF
--- a/docs/source/user/minor_version_compatibility.rst
+++ b/docs/source/user/minor_version_compatibility.rst
@@ -26,22 +26,6 @@ MVC is not supported on Windows.
 Installation
 ------------
 
-CUDA 12
-~~~~~~~
-
-To use MVC support, the ``pynvjitlink`` package must be installed. To install
-using conda, use:
-
-.. code:: bash
-
-   conda install -c rapidsai pynvjitlink
-
-To install with pip, use the NVIDIA package index:
-
-.. code:: bash
-
-   pip install --extra-index-url https://pypi.nvidia.com pynvjitlink-cu12
-
 CUDA 11
 ~~~~~~~
 
@@ -58,16 +42,24 @@ To install with pip, use the NVIDIA package index:
 
    pip install --extra-index-url https://pypi.nvidia.com ptxcompiler-cu11 cubinlinker-cu11
 
+CUDA 12
+~~~~~~~
+
+For CUDA 12, MVC is provied by default through the ``pynvjitlink``  package,
+which ``numba-cuda`` depends on directly, so no additional installation
+steps are required.
+
 Enabling MVC Support
 --------------------
+
+CUDA 11
+~~~~~~~
 
 MVC support is enabled by setting the environment variable:
 
 .. code:: bash
 
-   export NUMBA_CUDA_ENABLE_MINOR_VERSION_COMPATIBILITY=1 # CUDA 11
-   export NUMBA_CUDA_ENABLE_PYNVJITLINK=1 # CUDA 12
-
+   export NUMBA_CUDA_ENABLE_MINOR_VERSION_COMPATIBILITY=1
 
 or by setting a configuration variable prior to using any CUDA functionality in
 Numba:
@@ -75,8 +67,25 @@ Numba:
 .. code:: python
 
    from numba import config
-   config.CUDA_ENABLE_MINOR_VERSION_COMPATIBILITY = True # CUDA 11
-   config.CUDA_ENABLE_PYNVJITLINK = True # CUDA 12
+   config.CUDA_ENABLE_MINOR_VERSION_COMPATIBILITY = True
+
+
+CUDA 12
+~~~~~~~
+
+For CUDA 12, MVC support is enabled by default but may be disabled by setting the
+following environment variable or config setting respectively:
+
+.. code:: bash
+
+   export NUMBA_CUDA_ENABLE_PYNVJITLINK=0
+
+or
+
+.. code:: python
+
+   from numba import config
+   config.CUDA_ENABLE_PYNVJITLINK = False
 
 
 References

--- a/numba_cuda/numba/cuda/cudadrv/driver.py
+++ b/numba_cuda/numba/cuda/cudadrv/driver.py
@@ -83,12 +83,20 @@ _MVC_ERROR_MESSAGE = (
 )
 
 # Enable pynvjitlink if the environment variables NUMBA_CUDA_ENABLE_PYNVJITLINK
-# or CUDA_ENABLE_PYNVJITLINK are set, or if the pynvjitlink module is found.
-ENABLE_PYNVJITLINK = (
-    _readenv("NUMBA_CUDA_ENABLE_PYNVJITLINK", bool, False)
-    or getattr(config, "CUDA_ENABLE_PYNVJITLINK", False)
-    or importlib.util.find_spec("pynvjitlink") is not None
+# or CUDA_ENABLE_PYNVJITLINK are set, or if the pynvjitlink module is found. If
+# explicitly disabled, do not use pynvjitlink, even if present in the env.
+_pynvjitlink_enabled_in_env = _readenv(
+    "NUMBA_CUDA_ENABLE_PYNVJITLINK", bool, None
 )
+_pynvjitlink_enabled_in_cfg = getattr(config, "CUDA_ENABLE_PYNVJITLINK", None)
+
+if _pynvjitlink_enabled_in_env is not None:
+    ENABLE_PYNVJITLINK = _pynvjitlink_enabled_in_env
+elif _pynvjitlink_enabled_in_cfg is not None:
+    ENABLE_PYNVJITLINK = _pynvjitlink_enabled_in_cfg
+else:
+    ENABLE_PYNVJITLINK = importlib.util.find_spec("pynvjitlink") is not None
+
 if not hasattr(config, "CUDA_ENABLE_PYNVJITLINK"):
     config.CUDA_ENABLE_PYNVJITLINK = ENABLE_PYNVJITLINK
 

--- a/numba_cuda/numba/cuda/cudadrv/driver.py
+++ b/numba_cuda/numba/cuda/cudadrv/driver.py
@@ -82,9 +82,13 @@ _MVC_ERROR_MESSAGE = (
     "to be available"
 )
 
-ENABLE_PYNVJITLINK = _readenv(
-    "NUMBA_CUDA_ENABLE_PYNVJITLINK", bool, False
-) or getattr(config, "CUDA_ENABLE_PYNVJITLINK", False)
+# Enable pynvjitlink if the environment variables NUMBA_CUDA_ENABLE_PYNVJITLINK
+# or CUDA_ENABLE_PYNVJITLINK are set, or if the pynvjitlink module is found.
+ENABLE_PYNVJITLINK = (
+    _readenv("NUMBA_CUDA_ENABLE_PYNVJITLINK", bool, False)
+    or getattr(config, "CUDA_ENABLE_PYNVJITLINK", False)
+    or importlib.util.find_spec("pynvjitlink") is not None
+)
 if not hasattr(config, "CUDA_ENABLE_PYNVJITLINK"):
     config.CUDA_ENABLE_PYNVJITLINK = ENABLE_PYNVJITLINK
 

--- a/numba_cuda/numba/cuda/cudadrv/driver.py
+++ b/numba_cuda/numba/cuda/cudadrv/driver.py
@@ -82,13 +82,11 @@ _MVC_ERROR_MESSAGE = (
     "to be available"
 )
 
-# Enable pynvjitlink if the environment variables NUMBA_CUDA_ENABLE_PYNVJITLINK
-# or CUDA_ENABLE_PYNVJITLINK are set, or if the pynvjitlink module is found.
-ENABLE_PYNVJITLINK = (
-    _readenv("NUMBA_CUDA_ENABLE_PYNVJITLINK", bool, False)
-    or getattr(config, "CUDA_ENABLE_PYNVJITLINK", False)
-    or importlib.util.find_spec("pynvjitlink") is not None
-)
+# Enable pynvjitlink if the environment variable NUMBA_CUDA_ENABLE_PYNVJITLINK
+# is set or CUDA_ENABLE_PYNVJITLINK is set in the config
+ENABLE_PYNVJITLINK = _readenv(
+    "NUMBA_CUDA_ENABLE_PYNVJITLINK", bool, False
+) or getattr(config, "CUDA_ENABLE_PYNVJITLINK", False)
 if not hasattr(config, "CUDA_ENABLE_PYNVJITLINK"):
     config.CUDA_ENABLE_PYNVJITLINK = ENABLE_PYNVJITLINK
 

--- a/numba_cuda/numba/cuda/cudadrv/driver.py
+++ b/numba_cuda/numba/cuda/cudadrv/driver.py
@@ -82,11 +82,13 @@ _MVC_ERROR_MESSAGE = (
     "to be available"
 )
 
-# Enable pynvjitlink if the environment variable NUMBA_CUDA_ENABLE_PYNVJITLINK
-# is set or CUDA_ENABLE_PYNVJITLINK is set in the config
-ENABLE_PYNVJITLINK = _readenv(
-    "NUMBA_CUDA_ENABLE_PYNVJITLINK", bool, False
-) or getattr(config, "CUDA_ENABLE_PYNVJITLINK", False)
+# Enable pynvjitlink if the environment variables NUMBA_CUDA_ENABLE_PYNVJITLINK
+# or CUDA_ENABLE_PYNVJITLINK are set, or if the pynvjitlink module is found.
+ENABLE_PYNVJITLINK = (
+    _readenv("NUMBA_CUDA_ENABLE_PYNVJITLINK", bool, False)
+    or getattr(config, "CUDA_ENABLE_PYNVJITLINK", False)
+    or importlib.util.find_spec("pynvjitlink") is not None
+)
 if not hasattr(config, "CUDA_ENABLE_PYNVJITLINK"):
     config.CUDA_ENABLE_PYNVJITLINK = ENABLE_PYNVJITLINK
 

--- a/numba_cuda/numba/cuda/tests/cudadrv/test_nvjitlink.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_nvjitlink.py
@@ -299,12 +299,12 @@ class TestLinkerUsage(CUDATestCase):
 
     def test_linker_enabled_envvar(self):
         env = os.environ.copy()
-        env["NUMBA_CUDA_ENABLE_PYNVJITLINK"] = "1"
+        env.pop("NUMBA_CUDA_ENABLE_PYNVJITLINK", None)
         run_in_subprocess(self.src.format(config=""), env=env)
 
     def test_linker_disabled_envvar(self):
         env = os.environ.copy()
-        env.pop("NUMBA_CUDA_ENABLE_PYNVJITLINK", None)
+        env["NUMBA_CUDA_ENABLE_PYNVJITLINK"] = "0"
         with self.assertRaisesRegex(
             AssertionError, "LTO and additional flags require PyNvJitLinker"
         ):


### PR DESCRIPTION
This PR always enables `pynvjitlink` if available.

In the future, the development team plans to implement the changes proposed in #128 and use `cuda.core` linkers instead of relying on `pynvjitlink`. This improves the user experience until we can drop the dependency on `pynvjitlink`.