### PR TITLE
Update repo readme and point users to the official doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,10 @@ tracker](https://github.com/NVIDIA/numba-cuda/issues).
 To raise questions or initiate discussions, please use the [Numba Discourse
 forum](https://numba.discourse.group).
 
-## Installation with pip
+## Installation with pip or conda
 
-```shell
-pip install numba-cuda
-```
+Please refer to the [Installation documentation](https://nvidia.github.io/numba-cuda/user/installation.html#installation-with-a-python-package-manager).
 
-## Installation with Conda
-
-```shell
-conda install -c conda-forge numba-cuda
-```
 
 ## Installation from source
 
@@ -31,6 +24,8 @@ Install as an editable install:
 ```
 pip install -e .
 ```
+
+If you want to manage all run-time dependencies yourself, also pass the `--no-deps` flag.
 
 ## Running tests
 


### PR DESCRIPTION
xref https://github.com/NVIDIA/numba-cuda/pull/293#issuecomment-2977133324

Since we've updated the installation guide in the docs, my preference is to retain a single source of truth and not duplicate it in the README, therefore I only added a url to redirect the readers. I noticed that Graham has manually pushed a doc update (although the `gh-pages` branch is still outdated, which is puzzling) after #293 was merged, so this redirection is possible now.