### PR TITLE
Add debug support for dynamic types

### DIFF
--- a/numba_cuda/numba/cuda/debuginfo.py
+++ b/numba_cuda/numba/cuda/debuginfo.py
@@ -77,7 +77,7 @@ class CUDADIBuilder(DIBuilder):
                         derived_type = m.add_debug_info(
                             "DIDerivedType",
                             {
-                                "tag": ir.DIToken('DW_TAG_member'),
+                                "tag": ir.DIToken("DW_TAG_member"),
                                 "name": membername,
                                 "baseType": basetype,
                                 # DW_TAG_member size is in bits
@@ -88,12 +88,13 @@ class CUDADIBuilder(DIBuilder):
                         if memberwidth > maxwidth:
                             maxwidth = memberwidth
 
+            fake_union_name = "dbg_poly_union"
             return m.add_debug_info(
                 "DICompositeType",
                 {
                     "file": self.difile,
-                    "tag": ir.DIToken('DW_TAG_union_type'),
-                    "name": 'dbg_poly_union',
+                    "tag": ir.DIToken("DW_TAG_union_type"),
+                    "name": fake_union_name,
                     "identifier": str(lltype),
                     "elements": m.add_metadata(meta),
                     "size": maxwidth,

--- a/numba_cuda/numba/cuda/debuginfo.py
+++ b/numba_cuda/numba/cuda/debuginfo.py
@@ -70,9 +70,11 @@ class CUDADIBuilder(DIBuilder):
                         membersize = self.cgctx.get_abi_sizeof(dtype)
                         basetype = self._var_type(dtype, membersize, datamodel=mod)
                         if isinstance(mod.fe_type, types.Literal):
-                            membername = str(mod.fe_type.literal_type)
+                            typename = str(mod.fe_type.literal_type)
                         else:
-                            membername = str(mod.fe_type)
+                            typename = str(mod.fe_type)
+                        # Use a prefix "_" on type names as field names
+                        membername = "_" + typename
                         memberwidth = _BYTE_SIZE * membersize
                         derived_type = m.add_debug_info(
                             "DIDerivedType",

--- a/numba_cuda/numba/cuda/debuginfo.py
+++ b/numba_cuda/numba/cuda/debuginfo.py
@@ -2,6 +2,7 @@ from llvmlite import ir
 from numba.core import types, cgutils
 from numba.core.debuginfo import DIBuilder
 from numba.cuda.types import GridGroup
+from numba.core.datamodel.models import UnionModel
 
 _BYTE_SIZE = 8
 
@@ -16,6 +17,7 @@ class CUDADIBuilder(DIBuilder):
         is_bool = False
         is_int_literal = False
         is_grid_group = False
+        m = self.module
 
         if isinstance(lltype, ir.IntType):
             if datamodel is None:
@@ -36,7 +38,6 @@ class CUDADIBuilder(DIBuilder):
                     is_grid_group = True
 
         if is_bool or is_int_literal or is_grid_group:
-            m = self.module
             bitsize = _BYTE_SIZE * size
             # Boolean type workaround until upstream Numba is fixed
             if is_bool:
@@ -56,6 +57,49 @@ class CUDADIBuilder(DIBuilder):
                 },
             )
 
+        if isinstance(datamodel, UnionModel):
+            # UnionModel is handled here to represent polymorphic types
+            meta = []
+            maxwidth = 0
+            for field, model in zip(datamodel._fields, datamodel.inner_models()):
+                # Ignore the "tag" field, focus on the "payload" field which
+                # contains the data types in memory
+                if field == "payload":
+                    for mod in model.inner_models():
+                        dtype = mod.get_value_type()
+                        membersize = self.cgctx.get_abi_sizeof(dtype)
+                        basetype = self._var_type(dtype, membersize, datamodel=mod)
+                        if isinstance(mod.fe_type, types.Literal):
+                            membername = str(mod.fe_type.literal_type)
+                        else:
+                            membername = str(mod.fe_type)
+                        memberwidth = _BYTE_SIZE * membersize
+                        derived_type = m.add_debug_info(
+                            "DIDerivedType",
+                            {
+                                "tag": ir.DIToken('DW_TAG_member'),
+                                "name": membername,
+                                "baseType": basetype,
+                                # DW_TAG_member size is in bits
+                                "size": memberwidth,
+                            }
+                        )
+                        meta.append(derived_type)
+                        if memberwidth > maxwidth:
+                            maxwidth = memberwidth
+
+            return m.add_debug_info(
+                "DICompositeType",
+                {
+                    "file": self.difile,
+                    "tag": ir.DIToken('DW_TAG_union_type'),
+                    "name": 'dbg_poly_union',
+                    "identifier": str(lltype),
+                    "elements": m.add_metadata(meta),
+                    "size": maxwidth,
+                },
+                is_distinct = True
+            )
         # For other cases, use upstream Numba implementation
         return super()._var_type(lltype, size, datamodel=datamodel)
 

--- a/numba_cuda/numba/cuda/lowering.py
+++ b/numba_cuda/numba/cuda/lowering.py
@@ -78,7 +78,6 @@ class CUDALower(Lower):
         """
         Ensure the given variable has an allocated stack slot (if needed).
         """
-        #super()._alloca_var(name, fetype)
         # If the name is not handled yet and a store is needed
         if (name not in self.varmap and self.store_var_needed(name)):
             index = name.find(".")

--- a/numba_cuda/numba/cuda/lowering.py
+++ b/numba_cuda/numba/cuda/lowering.py
@@ -1,6 +1,7 @@
 from numba.core.lowering import Lower
 from llvmlite import ir
-
+from numba.core import ir as numba_ir
+from numba.core import types
 
 class CUDALower(Lower):
     def storevar(self, value, name, argidx=None):
@@ -14,10 +15,7 @@ class CUDALower(Lower):
         if (
             self.context.enable_debuginfo
             # Conditions used to elide stores in parent method
-            and (
-                name not in self._singly_assigned_vars
-                or self._disable_sroa_like_opt
-            )
+            and self.store_var_needed(name)
             # No emission of debuginfo for internal names
             and not name.startswith("$")
         ):
@@ -27,6 +25,11 @@ class CUDALower(Lower):
             int_type = (ir.IntType,)
             real_type = ir.FloatType, ir.DoubleType
             if isinstance(lltype, int_type + real_type):
+                index = name.find(".")
+                src_name = name[:index] if index > 0 else name
+                if src_name in self.poly_var_typ_map:
+                    # Do not emit debug value on polymorphic type var
+                    return
                 # Emit debug value for scalar variable
                 sizeof = self.context.get_abi_sizeof(lltype)
                 datamodel = self.context.data_model_manager[fetype]
@@ -41,3 +44,72 @@ class CUDALower(Lower):
                     datamodel,
                     argidx,
                 )
+
+    def pre_lower(self):
+        """
+        Called before lowering all blocks.
+        """
+        super().pre_lower()
+
+        self.poly_var_typ_map = {}
+        self.poly_var_loc_map = {}
+
+        # When debug info is enabled, walk through function body and mark
+        # variables with polymorphic types.
+        if self.context.enable_debuginfo and self._disable_sroa_like_opt:
+            # pre-scan all blocks
+            for block in self.blocks.values():
+                for x in block.find_insts(numba_ir.Assign):
+                    if x.target.name.startswith("$"):
+                        continue
+                    ssa_name = x.target.name
+                    index = ssa_name.find(".")
+                    src_name = ssa_name[:index] if index > 0 else ssa_name
+                    if len(x.target.versioned_names) > 0:
+                        fetype = self.typeof(ssa_name)
+                        if src_name not in self.poly_var_typ_map:
+                            self.poly_var_typ_map[src_name] = set()
+                        # deduplicate polymorphic types
+                        if isinstance(fetype, types.Literal):
+                            fetype = fetype.literal_type
+                        self.poly_var_typ_map[src_name].add(fetype)
+
+    def _alloca_var(self, name, fetype):
+        """
+        Ensure the given variable has an allocated stack slot (if needed).
+        """
+        #super()._alloca_var(name, fetype)
+        # If the name is not handled yet and a store is needed
+        if (name not in self.varmap and self.store_var_needed(name)):
+            index = name.find(".")
+            src_name = name[:index] if index > 0 else name
+            if src_name in self.poly_var_typ_map:
+                dtype = types.UnionType(self.poly_var_typ_map[src_name])
+                datamodel = self.context.data_model_manager[dtype]
+                if src_name not in self.poly_var_loc_map:
+                    # UnionType has sorted set of types, max at last index
+                    maxsizetype = dtype.types[-1]
+                    # Create a single element aggregate type
+                    aggr_type = types.UniTuple(maxsizetype, 1)
+                    lltype = self.context.get_value_type(aggr_type)
+                    ptr = self.alloca_lltype(src_name, lltype, datamodel)
+                    # save the location of the union type for polymorphic var
+                    self.poly_var_loc_map[src_name] = ptr
+                # Any member of this union type shoud type cast ptr to fetype
+                lltype = self.context.get_value_type(fetype)
+                castptr = self.builder.bitcast(self.poly_var_loc_map[src_name],
+                                               ir.PointerType(lltype))
+                # Remember the pointer
+                self.varmap[name] = castptr
+
+        super()._alloca_var(name, fetype)
+
+    def store_var_needed(self, name):
+        # Check the conditions used to elide stores in parent class,
+        # e.g. in method storevar() and _alloca_var()
+        return (
+            # used in multiple blocks
+            name not in self._singly_assigned_vars
+            # lowering with debuginfo
+            or self._disable_sroa_like_opt
+        )

--- a/numba_cuda/numba/cuda/tests/cudapy/test_debuginfo.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_debuginfo.py
@@ -373,6 +373,44 @@ class TestCudaDebugInfo(CUDATestCase):
         match = re.compile(pat).search(llvm_ir)
         self.assertIsNone(match, msg=llvm_ir)
 
+    def test_union_poly_types(self):
+        sig = (types.int32, types.int32)
+
+        @cuda.jit("void(int32, int32)", debug=True, opt=False)
+        def f(x, y):
+            foo = 100  # noqa: F841
+            foo = 2.34  # noqa: F841
+            foo = True  # noqa: F841
+            foo = 200  # noqa: F841
+
+        llvm_ir = f.inspect_llvm(sig)
+        # Extract the type node id
+        pat1 = r'!DILocalVariable\(.*name: "foo".*type: !(\d+)\)'
+        match = re.compile(pat1).search(llvm_ir)
+        self.assertIsNotNone(match, msg=llvm_ir)
+        mdnode_id = match.group(1)
+        # Verify the union type and extract the elements node id
+        pat2 = rf'!{mdnode_id} = distinct !DICompositeType\(elements: !(\d+),.*size: 64, tag: DW_TAG_union_type\)'  # noqa: E501
+        match = re.compile(pat2).search(llvm_ir)
+        self.assertIsNotNone(match, msg=llvm_ir)
+        mdnode_id = match.group(1)
+        # Extract the member node ids
+        pat3 = rf'!{{ !(\d+), !(\d+), !(\d+) }}'
+        match = re.compile(pat3).search(llvm_ir)
+        self.assertIsNotNone(match, msg=llvm_ir)
+        mdnode_id1 = match.group(1)
+        mdnode_id2 = match.group(2)
+        mdnode_id3 = match.group(3)
+        # Verify the member nodes
+        pat4 = rf'!{mdnode_id1} = !DIDerivedType(.*name: "_bool", size: 8, tag: DW_TAG_member)'  # noqa: E501
+        match = re.compile(pat4).search(llvm_ir)
+        self.assertIsNotNone(match, msg=llvm_ir)
+        pat5 = rf'!{mdnode_id2} = !DIDerivedType(.*name: "_float64", size: 64, tag: DW_TAG_member)'  # noqa: E501
+        match = re.compile(pat4).search(llvm_ir)
+        self.assertIsNotNone(match, msg=llvm_ir)
+        pat4 = rf'!{mdnode_id3} = !DIDerivedType(.*name: "_int64", size: 64, tag: DW_TAG_member)'  # noqa: E501
+        match = re.compile(pat4).search(llvm_ir)
+        self.assertIsNotNone(match, msg=llvm_ir)
 
 if __name__ == "__main__":
     unittest.main()

--- a/numba_cuda/numba/cuda/tests/cudapy/test_debuginfo.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_debuginfo.py
@@ -332,10 +332,10 @@ class TestCudaDebugInfo(CUDATestCase):
 
         @cuda.jit("void(int32, int32)", debug=True, opt=False)
         def f(x, y):
-            z = x  # noqa: F841
-            z = 100  # noqa: F841
-            z = y  # noqa: F841
-            z = True  # noqa: F841
+            z1 = x  # noqa: F841
+            z2 = 100  # noqa: F841
+            z3 = y  # noqa: F841
+            z4 = True  # noqa: F841
 
         llvm_ir = f.inspect_llvm(sig)
         # Verify the call to llvm.dbg.declare is replaced by llvm.dbg.value


### PR DESCRIPTION
This change adds debugging support for the multi-version multi-type (polymorphic) 
variables via a C Union approach.

(1) A pre-lower scan on function body collects infomation on all the assignment 
instructions for versioned / unversioned  targets names and generates a polymorphic
types map for each qualified source symbol;

(2) Frond end types, including Literal types, are deduplicated before being recorded
into a map entry.

(3) Leverage the UnionType and UnionModel and allocate a single memory slot for an
aggreate type with the maximum width instead of multiple slots to stroe and track the
variable value changes. The allccation of memory in LLVM IR uses a single element
aggregate type. For all the load / stroe instructions thereafter, necessary type casts are
applied.

(4) Use the "payload" field of UnionModel to handle the aggreate type and members
to represent data layout in memory, with field names being understore prefixed type
names, providing convenience for debugger printing and indicating internal members
as well.

E.g. the debugger output of an artificial union representation of a polymorphic variable
might looks like the following,
(cuda-gdb) info locals
foo = {_bool = true, _float64 = 2.3399999999999186, _int64 = 4612451630364040705}

or directly printing the needed type as,
(cuda-gdb) print foo._bool
$1 = true

(5) Add a unit test "test_union_poly_types".

This change implements the RFE in nvbug#5267572.
