### PR TITLE
Add deadlock warnings to Stream.add_callback and Stream.async_done docstrings

### DIFF
--- a/numba_cuda/numba/cuda/cudadrv/driver.py
+++ b/numba_cuda/numba/cuda/cudadrv/driver.py
@@ -2389,13 +2389,13 @@ class Stream(object):
         callbacks from being executed.
 
         .. warning::
-            There is a potential for deadlock if you are using a library
-            that calls CUDA functions without releasing the GIL. This can
+            There is a potential for deadlock due to a lock ordering issue
+            between the GIL and the CUDA driver lock when using libraries
+            that call CUDA functions without releasing the GIL. This can
             occur when the callback function attempts to acquire the GIL
-            while another thread is holding it and attempting to make CUDA
-            calls. Consider using libraries that properly release the GIL
-            around CUDA operations or restructure your code to avoid this
-            situation.
+            while the CUDA driver lock is held. Consider using libraries
+            that properly release the GIL around CUDA operations or
+            restructure your code to avoid this situation.
 
         Note: The driver function underlying this method is marked for
         eventual deprecation and may be replaced in a future CUDA release.
@@ -2433,13 +2433,13 @@ class Stream(object):
         are complete. The result of the awaitable is the current stream.
 
         .. warning::
-            There is a potential for deadlock if you are using a library
-            that calls CUDA functions without releasing the GIL. This can
+            There is a potential for deadlock due to a lock ordering issue
+            between the GIL and the CUDA driver lock when using libraries
+            that call CUDA functions without releasing the GIL. This can
             occur when the callback function (internally used by this method)
-            attempts to acquire the GIL while another thread is holding it
-            and attempting to make CUDA calls. Consider using libraries that
-            properly release the GIL around CUDA operations or restructure
-            your code to avoid this situation.
+            attempts to acquire the GIL while the CUDA driver lock is held.
+            Consider using libraries that properly release the GIL around
+            CUDA operations or restructure your code to avoid this situation.
         """
         loop = asyncio.get_running_loop()
         future = loop.create_future()

--- a/numba_cuda/numba/cuda/cudadrv/driver.py
+++ b/numba_cuda/numba/cuda/cudadrv/driver.py
@@ -2392,10 +2392,11 @@ class Stream(object):
             There is a potential for deadlock due to a lock ordering issue
             between the GIL and the CUDA driver lock when using libraries
             that call CUDA functions without releasing the GIL. This can
-            occur when the callback function attempts to acquire the GIL
-            while the CUDA driver lock is held. Consider using libraries
-            that properly release the GIL around CUDA operations or
-            restructure your code to avoid this situation.
+            occur when the callback function, which holds the CUDA driver lock,
+            attempts to acquire the GIL while another thread that holds the GIL
+            is waiting for the CUDA driver lock. Consider using libraries that
+            properly release the GIL around CUDA operations or restructure
+            your code to avoid this situation.
 
         Note: The driver function underlying this method is marked for
         eventual deprecation and may be replaced in a future CUDA release.
@@ -2436,8 +2437,9 @@ class Stream(object):
             There is a potential for deadlock due to a lock ordering issue
             between the GIL and the CUDA driver lock when using libraries
             that call CUDA functions without releasing the GIL. This can
-            occur when the callback function (internally used by this method)
-            attempts to acquire the GIL while the CUDA driver lock is held.
+            occur when the callback function (internally used by this method),
+            which holds the CUDA driver lock, attempts to acquire the GIL
+            while another thread that holds the GIL is waiting for the CUDA driver lock.
             Consider using libraries that properly release the GIL around
             CUDA operations or restructure your code to avoid this situation.
         """

--- a/numba_cuda/numba/cuda/cudadrv/driver.py
+++ b/numba_cuda/numba/cuda/cudadrv/driver.py
@@ -2388,6 +2388,15 @@ class Stream(object):
         callback will block later work in the stream and may block other
         callbacks from being executed.
 
+        .. warning::
+            There is a potential for deadlock if you are using a library
+            that calls CUDA functions without releasing the GIL. This can
+            occur when the callback function attempts to acquire the GIL
+            while another thread is holding it and attempting to make CUDA
+            calls. Consider using libraries that properly release the GIL
+            around CUDA operations or restructure your code to avoid this
+            situation.
+
         Note: The driver function underlying this method is marked for
         eventual deprecation and may be replaced in a future CUDA release.
 
@@ -2422,6 +2431,15 @@ class Stream(object):
         """
         Return an awaitable that resolves once all preceding stream operations
         are complete. The result of the awaitable is the current stream.
+
+        .. warning::
+            There is a potential for deadlock if you are using a library
+            that calls CUDA functions without releasing the GIL. This can
+            occur when the callback function (internally used by this method)
+            attempts to acquire the GIL while another thread is holding it
+            and attempting to make CUDA calls. Consider using libraries that
+            properly release the GIL around CUDA operations or restructure
+            your code to avoid this situation.
         """
         loop = asyncio.get_running_loop()
         future = loop.create_future()


### PR DESCRIPTION
This PR adds important deadlock warnings to the docstrings of Stream.add_callback and Stream.async_done methods.

## Changes Made

- Added warning about potential deadlock when using libraries that call CUDA functions without releasing the GIL
- This can occur when callback functions attempt to acquire the GIL while another thread is holding it and making CUDA calls
- Recommends using libraries that properly release the GIL around CUDA operations

## Context

Based on the third bullet point from https://github.com/NVIDIA/numba-cuda/issues/317#issuecomment-3073930435, these methods need clearer documentation about potential deadlock scenarios when integrating with other CUDA libraries that don't properly handle GIL management.

The warnings help developers understand the threading implications and make informed decisions about their code architecture to avoid deadlocks.

---
*This pull request was generated from Cursor*