### PR TITLE
Fix `DeviceNDArray.device_ctypes_pointer` to always be ctypes

### DIFF
--- a/numba_cuda/numba/cuda/cudadrv/devicearray.py
+++ b/numba_cuda/numba/cuda/cudadrv/devicearray.py
@@ -121,16 +121,10 @@ class DeviceNDArrayBase(_devicearray.DeviceArray):
 
     @property
     def __cuda_array_interface__(self):
-        if _driver.USE_NV_BINDING:
-            if self.device_ctypes_pointer is not None:
-                ptr = int(self.device_ctypes_pointer)
-            else:
-                ptr = 0
+        if self.device_ctypes_pointer.value is not None:
+            ptr = self.device_ctypes_pointer.value
         else:
-            if self.device_ctypes_pointer.value is not None:
-                ptr = self.device_ctypes_pointer.value
-            else:
-                ptr = 0
+            ptr = 0
 
         return {
             "shape": tuple(self.shape),
@@ -204,10 +198,7 @@ class DeviceNDArrayBase(_devicearray.DeviceArray):
     def device_ctypes_pointer(self):
         """Returns the ctypes pointer to the GPU data buffer"""
         if self.gpu_data is None:
-            if _driver.USE_NV_BINDING:
-                return _driver.binding.CUdeviceptr(0)
-            else:
-                return c_void_p(0)
+            return c_void_p(0)
         else:
             return self.gpu_data.device_ctypes_pointer
 

--- a/numba_cuda/numba/cuda/cudadrv/driver.py
+++ b/numba_cuda/numba/cuda/cudadrv/driver.py
@@ -2090,6 +2090,8 @@ class MemoryPointer(object):
 
     @property
     def device_ctypes_pointer(self):
+        if USE_NV_BINDING:
+            return drvapi.cu_device_ptr(int(self.device_pointer))
         return self.device_pointer
 
     @property
@@ -3431,8 +3433,8 @@ def device_extents(devmem):
     """
     devptr = device_ctypes_pointer(devmem)
     if USE_NV_BINDING:
-        s, n = driver.cuMemGetAddressRange(devptr)
-        return s, binding.CUdeviceptr(int(s) + n)
+        s, n = driver.cuMemGetAddressRange(devptr.value)
+        return int(s), int(binding.CUdeviceptr(int(s) + n))
     else:
         s = drvapi.cu_device_ptr()
         n = c_size_t()
@@ -3449,10 +3451,7 @@ def device_memory_size(devmem):
     sz = getattr(devmem, "_cuda_memsize_", None)
     if sz is None:
         s, e = device_extents(devmem)
-        if USE_NV_BINDING:
-            sz = int(e) - int(s)
-        else:
-            sz = e - s
+        sz = e - s
         devmem._cuda_memsize_ = sz
     assert sz >= 0, "{} length array".format(sz)
     return sz
@@ -3518,10 +3517,7 @@ def host_memory_size(obj):
 
 def device_pointer(obj):
     "Get the device pointer as an integer"
-    if USE_NV_BINDING:
-        return obj.device_ctypes_pointer
-    else:
-        return device_ctypes_pointer(obj).value
+    return device_ctypes_pointer(obj).value
 
 
 def device_ctypes_pointer(obj):

--- a/numba_cuda/numba/cuda/dispatcher.py
+++ b/numba_cuda/numba/cuda/dispatcher.py
@@ -588,8 +588,6 @@ class _Kernel(serialize.ReduceMixin):
         elif isinstance(ty, types.Record):
             devrec = wrap_arg(val).to_device(retr, stream)
             ptr = devrec.device_ctypes_pointer
-            if driver.USE_NV_BINDING:
-                ptr = ctypes.c_void_p(int(ptr))
             kernelargs.append(ptr)
 
         elif isinstance(ty, types.BaseTuple):

--- a/numba_cuda/numba/cuda/tests/cudadrv/test_cuda_driver.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_cuda_driver.py
@@ -1,4 +1,4 @@
-from ctypes import byref, c_int, c_void_p, sizeof
+from ctypes import byref, c_int, sizeof
 
 from numba.cuda.cudadrv.driver import (
     host_to_device,
@@ -94,7 +94,6 @@ class TestCudaDriver(CUDATestCase):
         stream = 0
 
         if _driver.USE_NV_BINDING:
-            ptr = c_void_p(int(ptr))
             stream = _driver.binding.CUstream(stream)
 
         launch_kernel(
@@ -129,8 +128,6 @@ class TestCudaDriver(CUDATestCase):
             host_to_device(memory, array, sizeof(array), stream=stream)
 
             ptr = memory.device_ctypes_pointer
-            if _driver.USE_NV_BINDING:
-                ptr = c_void_p(int(ptr))
 
             launch_kernel(
                 function.handle,  # Kernel

--- a/numba_cuda/numba/cuda/tests/cudadrv/test_cuda_memory.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_cuda_memory.py
@@ -20,10 +20,7 @@ class TestCudaMemory(ContextResettingTestCase):
     def _template(self, obj):
         self.assertTrue(driver.is_device_memory(obj))
         driver.require_device_memory(obj)
-        if driver.USE_NV_BINDING:
-            expected_class = driver.binding.CUdeviceptr
-        else:
-            expected_class = drvapi.cu_device_ptr
+        expected_class = drvapi.cu_device_ptr
         self.assertTrue(isinstance(obj.device_ctypes_pointer, expected_class))
 
     def test_device_memory(self):

--- a/numba_cuda/numba/cuda/tests/cudapy/test_cuda_array_interface.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_cuda_array_interface.py
@@ -12,10 +12,9 @@ from unittest.mock import call, patch
 @skip_on_cudasim("CUDA Array Interface is not supported in the simulator")
 class TestCudaArrayInterface(ContextResettingTestCase):
     def assertPointersEqual(self, a, b):
-        if driver.USE_NV_BINDING:
-            self.assertEqual(
-                int(a.device_ctypes_pointer), int(b.device_ctypes_pointer)
-            )
+        self.assertEqual(
+            a.device_ctypes_pointer.value, b.device_ctypes_pointer.value
+        )
 
     def test_as_cuda_array(self):
         h_arr = np.arange(10)


### PR DESCRIPTION
When the NVIDIA bindings are in use, `device_ctypes_pointer` should always be a ctypes pointer, otherwise the interface changes depending on which set of bindings are in use. This has been a long-standing inconsistency, but it needs to be resolved.

The fundamental change is only to `DeviceNDArray.device_ctypes_pointer`. The associated changes are all fixups to maintain internal consistency.

This likely covers 95% of broken use cases, with the remaining small number being related to streams and events, that are both more involved to fix and less likely to be directly affected by users (because users will mostly not look directly at the stream / event handle).

<!--

Thank you for contributing to numba-cuda :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
