### PR TITLE
Fix nvrtc resolution when CUDA_HOME env is set

### DIFF
--- a/numba_cuda/numba/cuda/cuda_paths.py
+++ b/numba_cuda/numba/cuda/cuda_paths.py
@@ -97,10 +97,17 @@ def _get_nvrtc_system_ctk():
         return max(candidates)
 
 
+def _nvrtc_lib_dir():
+    if IS_WIN32:
+        return ("bin",)
+    else:
+        return ("lib64",)
+
+
 def _get_nvrtc_path_decision():
     options = _build_options(
         [
-            ("CUDA_HOME", lambda: get_cuda_home("nvrtc")),
+            ("CUDA_HOME", lambda: get_cuda_home(*_nvrtc_lib_dir())),
             ("Conda environment", get_conda_ctk),
             ("Conda environment (NVIDIA package)", get_nvidia_cudalib_ctk),
             ("NVIDIA NVCC Wheel", _get_nvrtc_wheel),

--- a/numba_cuda/numba/cuda/cuda_paths.py
+++ b/numba_cuda/numba/cuda/cuda_paths.py
@@ -97,17 +97,10 @@ def _get_nvrtc_system_ctk():
         return max(candidates)
 
 
-def _nvrtc_lib_dir():
-    if IS_WIN32:
-        return ("bin",)
-    else:
-        return ("lib64",)
-
-
 def _get_nvrtc_path_decision():
     options = _build_options(
         [
-            ("CUDA_HOME", lambda: get_cuda_home(*_nvrtc_lib_dir())),
+            ("CUDA_HOME", lambda: get_cuda_home(_cudalib_path())),
             ("Conda environment", get_conda_ctk),
             ("Conda environment (NVIDIA package)", get_nvidia_cudalib_ctk),
             ("NVIDIA NVCC Wheel", _get_nvrtc_wheel),


### PR DESCRIPTION
`libnvrtc.so` is located in the `lib64` folder not in the separate folder. I guess it is a typo based on the `nvvm` location. Not sure about Windows path, but was following same logic as `nvvm` does, but without subfolder.

UPD: probably won't be needed after #308 
