### PR TITLE
Don't skip debug tests when LTO enabled by default

### DIFF
--- a/numba_cuda/numba/cuda/testing.py
+++ b/numba_cuda/numba/cuda/testing.py
@@ -35,14 +35,6 @@ class CUDATestCase(SerialMixin, TestCase):
         config.CUDA_LOW_OCCUPANCY_WARNINGS = self._low_occupancy_warnings
         config.CUDA_WARN_ON_IMPLICIT_COPY = self._warn_on_implicit_copy
 
-    def skip_if_lto(self, reason):
-        # Some linkers need the compute capability to be specified, so we
-        # always specify it here.
-        cc = devices.get_context().device.compute_capability
-        linker = driver._Linker.new(cc=cc)
-        if linker.lto:
-            self.skipTest(reason)
-
 
 class ContextResettingTestCase(CUDATestCase):
     """

--- a/numba_cuda/numba/cuda/tests/cudapy/test_debuginfo.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_debuginfo.py
@@ -14,15 +14,6 @@ class TestCudaDebugInfo(CUDATestCase):
     These tests only checks the compiled PTX for debuginfo section
     """
 
-    def setUp(self):
-        super().setUp()
-        # If we're using LTO then we can't check the PTX in these tests,
-        # because we produce LTO-IR, which is opaque to the user.
-        # Additionally, LTO optimizes away the exception status due to an
-        # oversight in the way we generate it (it is not added to the used
-        # list).
-        self.skip_if_lto("Exceptions not supported with LTO")
-
     def _getasm(self, fn, sig):
         fn.compile(sig)
         return fn.inspect_asm(sig)

--- a/numba_cuda/numba/cuda/tests/cudapy/test_exception.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_exception.py
@@ -6,12 +6,6 @@ from numba.core import config
 
 
 class TestException(CUDATestCase):
-    def setUp(self):
-        super().setUp()
-        # LTO optimizes away the exception status due to an oversight
-        # in the way we generate it (it is not added to the used list).
-        self.skip_if_lto("Exceptions not supported with LTO")
-
     def test_exception(self):
         def foo(ary):
             x = cuda.threadIdx.x

--- a/numba_cuda/numba/cuda/tests/cudapy/test_fastmath.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_fastmath.py
@@ -188,10 +188,6 @@ class TestFastMathOption(CUDATestCase):
         )
 
     def test_divf_exception(self):
-        # LTO optimizes away the exception status due to an oversight
-        # in the way we generate it (it is not added to the used list).
-        self.skip_if_lto("Exceptions not supported with LTO")
-
         def f10(r, x, y):
             r[0] = x / y
 

--- a/numba_cuda/numba/cuda/tests/cudapy/test_userexc.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_userexc.py
@@ -13,13 +13,6 @@ regex_pattern = (
 
 
 class TestUserExc(CUDATestCase):
-    def setUp(self):
-        super().setUp()
-        # LTO optimizes away the exception status due to an oversight
-        # in the way we generate it (it is not added to the used list).
-        # See https://github.com/numba/numba/issues/9526.
-        self.skip_if_lto("Exceptions not supported with LTO")
-
     def test_user_exception(self):
         @cuda.jit("void(int32)", debug=True, opt=False)
         def test_exc(x):


### PR DESCRIPTION
These used to be skipped when LTO was enabled because it was unconditionally enabled, even for kernels where `debug=True`. Now if `debug=True` LTO is disabled, so it is not a problem to run the debug tests even when LTO is enabled.

This fixes something of a regression in our test coverage, where these tests were run in fewer settings due to LTO being enabled by default.

<!--

Thank you for contributing to numba-cuda :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
