### PR TITLE
Drop `apt-get update` calls

### DIFF
--- a/ci/test_conda.sh
+++ b/ci/test_conda.sh
@@ -9,7 +9,6 @@ if [ "${CUDA_VER%.*.*}" = "11" ]; then
   CTK_PACKAGES="cudatoolkit=11"
 else
   CTK_PACKAGES="cuda-cccl cuda-nvcc-impl cuda-nvrtc libcurand-dev"
-  apt-get update
   apt remove --purge `dpkg --get-selections | grep cuda-nvvm | awk '{print $1}'` -y
   apt remove --purge `dpkg --get-selections | grep cuda-nvrtc | awk '{print $1}'` -y
 fi

--- a/ci/test_wheel_deps_wheels.sh
+++ b/ci/test_wheel_deps_wheels.sh
@@ -53,7 +53,6 @@ rapids-logger "Show Numba system info"
 python -m numba --sysinfo
 
 # remove cuda-nvvm-12-5 leaving libnvvm.so from nvidia-cuda-nvcc-cu12 only
-apt-get update
 apt remove --purge `dpkg --get-selections | grep cuda-nvvm | awk '{print $1}'` -y
 apt remove --purge `dpkg --get-selections | grep cuda-nvrtc | awk '{print $1}'` -y
 


### PR DESCRIPTION
These are pulling in newer versions of `cuda-compat`, which appear to be missing some files. So simply drop these calls so that update doesn't occur. This should keep the `cuda-compat` version that is known to work.