### PR TITLE
Add support for launch bounds

### DIFF
--- a/numba_cuda/numba/cuda/compiler.py
+++ b/numba_cuda/numba/cuda/compiler.py
@@ -630,7 +630,7 @@ def compile(
 
                           If a scalar is provided, it is used as the maximum
                           number of threads per block.
-    :type launch_bounds: (int, tuple)
+    :type launch_bounds: int or tuple[int]
     :return: (code, resty): The compiled code and inferred return type
     :rtype: tuple
     """

--- a/numba_cuda/numba/cuda/compiler.py
+++ b/numba_cuda/numba/cuda/compiler.py
@@ -630,7 +630,7 @@ def compile(
 
                           If a scalar is provided, it is used as the maximum
                           number of threads per block.
-    :type launch_bounds: int or tuple[int]
+    :type launch_bounds: int | tuple[int]
     :return: (code, resty): The compiled code and inferred return type
     :rtype: tuple
     """

--- a/numba_cuda/numba/cuda/compiler.py
+++ b/numba_cuda/numba/cuda/compiler.py
@@ -575,6 +575,7 @@ def compile(
     abi_info=None,
     output="ptx",
     forceinline=False,
+    launch_bounds=None,
 ):
     """Compile a Python function to PTX or LTO-IR for a given set of argument
     types.
@@ -620,6 +621,16 @@ def compile(
                         ``alwaysinline`` function attribute to the function
                         definition. This is only valid when the output is
                         ``"ltoir"``.
+    :param launch_bounds: Kernel launch bounds, specified as a scalar or a tuple
+                          of between one and three items. Tuple items provide:
+
+                          - The maximum number of threads per block,
+                          - The minimum number of blocks per SM,
+                          - The maximum number of blocks per cluster.
+
+                          If a scalar is provided, it is used as the maximum
+                          number of threads per block.
+    :type launch_bounds: (int, tuple)
     :return: (code, resty): The compiled code and inferred return type
     :rtype: tuple
     """
@@ -693,6 +704,7 @@ def compile(
         kernel = lib.get_function(cres.fndesc.llvm_func_name)
         lib._entry_name = cres.fndesc.llvm_func_name
         kernel_fixup(kernel, debug)
+        nvvm.set_launch_bounds(kernel, launch_bounds)
 
     if lto:
         code = lib.get_ltoir(cc=cc)
@@ -713,6 +725,7 @@ def compile_for_current_device(
     abi_info=None,
     output="ptx",
     forceinline=False,
+    launch_bounds=None,
 ):
     """Compile a Python function to PTX or LTO-IR for a given signature for the
     current device's compute capabilility. This calls :func:`compile` with an
@@ -731,6 +744,7 @@ def compile_for_current_device(
         abi_info=abi_info,
         output=output,
         forceinline=forceinline,
+        launch_bounds=launch_bounds,
     )
 
 
@@ -746,6 +760,7 @@ def compile_ptx(
     abi="numba",
     abi_info=None,
     forceinline=False,
+    launch_bounds=None,
 ):
     """Compile a Python function to PTX for a given signature. See
     :func:`compile`. The defaults for this function are to compile a kernel
@@ -764,6 +779,7 @@ def compile_ptx(
         abi_info=abi_info,
         output="ptx",
         forceinline=forceinline,
+        launch_bounds=launch_bounds,
     )
 
 
@@ -778,6 +794,7 @@ def compile_ptx_for_current_device(
     abi="numba",
     abi_info=None,
     forceinline=False,
+    launch_bounds=None,
 ):
     """Compile a Python function to PTX for a given signature for the current
     device's compute capabilility. See :func:`compile_ptx`."""
@@ -794,6 +811,7 @@ def compile_ptx_for_current_device(
         abi=abi,
         abi_info=abi_info,
         forceinline=forceinline,
+        launch_bounds=launch_bounds,
     )
 
 

--- a/numba_cuda/numba/cuda/cudadrv/nvvm.py
+++ b/numba_cuda/numba/cuda/cudadrv/nvvm.py
@@ -857,6 +857,23 @@ def set_cuda_kernel(function):
     function.attributes.discard("noinline")
 
 
+def set_launch_bounds(kernel, launch_bounds):
+    if isinstance(launch_bounds, int):
+        launch_bounds = (launch_bounds,)
+
+    module = kernel.module
+    nvvm_annotations = cgutils.get_or_insert_named_metadata(
+        module, "nvvm.annotations"
+    )
+
+    indices = "xyz"
+    for index, bound in zip(indices, launch_bounds):
+        mdstr = ir.MetaDataString(module, f"maxntid{index}")
+        mdvalue = ir.Constant(ir.IntType(32), bound)
+        md = module.add_metadata((kernel, mdstr, mdvalue))
+        nvvm_annotations.add(md)
+
+
 def add_ir_version(mod):
     """Add NVVM IR version to module"""
     # We specify the IR version to match the current NVVM's IR version

--- a/numba_cuda/numba/cuda/cudadrv/nvvm.py
+++ b/numba_cuda/numba/cuda/cudadrv/nvvm.py
@@ -871,6 +871,12 @@ def set_launch_bounds(kernel, launch_bounds):
     if isinstance(launch_bounds, int):
         launch_bounds = (launch_bounds,)
 
+    if (n := len(launch_bounds)) > 3:
+        raise ValueError(
+            f"Got {n} launch bounds: {launch_bounds}. A maximum of three are supported: "
+            "(max_threads_per_block, min_blocks_per_sm, max_blocks_per_cluster)"
+        )
+
     module = kernel.module
     nvvm_annotations = cgutils.get_or_insert_named_metadata(
         module, "nvvm.annotations"

--- a/numba_cuda/numba/cuda/cudadrv/nvvm.py
+++ b/numba_cuda/numba/cuda/cudadrv/nvvm.py
@@ -865,6 +865,9 @@ def set_launch_bounds(kernel, launch_bounds):
     # NVVM IR Specification 12.9, Section 13:
     # https://docs.nvidia.com/cuda/archive/12.9.0/nvvm-ir-spec/index.html#global-property-annotation
 
+    if launch_bounds is None:
+        return
+
     if isinstance(launch_bounds, int):
         launch_bounds = (launch_bounds,)
 

--- a/numba_cuda/numba/cuda/decorators.py
+++ b/numba_cuda/numba/cuda/decorators.py
@@ -23,6 +23,7 @@ def jit(
     opt=None,
     lineinfo=False,
     cache=False,
+    launch_bounds=None,
     **kws,
 ):
     """
@@ -153,6 +154,7 @@ def jit(
             targetoptions["inline"] = inline
             targetoptions["forceinline"] = forceinline
             targetoptions["extensions"] = extensions
+            targetoptions["launch_bounds"] = launch_bounds
 
             disp = CUDADispatcher(func, targetoptions=targetoptions)
 
@@ -200,6 +202,7 @@ def jit(
                         lineinfo=lineinfo,
                         link=link,
                         cache=cache,
+                        launch_bounds=launch_bounds,
                         **kws,
                     )
 
@@ -221,6 +224,7 @@ def jit(
                 targetoptions["inline"] = inline
                 targetoptions["forceinline"] = forceinline
                 targetoptions["extensions"] = extensions
+                targetoptions["launch_bounds"] = launch_bounds
                 disp = CUDADispatcher(func_or_sig, targetoptions=targetoptions)
 
                 if cache:

--- a/numba_cuda/numba/cuda/decorators.py
+++ b/numba_cuda/numba/cuda/decorators.py
@@ -82,7 +82,7 @@ def jit(
 
                           If a scalar is provided, it is used as the maximum
                           number of threads per block.
-    :type launch_bounds: int or tuple[int]
+    :type launch_bounds: int | tuple[int]
     """
 
     if link and config.ENABLE_CUDASIM:

--- a/numba_cuda/numba/cuda/decorators.py
+++ b/numba_cuda/numba/cuda/decorators.py
@@ -73,6 +73,16 @@ def jit(
     :type lineinfo: bool
     :param cache: If True, enables the file-based cache for this function.
     :type cache: bool
+    :param launch_bounds: Kernel launch bounds, specified as a scalar or a tuple
+                          of between one and three items. Tuple items provide:
+
+                          - The maximum number of threads per block,
+                          - The minimum number of blocks per SM,
+                          - The maximum number of blocks per cluster.
+
+                          If a scalar is provided, it is used as the maximum
+                          number of threads per block.
+    :type launch_bounds: (int, tuple)
     """
 
     if link and config.ENABLE_CUDASIM:

--- a/numba_cuda/numba/cuda/decorators.py
+++ b/numba_cuda/numba/cuda/decorators.py
@@ -82,7 +82,7 @@ def jit(
 
                           If a scalar is provided, it is used as the maximum
                           number of threads per block.
-    :type launch_bounds: (int, tuple)
+    :type launch_bounds: int or tuple[int]
     """
 
     if link and config.ENABLE_CUDASIM:

--- a/numba_cuda/numba/cuda/dispatcher.py
+++ b/numba_cuda/numba/cuda/dispatcher.py
@@ -94,6 +94,7 @@ class _Kernel(serialize.ReduceMixin):
         lto=False,
         opt=True,
         device=False,
+        launch_bounds=None,
     ):
         if device:
             raise RuntimeError("Cannot compile a device function as a kernel")
@@ -120,6 +121,7 @@ class _Kernel(serialize.ReduceMixin):
         self.debug = debug
         self.lineinfo = lineinfo
         self.extensions = extensions or []
+        self.launch_bounds = launch_bounds
 
         nvvm_options = {"fastmath": fastmath, "opt": 3 if opt else 0}
 

--- a/numba_cuda/numba/cuda/dispatcher.py
+++ b/numba_cuda/numba/cuda/dispatcher.py
@@ -18,7 +18,7 @@ from numba.cuda.compiler import (
     kernel_fixup,
 )
 import re
-from numba.cuda.cudadrv import driver
+from numba.cuda.cudadrv import driver, nvvm
 from numba.cuda.cudadrv.linkable_code import LinkableCode
 from numba.cuda.cudadrv.devices import get_context
 from numba.cuda.descriptor import cuda_target
@@ -147,6 +147,7 @@ class _Kernel(serialize.ReduceMixin):
         kernel = lib.get_function(cres.fndesc.llvm_func_name)
         lib._entry_name = cres.fndesc.llvm_func_name
         kernel_fixup(kernel, self.debug)
+        nvvm.set_launch_bounds(kernel, launch_bounds)
 
         if not link:
             link = []

--- a/numba_cuda/numba/cuda/tests/cudapy/test_compiler.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_compiler.py
@@ -355,6 +355,16 @@ class TestCompileWithLaunchBounds(unittest.TestCase):
         self.assertRegex(ptx, r".minnctapersm\s+2")
         self.assertRegex(ptx, r".maxclusterrank\s+4")
 
+    def test_too_many_launch_bounds(self):
+        def f():
+            pass
+
+        sig = "void()"
+        launch_bounds = (128, 2, 4, 8)
+
+        with self.assertRaisesRegex(ValueError, "Got 4 launch bounds:"):
+            cuda.compile_ptx(f, sig, launch_bounds=launch_bounds)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/numba_cuda/numba/cuda/tests/cudapy/test_dispatcher.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_dispatcher.py
@@ -1,3 +1,4 @@
+from numba.cuda.cudadrv.driver import CudaAPIError
 import numpy as np
 import threading
 
@@ -14,7 +15,12 @@ from numba import (
     void,
 )
 from numba.core.errors import TypingError
-from numba.cuda.testing import skip_on_cudasim, unittest, CUDATestCase
+from numba.cuda.testing import (
+    cc_X_or_above,
+    skip_on_cudasim,
+    unittest,
+    CUDATestCase,
+)
 import math
 
 
@@ -746,6 +752,59 @@ class TestDispatcherKernelProperties(CUDATestCase):
         local_mem_per_thread = simple_lmem.get_local_mem_per_thread()
         self.assertIsInstance(local_mem_per_thread, int)
         self.assertGreaterEqual(local_mem_per_thread, N * 4)
+
+
+@skip_on_cudasim("Simulator does not support launch bounds")
+class TestLaunchBounds(CUDATestCase):
+    def _test_launch_bounds_common(self, launch_bounds):
+        @cuda.jit(launch_bounds=launch_bounds)
+        def f():
+            pass
+
+        # Test successful launch
+        f[1, 128]()
+
+        # Test launch bound exceeded
+        msg = "Call to cuLaunchKernel results in CUDA_ERROR_INVALID_VALUE"
+        with self.assertRaisesRegex(CudaAPIError, msg):
+            f[1, 256]()
+
+        sig = f.signatures[0]
+        ptx = f.inspect_asm(sig)
+        self.assertRegex(ptx, r".maxntid\s+128,\s+1,\s+1")
+
+        return ptx
+
+    def test_launch_bounds_scalar(self):
+        launch_bounds = 128
+        ptx = self._test_launch_bounds_common(launch_bounds)
+
+        self.assertNotIn(".minnctapersm", ptx)
+        self.assertNotIn(".maxclusterrank", ptx)
+
+    def test_launch_bounds_tuple(self):
+        launch_bounds = (128,)
+        ptx = self._test_launch_bounds_common(launch_bounds)
+
+        self.assertNotIn(".minnctapersm", ptx)
+        self.assertNotIn(".maxclusterrank", ptx)
+
+    def test_launch_bounds_with_min_cta(self):
+        launch_bounds = (128, 2)
+        ptx = self._test_launch_bounds_common(launch_bounds)
+
+        self.assertRegex(ptx, r".minnctapersm\s+2")
+        self.assertNotIn(".maxclusterrank", ptx)
+
+    @unittest.skipUnless(
+        cc_X_or_above(8, 9), "CC 9.0 needed for max cluster rank"
+    )
+    def test_launch_bounds_with_max_cluster_rank(self):
+        launch_bounds = (128, 2, 4)
+        ptx = self._test_launch_bounds_common(launch_bounds)
+
+        self.assertRegex(ptx, r".minnctapersm\s+2")
+        self.assertRegex(ptx, r".maxclusterrank\s+4")
 
 
 if __name__ == "__main__":

--- a/numba_cuda/numba/cuda/tests/cudapy/test_dispatcher.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_dispatcher.py
@@ -806,6 +806,11 @@ class TestLaunchBounds(CUDATestCase):
         self.assertRegex(ptx, r".minnctapersm\s+2")
         self.assertRegex(ptx, r".maxclusterrank\s+4")
 
+    def test_too_many_launch_bounds(self):
+        launch_bounds = (128, 2, 4, 8)
+        with self.assertRaisesRegex(ValueError, "Got 4 launch bounds:"):
+            cuda.jit("void()", launch_bounds=launch_bounds)(lambda: None)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/numba_cuda/numba/cuda/tests/cudapy/test_dispatcher.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_dispatcher.py
@@ -797,7 +797,7 @@ class TestLaunchBounds(CUDATestCase):
         self.assertNotIn(".maxclusterrank", ptx)
 
     @unittest.skipUnless(
-        cc_X_or_above(8, 9), "CC 9.0 needed for max cluster rank"
+        cc_X_or_above(9, 0), "CC 9.0 needed for max cluster rank"
     )
     def test_launch_bounds_with_max_cluster_rank(self):
         launch_bounds = (128, 2, 4)


### PR DESCRIPTION
Adds support for launch bounds, specified as the `launch_bounds` kwarg of the `@cuda.jit` decorator or `cuda.compile()` function. The API design is intended to follow that of the [Launch Bounds API in CUDA C/C++](https://docs.nvidia.com/cuda/archive/12.9.0/cuda-c-programming-guide/index.html#launch-bounds).

Bounds may be specified as a scalar or a tuple of between one and three items. Tuple items provide:

- The maximum number of threads per block,
- The minimum number of blocks per SM,
- The maximum number of blocks per cluster.

If a scalar is provided instead, it is used as the maximum number of threads per block.

A sketch of some possile uses of the API in the `@cuda.jit` decorator:

```python
# Specify max threads per block only:
@cuda.jit(launch_bounds=128)
def kernel(...):
    ...

# Specify max threads per block and minimum blocks per SM:
@cuda.jit(launch_bounds=(max_threads_per_block, min_blocks_per_sm))
def kernel(...):
    ...

# Specify all three kinds of bounds:
@cuda.jit(launch_bounds=(max_threads_per_block, min_blocks_per_sm, max_blocks_per_cluster))
def kernel(...):
    ...
```

cc @ZzEeKkAa.
