### PR TITLE
Fix lineinfo generation when compile_internal used (#271)

### DIFF
--- a/numba_cuda/numba/cuda/compiler.py
+++ b/numba_cuda/numba/cuda/compiler.py
@@ -14,8 +14,6 @@ from numba.core.compiler import (
     sanitize_compile_result_entries,
     CompilerBase,
     DefaultPassBuilder,
-    Flags,
-    Option,
     CompileResult,
 )
 from numba.core.compiler_lock import global_compiler_lock
@@ -39,43 +37,9 @@ from numba.cuda.api import get_current_device
 from numba.cuda.codegen import ExternalCodeLibrary
 from numba.cuda.cudadrv import nvvm
 from numba.cuda.descriptor import cuda_target
+from numba.cuda.flags import CUDAFlags
 from numba.cuda.target import CUDACABICallConv
 from numba.cuda import lowering
-
-
-def _nvvm_options_type(x):
-    if x is None:
-        return None
-
-    else:
-        assert isinstance(x, dict)
-        return x
-
-
-def _optional_int_type(x):
-    if x is None:
-        return None
-
-    else:
-        assert isinstance(x, int)
-        return x
-
-
-class CUDAFlags(Flags):
-    nvvm_options = Option(
-        type=_nvvm_options_type,
-        default=None,
-        doc="NVVM options",
-    )
-    compute_capability = Option(
-        type=tuple,
-        default=None,
-        doc="Compute Capability",
-    )
-    max_registers = Option(
-        type=_optional_int_type, default=None, doc="Max registers"
-    )
-    lto = Option(type=bool, default=False, doc="Enable Link-time Optimization")
 
 
 # The CUDACompileResult (CCR) has a specially-defined entry point equal to its

--- a/numba_cuda/numba/cuda/flags.py
+++ b/numba_cuda/numba/cuda/flags.py
@@ -1,0 +1,36 @@
+from numba.core.compiler import Flags, Option
+
+
+def _nvvm_options_type(x):
+    if x is None:
+        return None
+
+    else:
+        assert isinstance(x, dict)
+        return x
+
+
+def _optional_int_type(x):
+    if x is None:
+        return None
+
+    else:
+        assert isinstance(x, int)
+        return x
+
+
+class CUDAFlags(Flags):
+    nvvm_options = Option(
+        type=_nvvm_options_type,
+        default=None,
+        doc="NVVM options",
+    )
+    compute_capability = Option(
+        type=tuple,
+        default=None,
+        doc="Compute Capability",
+    )
+    max_registers = Option(
+        type=_optional_int_type, default=None, doc="Max registers"
+    )
+    lto = Option(type=bool, default=False, doc="Enable Link-time Optimization")

--- a/numba_cuda/numba/cuda/target.py
+++ b/numba_cuda/numba/cuda/target.py
@@ -2,9 +2,20 @@ import re
 from functools import cached_property
 import llvmlite.binding as ll
 from llvmlite import ir
+import warnings
 
-from numba.core import cgutils, config, itanium_mangler, types, typing
+from numba.core import (
+    cgutils,
+    compiler,
+    config,
+    itanium_mangler,
+    targetconfig,
+    types,
+    typing,
+)
+from numba.core.compiler_lock import global_compiler_lock
 from numba.core.dispatcher import Dispatcher
+from numba.core.errors import NumbaWarning
 from numba.core.base import BaseContext
 from numba.core.callconv import BaseCallConv, MinimalCallConv
 from numba.core.typing import cmathdecl
@@ -13,6 +24,7 @@ from numba.core import datamodel
 from .cudadrv import nvvm
 from numba.cuda import codegen, ufuncs
 from numba.cuda.debuginfo import CUDADIBuilder
+from numba.cuda.flags import CUDAFlags
 from numba.cuda.models import cuda_data_manager
 
 # -----------------------------------------------------------------------------
@@ -287,6 +299,47 @@ class CUDATargetContext(BaseContext):
 
     def get_ufunc_info(self, ufunc_key):
         return ufuncs.get_ufunc_info(ufunc_key)
+
+    def _compile_subroutine_no_cache(
+        self, builder, impl, sig, locals=None, flags=None
+    ):
+        # Overrides numba.core.base.BaseContext._compile_subroutine_no_cache().
+        # Modified to use flags from the context stack if they are not provided
+        # (pending a fix in Numba upstream).
+
+        if locals is None:
+            locals = {}
+
+        with global_compiler_lock:
+            codegen = self.codegen()
+            library = codegen.create_library(impl.__name__)
+            if flags is None:
+                cstk = targetconfig.ConfigStack()
+                if cstk:
+                    flags = cstk.top().copy()
+                else:
+                    msg = "There should always be a context stack; none found."
+                    warnings.warn(msg, NumbaWarning)
+                    flags = CUDAFlags()
+
+            flags.no_compile = True
+            flags.no_cpython_wrapper = True
+            flags.no_cfunc_wrapper = True
+
+            cres = compiler.compile_internal(
+                self.typing_context,
+                self,
+                library,
+                impl,
+                sig.args,
+                sig.return_type,
+                flags,
+                locals=locals,
+            )
+
+            # Allow inlining the function inside callers
+            self.active_code_library.add_linking_library(cres.library)
+            return cres
 
 
 class CUDACallConv(MinimalCallConv):


### PR DESCRIPTION
Lineinfo generation is broken by function implementations that generate code via `context.compile_internal()`. The root cause is that the implementation eventually reaches upstream Numba's `BaseContext._compile_subroutine_no_cache()` method, which ignores the flags in the context stack and creates new ones. The outcome of this is that the debug info kind is forgotten, leading to a default debug info kind of `"FullDebug"` being emitted, which then enables the PTX `debug` target, leading to deoptimized code.

This change works around the issue (pending a fix upstream) by overriding the `_compile_subroutine_no_cache()` implementation to use flags from the context stack when they are otherwise not provided. The fix to upstream will look like a similar modification of the method.

The `CUDAFlags` class is moved to its own module to avoid circular import dependencies between `compiler.py` and `target.py`.

Fixes #271.

<!--

Thank you for contributing to numba-cuda :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
