### PR TITLE
Raise better error when `cuda.bindings` are not available

### DIFF
--- a/numba_cuda/numba/cuda/__init__.py
+++ b/numba_cuda/numba/cuda/__init__.py
@@ -35,12 +35,12 @@ if config.CUDA_USE_NVIDIA_BINDING:
     if not importlib.util.find_spec("cuda.bindings"):
         raise ImportError(
             "CUDA bindings not found. Please install through "
-            "the cuda-bindings[cuXY] package where XY is the "
-            "required CUDA version. Alternatively, install "
-            "numba-cuda-cuXY to install the required binding "
-            "automatically. If no CUDA bindings are desired, "
-            "set NUMBA_CUDA_USE_NVIDIA_BINDING=0 to enable "
-            "ctypes bindings."
+            "the cuda-bindings package. Alternatively, install "
+            "numba-cuda[cuXY], where XY is the required CUDA "
+            "version, to install the binding automatically. "
+            "If no CUDA bindings are desired, set the env var "
+            "NUMBA_CUDA_USE_NVIDIA_BINDING=0 to enable ctypes "
+            "bindings."
         )
 
 if config.ENABLE_CUDASIM:

--- a/numba_cuda/numba/cuda/__init__.py
+++ b/numba_cuda/numba/cuda/__init__.py
@@ -34,8 +34,8 @@ else:
 if config.CUDA_USE_NVIDIA_BINDING:
     if not importlib.util.find_spec("cuda.bindings"):
         raise ImportError(
-            "CUDA bindings not found. Please install through "
-            "the cuda-bindings package. Alternatively, install "
+            "CUDA bindings not found. Please pip install the "
+            "cuda-bindings package. Alternatively, install "
             "numba-cuda[cuXY], where XY is the required CUDA "
             "version, to install the binding automatically. "
             "If no CUDA bindings are desired, set the env var "

--- a/numba_cuda/numba/cuda/__init__.py
+++ b/numba_cuda/numba/cuda/__init__.py
@@ -31,6 +31,17 @@ if _nvidia_binding_enabled_in_env is False:
 else:
     USE_NV_BINDING = True
     config.CUDA_USE_NVIDIA_BINDING = USE_NV_BINDING
+if config.CUDA_USE_NVIDIA_BINDING:
+    if not importlib.util.find_spec("cuda.bindings"):
+        raise ImportError(
+            "CUDA bindings not found. Please install through "
+            "the cuda-bindings[cuXY] package where XY is the "
+            "required CUDA version. Alternatively, install "
+            "numba-cuda-cuXY to install the required binding "
+            "automatically. If no CUDA bindings are desired, "
+            "set NUMBA_CUDA_USE_NVIDIA_BINDING=0 to enable "
+            "ctypes bindings."
+        )
 
 if config.ENABLE_CUDASIM:
     from .simulator_init import *


### PR DESCRIPTION
Raises a better error with instructions of what to do if the base install is used and no user provided cuda bindings are present in the environment. 