### PR TITLE
Vendor in PassManager, typed and untyped pass, and related helpers for CUDA-specific customization

### DIFF
--- a/numba_cuda/numba/cuda/compiler.py
+++ b/numba_cuda/numba/cuda/compiler.py
@@ -10,14 +10,8 @@ from numba.core import (
     sigutils,
     utils,
 )
-from numba.core.compiler import (
-    sanitize_compile_result_entries,
-    CompilerBase,
-    DefaultPassBuilder,
-    CompileResult,
-)
 from numba.cuda.core.compiler_lock import global_compiler_lock
-from numba.core.compiler_machinery import (
+from numba.cuda.core.compiler_machinery import (
     FunctionPass,
     LoweringPass,
     PassManager,
@@ -25,8 +19,8 @@ from numba.core.compiler_machinery import (
 )
 from numba.core.interpreter import Interpreter
 from numba.core.errors import NumbaInvalidConfigWarning
-from numba.core.untyped_passes import TranslateByteCode
-from numba.core.typed_passes import (
+from numba.cuda.core.untyped_passes import TranslateByteCode
+from numba.cuda.core.typed_passes import (
     IRLegalization,
     NativeLowering,
     AnnotateTypes,
@@ -40,6 +34,783 @@ from numba.cuda.descriptor import cuda_target
 from numba.cuda.flags import CUDAFlags
 from numba.cuda.target import CUDACABICallConv
 from numba.cuda import lowering
+
+from collections import namedtuple
+import copy
+import warnings
+from numba.core.tracing import event
+
+from numba.core import (
+    errors,
+    interpreter,
+    bytecode,
+    postproc,
+    callconv,
+    cpu,
+)
+from numba.parfors.parfor import ParforDiagnostics
+from numba.core.errors import CompilerError
+from numba.core.environment import lookup_environment
+
+
+from numba.cuda.core.untyped_passes import (
+    ExtractByteCode,
+    FixupArgs,
+    IRProcessing,
+    DeadBranchPrune,
+    RewriteSemanticConstants,
+    InlineClosureLikes,
+    GenericRewrites,
+    WithLifting,
+    InlineInlinables,
+    FindLiterallyCalls,
+    MakeFunctionToJitFunction,
+    CanonicalizeLoopExit,
+    CanonicalizeLoopEntry,
+    LiteralUnroll,
+    ReconstructSSA,
+    RewriteDynamicRaises,
+    LiteralPropagationSubPipelinePass,
+)
+
+from numba.cuda.core.typed_passes import (
+    NopythonTypeInference,
+    NopythonRewrites,
+    PreParforPass,
+    ParforPass,
+    DumpParforDiagnostics,
+    NoPythonBackend,
+    InlineOverloads,
+    PreLowerStripPhis,
+    NativeParforLowering,
+    NoPythonSupportedFeatureValidation,
+    ParforFusionPass,
+    ParforPreLoweringPass,
+)
+
+from numba.core.object_mode_passes import ObjectModeFrontEnd, ObjectModeBackEnd
+
+from numba.core.targetconfig import ConfigStack
+
+
+CR_FIELDS = [
+    "typing_context",
+    "target_context",
+    "entry_point",
+    "typing_error",
+    "type_annotation",
+    "signature",
+    "objectmode",
+    "lifted",
+    "fndesc",
+    "library",
+    "call_helper",
+    "environment",
+    "metadata",
+    # List of functions to call to initialize on unserialization
+    # (i.e cache load).
+    "reload_init",
+    "referenced_envs",
+]
+
+
+class CompileResult(namedtuple("_CompileResult", CR_FIELDS)):
+    """
+    A structure holding results from the compilation of a function.
+    """
+
+    __slots__ = ()
+
+    def _reduce(self):
+        """
+        Reduce a CompileResult to picklable components.
+        """
+        libdata = self.library.serialize_using_object_code()
+        # Make it (un)picklable efficiently
+        typeann = str(self.type_annotation)
+        fndesc = self.fndesc
+        # Those don't need to be pickled and may fail
+        fndesc.typemap = fndesc.calltypes = None
+        # Include all referenced environments
+        referenced_envs = self._find_referenced_environments()
+        return (
+            libdata,
+            self.fndesc,
+            self.environment,
+            self.signature,
+            self.objectmode,
+            self.lifted,
+            typeann,
+            self.reload_init,
+            tuple(referenced_envs),
+        )
+
+    def _find_referenced_environments(self):
+        """Returns a list of referenced environments"""
+        mod = self.library._final_module
+        # Find environments
+        referenced_envs = []
+        for gv in mod.global_variables:
+            gvn = gv.name
+            if gvn.startswith("_ZN08NumbaEnv"):
+                env = lookup_environment(gvn)
+                if env is not None:
+                    if env.can_cache():
+                        referenced_envs.append(env)
+        return referenced_envs
+
+    @classmethod
+    def _rebuild(
+        cls,
+        target_context,
+        libdata,
+        fndesc,
+        env,
+        signature,
+        objectmode,
+        lifted,
+        typeann,
+        reload_init,
+        referenced_envs,
+    ):
+        if reload_init:
+            # Re-run all
+            for fn in reload_init:
+                fn()
+
+        library = target_context.codegen().unserialize_library(libdata)
+        cfunc = target_context.get_executable(library, fndesc, env)
+        cr = cls(
+            target_context=target_context,
+            typing_context=target_context.typing_context,
+            library=library,
+            environment=env,
+            entry_point=cfunc,
+            fndesc=fndesc,
+            type_annotation=typeann,
+            signature=signature,
+            objectmode=objectmode,
+            lifted=lifted,
+            typing_error=None,
+            call_helper=None,
+            metadata=None,  # Do not store, arbitrary & potentially large!
+            reload_init=reload_init,
+            referenced_envs=referenced_envs,
+        )
+
+        # Load Environments
+        for env in referenced_envs:
+            library.codegen.set_env(env.env_name, env)
+
+        return cr
+
+    @property
+    def codegen(self):
+        return self.target_context.codegen()
+
+    def dump(self, tab=""):
+        print(f"{tab}DUMP {type(self).__name__} {self.entry_point}")
+        self.signature.dump(tab=tab + "  ")
+        print(f"{tab}END DUMP")
+
+
+_LowerResult = namedtuple(
+    "_LowerResult",
+    [
+        "fndesc",
+        "call_helper",
+        "cfunc",
+        "env",
+    ],
+)
+
+
+def sanitize_compile_result_entries(entries):
+    keys = set(entries.keys())
+    fieldset = set(CR_FIELDS)
+    badnames = keys - fieldset
+    if badnames:
+        raise NameError(*badnames)
+    missing = fieldset - keys
+    for k in missing:
+        entries[k] = None
+    # Avoid keeping alive traceback variables
+    err = entries["typing_error"]
+    if err is not None:
+        entries["typing_error"] = err.with_traceback(None)
+    return entries
+
+
+def compile_result(**entries):
+    entries = sanitize_compile_result_entries(entries)
+    return CompileResult(**entries)
+
+
+def run_frontend(func, inline_closures=False, emit_dels=False):
+    """
+    Run the compiler frontend over the given Python function, and return
+    the function's canonical Numba IR.
+
+    If inline_closures is Truthy then closure inlining will be run
+    If emit_dels is Truthy the ir.Del nodes will be emitted appropriately
+    """
+    # XXX make this a dedicated Pipeline?
+    func_id = bytecode.FunctionIdentity.from_function(func)
+    interp = interpreter.Interpreter(func_id)
+    bc = bytecode.ByteCode(func_id=func_id)
+    func_ir = interp.interpret(bc)
+    if inline_closures:
+        from numba.core.inline_closurecall import InlineClosureCallPass
+
+        inline_pass = InlineClosureCallPass(
+            func_ir, cpu.ParallelOptions(False), {}, False
+        )
+        inline_pass.run()
+    post_proc = postproc.PostProcessor(func_ir)
+    post_proc.run(emit_dels)
+    return func_ir
+
+
+class _CompileStatus(object):
+    """
+    Describes the state of compilation. Used like a C record.
+    """
+
+    __slots__ = ["fail_reason", "can_fallback"]
+
+    def __init__(self, can_fallback):
+        self.fail_reason = None
+        self.can_fallback = can_fallback
+
+    def __repr__(self):
+        vals = []
+        for k in self.__slots__:
+            vals.append("{k}={v}".format(k=k, v=getattr(self, k)))
+        return ", ".join(vals)
+
+
+class _EarlyPipelineCompletion(Exception):
+    """
+    Raised to indicate that a pipeline has completed early
+    """
+
+    def __init__(self, result):
+        self.result = result
+
+
+class StateDict(dict):
+    """
+    A dictionary that has an overloaded getattr and setattr to permit getting
+    and setting key/values through the use of attributes.
+    """
+
+    def __getattr__(self, attr):
+        try:
+            return self[attr]
+        except KeyError:
+            raise AttributeError(attr)
+
+    def __setattr__(self, attr, value):
+        self[attr] = value
+
+
+def _make_subtarget(targetctx, flags):
+    """
+    Make a new target context from the given target context and flags.
+    """
+    subtargetoptions = {}
+    if flags.debuginfo:
+        subtargetoptions["enable_debuginfo"] = True
+    if flags.boundscheck:
+        subtargetoptions["enable_boundscheck"] = True
+    if flags.nrt:
+        subtargetoptions["enable_nrt"] = True
+    if flags.auto_parallel:
+        subtargetoptions["auto_parallel"] = flags.auto_parallel
+    if flags.fastmath:
+        subtargetoptions["fastmath"] = flags.fastmath
+    error_model = callconv.create_error_model(flags.error_model, targetctx)
+    subtargetoptions["error_model"] = error_model
+
+    return targetctx.subtarget(**subtargetoptions)
+
+
+class CompilerBase(object):
+    """
+    Stores and manages states for the compiler
+    """
+
+    def __init__(
+        self, typingctx, targetctx, library, args, return_type, flags, locals
+    ):
+        # Make sure the environment is reloaded
+        config.reload_config()
+        typingctx.refresh()
+        targetctx.refresh()
+
+        self.state = StateDict()
+
+        self.state.typingctx = typingctx
+        self.state.targetctx = _make_subtarget(targetctx, flags)
+        self.state.library = library
+        self.state.args = args
+        self.state.return_type = return_type
+        self.state.flags = flags
+        self.state.locals = locals
+
+        # Results of various steps of the compilation pipeline
+        self.state.bc = None
+        self.state.func_id = None
+        self.state.func_ir = None
+        self.state.lifted = None
+        self.state.lifted_from = None
+        self.state.typemap = None
+        self.state.calltypes = None
+        self.state.type_annotation = None
+        # holds arbitrary inter-pipeline stage meta data
+        self.state.metadata = {}
+        self.state.reload_init = []
+        # hold this for e.g. with_lifting, null out on exit
+        self.state.pipeline = self
+
+        # parfor diagnostics info, add to metadata
+        self.state.parfor_diagnostics = ParforDiagnostics()
+        self.state.metadata["parfor_diagnostics"] = (
+            self.state.parfor_diagnostics
+        )
+        self.state.metadata["parfors"] = {}
+
+        self.state.status = _CompileStatus(
+            can_fallback=self.state.flags.enable_pyobject
+        )
+
+    def compile_extra(self, func):
+        self.state.func_id = bytecode.FunctionIdentity.from_function(func)
+        ExtractByteCode().run_pass(self.state)
+
+        self.state.lifted = ()
+        self.state.lifted_from = None
+        return self._compile_bytecode()
+
+    def compile_ir(self, func_ir, lifted=(), lifted_from=None):
+        self.state.func_id = func_ir.func_id
+        self.state.lifted = lifted
+        self.state.lifted_from = lifted_from
+        self.state.func_ir = func_ir
+        self.state.nargs = self.state.func_ir.arg_count
+
+        FixupArgs().run_pass(self.state)
+        return self._compile_ir()
+
+    def define_pipelines(self):
+        """Child classes override this to customize the pipelines in use."""
+        raise NotImplementedError()
+
+    def _compile_core(self):
+        """
+        Populate and run compiler pipeline
+        """
+        with ConfigStack().enter(self.state.flags.copy()):
+            pms = self.define_pipelines()
+            for pm in pms:
+                pipeline_name = pm.pipeline_name
+                func_name = "%s.%s" % (
+                    self.state.func_id.modname,
+                    self.state.func_id.func_qualname,
+                )
+
+                event("Pipeline: %s for %s" % (pipeline_name, func_name))
+                self.state.metadata["pipeline_times"] = {
+                    pipeline_name: pm.exec_times
+                }
+                is_final_pipeline = pm == pms[-1]
+                res = None
+                try:
+                    pm.run(self.state)
+                    if self.state.cr is not None:
+                        break
+                except _EarlyPipelineCompletion as e:
+                    res = e.result
+                    break
+                except Exception as e:
+                    if not isinstance(e, errors.NumbaError):
+                        raise e
+                    self.state.status.fail_reason = e
+                    if is_final_pipeline:
+                        raise e
+            else:
+                raise CompilerError("All available pipelines exhausted")
+
+            # Pipeline is done, remove self reference to release refs to user
+            # code
+            self.state.pipeline = None
+
+            # organise a return
+            if res is not None:
+                # Early pipeline completion
+                return res
+            else:
+                assert self.state.cr is not None
+                return self.state.cr
+
+    def _compile_bytecode(self):
+        """
+        Populate and run pipeline for bytecode input
+        """
+        assert self.state.func_ir is None
+        return self._compile_core()
+
+    def _compile_ir(self):
+        """
+        Populate and run pipeline for IR input
+        """
+        assert self.state.func_ir is not None
+        return self._compile_core()
+
+
+class Compiler(CompilerBase):
+    """The default compiler"""
+
+    def define_pipelines(self):
+        if self.state.flags.force_pyobject:
+            # either object mode
+            return [
+                DefaultPassBuilder.define_objectmode_pipeline(self.state),
+            ]
+        else:
+            # or nopython mode
+            return [
+                DefaultPassBuilder.define_nopython_pipeline(self.state),
+            ]
+
+
+class DefaultPassBuilder(object):
+    """
+    This is the default pass builder, it contains the "classic" default
+    pipelines as pre-canned PassManager instances:
+      - nopython
+      - objectmode
+      - interpreted
+      - typed
+      - untyped
+      - nopython lowering
+    """
+
+    @staticmethod
+    def define_nopython_pipeline(state, name="nopython"):
+        """Returns an nopython mode pipeline based PassManager"""
+        # compose pipeline from untyped, typed and lowering parts
+        dpb = DefaultPassBuilder
+        pm = PassManager(name)
+        untyped_passes = dpb.define_untyped_pipeline(state)
+        pm.passes.extend(untyped_passes.passes)
+
+        typed_passes = dpb.define_typed_pipeline(state)
+        pm.passes.extend(typed_passes.passes)
+
+        lowering_passes = dpb.define_nopython_lowering_pipeline(state)
+        pm.passes.extend(lowering_passes.passes)
+
+        pm.finalize()
+        return pm
+
+    @staticmethod
+    def define_nopython_lowering_pipeline(state, name="nopython_lowering"):
+        pm = PassManager(name)
+        # legalise
+        pm.add_pass(
+            NoPythonSupportedFeatureValidation,
+            "ensure features that are in use are in a valid form",
+        )
+        pm.add_pass(IRLegalization, "ensure IR is legal prior to lowering")
+        # Annotate only once legalized
+        pm.add_pass(AnnotateTypes, "annotate types")
+        # lower
+        if state.flags.auto_parallel.enabled:
+            pm.add_pass(NativeParforLowering, "native parfor lowering")
+        else:
+            pm.add_pass(NativeLowering, "native lowering")
+        pm.add_pass(NoPythonBackend, "nopython mode backend")
+        pm.add_pass(DumpParforDiagnostics, "dump parfor diagnostics")
+        pm.finalize()
+        return pm
+
+    @staticmethod
+    def define_parfor_gufunc_nopython_lowering_pipeline(
+        state, name="parfor_gufunc_nopython_lowering"
+    ):
+        pm = PassManager(name)
+        # legalise
+        pm.add_pass(
+            NoPythonSupportedFeatureValidation,
+            "ensure features that are in use are in a valid form",
+        )
+        pm.add_pass(IRLegalization, "ensure IR is legal prior to lowering")
+        # Annotate only once legalized
+        pm.add_pass(AnnotateTypes, "annotate types")
+        # lower
+        if state.flags.auto_parallel.enabled:
+            pm.add_pass(NativeParforLowering, "native parfor lowering")
+        else:
+            pm.add_pass(NativeLowering, "native lowering")
+        pm.add_pass(NoPythonBackend, "nopython mode backend")
+        pm.finalize()
+        return pm
+
+    @staticmethod
+    def define_typed_pipeline(state, name="typed"):
+        """Returns the typed part of the nopython pipeline"""
+        pm = PassManager(name)
+        # typing
+        pm.add_pass(NopythonTypeInference, "nopython frontend")
+
+        # strip phis
+        pm.add_pass(PreLowerStripPhis, "remove phis nodes")
+
+        # optimisation
+        pm.add_pass(InlineOverloads, "inline overloaded functions")
+        if state.flags.auto_parallel.enabled:
+            pm.add_pass(PreParforPass, "Preprocessing for parfors")
+        if not state.flags.no_rewrites:
+            pm.add_pass(NopythonRewrites, "nopython rewrites")
+        if state.flags.auto_parallel.enabled:
+            pm.add_pass(ParforPass, "convert to parfors")
+            pm.add_pass(ParforFusionPass, "fuse parfors")
+            pm.add_pass(ParforPreLoweringPass, "parfor prelowering")
+
+        pm.finalize()
+        return pm
+
+    @staticmethod
+    def define_parfor_gufunc_pipeline(state, name="parfor_gufunc_typed"):
+        """Returns the typed part of the nopython pipeline"""
+        pm = PassManager(name)
+        assert state.func_ir
+        pm.add_pass(IRProcessing, "processing IR")
+        pm.add_pass(NopythonTypeInference, "nopython frontend")
+        pm.add_pass(ParforPreLoweringPass, "parfor prelowering")
+
+        pm.finalize()
+        return pm
+
+    @staticmethod
+    def define_untyped_pipeline(state, name="untyped"):
+        """Returns an untyped part of the nopython pipeline"""
+        pm = PassManager(name)
+        if state.func_ir is None:
+            pm.add_pass(TranslateByteCode, "analyzing bytecode")
+            pm.add_pass(FixupArgs, "fix up args")
+        pm.add_pass(IRProcessing, "processing IR")
+        pm.add_pass(WithLifting, "Handle with contexts")
+
+        # inline closures early in case they are using nonlocal's
+        # see issue #6585.
+        pm.add_pass(
+            InlineClosureLikes, "inline calls to locally defined closures"
+        )
+
+        # pre typing
+        if not state.flags.no_rewrites:
+            pm.add_pass(RewriteSemanticConstants, "rewrite semantic constants")
+            pm.add_pass(DeadBranchPrune, "dead branch pruning")
+            pm.add_pass(GenericRewrites, "nopython rewrites")
+
+        pm.add_pass(RewriteDynamicRaises, "rewrite dynamic raises")
+
+        # convert any remaining closures into functions
+        pm.add_pass(
+            MakeFunctionToJitFunction,
+            "convert make_function into JIT functions",
+        )
+        # inline functions that have been determined as inlinable and rerun
+        # branch pruning, this needs to be run after closures are inlined as
+        # the IR repr of a closure masks call sites if an inlinable is called
+        # inside a closure
+        pm.add_pass(InlineInlinables, "inline inlinable functions")
+        if not state.flags.no_rewrites:
+            pm.add_pass(DeadBranchPrune, "dead branch pruning")
+
+        pm.add_pass(FindLiterallyCalls, "find literally calls")
+        pm.add_pass(LiteralUnroll, "handles literal_unroll")
+
+        if state.flags.enable_ssa:
+            pm.add_pass(ReconstructSSA, "ssa")
+
+        if not state.flags.no_rewrites:
+            pm.add_pass(DeadBranchPrune, "dead branch pruning")
+
+        pm.add_pass(LiteralPropagationSubPipelinePass, "Literal propagation")
+
+        pm.finalize()
+        return pm
+
+    @staticmethod
+    def define_objectmode_pipeline(state, name="object"):
+        """Returns an object-mode pipeline based PassManager"""
+        pm = PassManager(name)
+        if state.func_ir is None:
+            pm.add_pass(TranslateByteCode, "analyzing bytecode")
+            pm.add_pass(FixupArgs, "fix up args")
+        else:
+            # Reaches here if it's a fallback from nopython mode.
+            # Strip the phi nodes.
+            pm.add_pass(PreLowerStripPhis, "remove phis nodes")
+        pm.add_pass(IRProcessing, "processing IR")
+
+        # The following passes are needed to adjust for looplifting
+        pm.add_pass(CanonicalizeLoopEntry, "canonicalize loop entry")
+        pm.add_pass(CanonicalizeLoopExit, "canonicalize loop exit")
+
+        pm.add_pass(ObjectModeFrontEnd, "object mode frontend")
+        pm.add_pass(
+            InlineClosureLikes, "inline calls to locally defined closures"
+        )
+        # convert any remaining closures into functions
+        pm.add_pass(
+            MakeFunctionToJitFunction,
+            "convert make_function into JIT functions",
+        )
+        pm.add_pass(IRLegalization, "ensure IR is legal prior to lowering")
+        pm.add_pass(AnnotateTypes, "annotate types")
+        pm.add_pass(ObjectModeBackEnd, "object mode backend")
+        pm.finalize()
+        return pm
+
+
+def compile_extra(
+    typingctx,
+    targetctx,
+    func,
+    args,
+    return_type,
+    flags,
+    locals,
+    library=None,
+    pipeline_class=Compiler,
+):
+    """Compiler entry point
+
+    Parameter
+    ---------
+    typingctx :
+        typing context
+    targetctx :
+        target context
+    func : function
+        the python function to be compiled
+    args : tuple, list
+        argument types
+    return_type :
+        Use ``None`` to indicate void return
+    flags : numba.compiler.Flags
+        compiler flags
+    library : numba.codegen.CodeLibrary
+        Used to store the compiled code.
+        If it is ``None``, a new CodeLibrary is used.
+    pipeline_class : type like numba.compiler.CompilerBase
+        compiler pipeline
+    """
+    pipeline = pipeline_class(
+        typingctx, targetctx, library, args, return_type, flags, locals
+    )
+    return pipeline.compile_extra(func)
+
+
+def compile_ir(
+    typingctx,
+    targetctx,
+    func_ir,
+    args,
+    return_type,
+    flags,
+    locals,
+    lifted=(),
+    lifted_from=None,
+    is_lifted_loop=False,
+    library=None,
+    pipeline_class=Compiler,
+):
+    """
+    Compile a function with the given IR.
+
+    For internal use only.
+    """
+
+    # This is a special branch that should only run on IR from a lifted loop
+    if is_lifted_loop:
+        # This code is pessimistic and costly, but it is a not often trodden
+        # path and it will go away once IR is made immutable. The problem is
+        # that the rewrite passes can mutate the IR into a state that makes
+        # it possible for invalid tokens to be transmitted to lowering which
+        # then trickle through into LLVM IR and causes RuntimeErrors as LLVM
+        # cannot compile it. As a result the following approach is taken:
+        # 1. Create some new flags that copy the original ones but switch
+        #    off rewrites.
+        # 2. Compile with 1. to get a compile result
+        # 3. Try and compile another compile result but this time with the
+        #    original flags (and IR being rewritten).
+        # 4. If 3 was successful, use the result, else use 2.
+
+        # create flags with no rewrites
+        norw_flags = copy.deepcopy(flags)
+        norw_flags.no_rewrites = True
+
+        def compile_local(the_ir, the_flags):
+            pipeline = pipeline_class(
+                typingctx,
+                targetctx,
+                library,
+                args,
+                return_type,
+                the_flags,
+                locals,
+            )
+            return pipeline.compile_ir(
+                func_ir=the_ir, lifted=lifted, lifted_from=lifted_from
+            )
+
+        # compile with rewrites off, IR shouldn't be mutated irreparably
+        norw_cres = compile_local(func_ir.copy(), norw_flags)
+
+        # try and compile with rewrites on if no_rewrites was not set in the
+        # original flags, IR might get broken but we've got a CompileResult
+        # that's usable from above.
+        rw_cres = None
+        if not flags.no_rewrites:
+            # Suppress warnings in compilation retry
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", errors.NumbaWarning)
+                try:
+                    rw_cres = compile_local(func_ir.copy(), flags)
+                except Exception:
+                    pass
+        # if the rewrite variant of compilation worked, use it, else use
+        # the norewrites backup
+        if rw_cres is not None:
+            cres = rw_cres
+        else:
+            cres = norw_cres
+        return cres
+
+    else:
+        pipeline = pipeline_class(
+            typingctx, targetctx, library, args, return_type, flags, locals
+        )
+        return pipeline.compile_ir(
+            func_ir=func_ir, lifted=lifted, lifted_from=lifted_from
+        )
+
+
+def compile_internal(
+    typingctx, targetctx, library, func, args, return_type, flags, locals
+):
+    """
+    For internal use only.
+    """
+    pipeline = Compiler(
+        typingctx, targetctx, library, args, return_type, flags, locals
+    )
+    return pipeline.compile_extra(func)
 
 
 # The CUDACompileResult (CCR) has a specially-defined entry point equal to its

--- a/numba_cuda/numba/cuda/compiler.py
+++ b/numba_cuda/numba/cuda/compiler.py
@@ -16,7 +16,7 @@ from numba.core.compiler import (
     DefaultPassBuilder,
     CompileResult,
 )
-from numba.core.compiler_lock import global_compiler_lock
+from numba.cuda.core.compiler_lock import global_compiler_lock
 from numba.core.compiler_machinery import (
     FunctionPass,
     LoweringPass,

--- a/numba_cuda/numba/cuda/core/compiler_lock.py
+++ b/numba_cuda/numba/cuda/core/compiler_lock.py
@@ -1,0 +1,56 @@
+import threading
+import functools
+import numba.core.event as ev
+
+
+# Lock for the preventing multiple compiler execution
+class _CompilerLock(object):
+    def __init__(self):
+        self._lock = threading.RLock()
+
+    def acquire(self):
+        ev.start_event("numba:compiler_lock")
+        self._lock.acquire()
+
+    def release(self):
+        self._lock.release()
+        ev.end_event("numba:compiler_lock")
+
+    def __enter__(self):
+        self.acquire()
+
+    def __exit__(self, exc_val, exc_type, traceback):
+        self.release()
+
+    def is_locked(self):
+        is_owned = getattr(self._lock, "_is_owned")
+        if not callable(is_owned):
+            is_owned = self._is_owned
+        return is_owned()
+
+    def __call__(self, func):
+        @functools.wraps(func)
+        def _acquire_compile_lock(*args, **kwargs):
+            with self:
+                return func(*args, **kwargs)
+
+        return _acquire_compile_lock
+
+    def _is_owned(self):
+        # This method is borrowed from threading.Condition.
+        # Return True if lock is owned by current_thread.
+        # This method is called only if _lock doesn't have _is_owned().
+        if self._lock.acquire(0):
+            self._lock.release()
+            return False
+        else:
+            return True
+
+
+global_compiler_lock = _CompilerLock()
+
+
+def require_global_compiler_lock():
+    """Sentry that checks the global_compiler_lock is acquired."""
+    # Use assert to allow turning off this check
+    assert global_compiler_lock.is_locked()

--- a/numba_cuda/numba/cuda/core/compiler_machinery.py
+++ b/numba_cuda/numba/cuda/core/compiler_machinery.py
@@ -1,0 +1,491 @@
+import timeit
+from abc import abstractmethod, ABCMeta
+from collections import namedtuple, OrderedDict
+import inspect
+
+
+from numba.cuda.core.compiler_lock import global_compiler_lock
+from numba.core import errors, config, transforms, utils
+from numba.core.tracing import event
+from numba.core.postproc import PostProcessor
+from numba.core.ir_utils import enforce_no_dels, legalize_single_scope
+import numba.core.event as ev
+
+import numba.core.compiler_machinery as nccm
+
+# terminal color markup
+_termcolor = errors.termcolor()
+
+
+class SimpleTimer(object):
+    """
+    A simple context managed timer
+    """
+
+    def __enter__(self):
+        self.ts = timeit.default_timer()
+        return self
+
+    def __exit__(self, *exc):
+        self.elapsed = timeit.default_timer() - self.ts
+
+
+class CompilerPass(metaclass=ABCMeta):
+    """The base class for all compiler passes."""
+
+    @abstractmethod
+    def __init__(self, *args, **kwargs):
+        self._analysis = None
+        self._pass_id = None
+
+    @classmethod
+    def name(cls):
+        """
+        Returns the name of the pass
+        """
+        return cls._name
+
+    @property
+    def pass_id(self):
+        """
+        The ID of the pass
+        """
+        return self._pass_id
+
+    @pass_id.setter
+    def pass_id(self, val):
+        """
+        Sets the ID of the pass
+        """
+        self._pass_id = val
+
+    @property
+    def analysis(self):
+        """
+        Analysis data for the pass
+        """
+        return self._analysis
+
+    @analysis.setter
+    def analysis(self, val):
+        """
+        Set the analysis data for the pass
+        """
+        self._analysis = val
+
+    def run_initialization(self, *args, **kwargs):
+        """
+        Runs the initialization sequence for the pass, will run before
+        `run_pass`.
+        """
+        return False
+
+    @abstractmethod
+    def run_pass(self, *args, **kwargs):
+        """
+        Runs the pass itself. Must return True/False depending on whether
+        statement level modification took place.
+        """
+        pass
+
+    def run_finalizer(self, *args, **kwargs):
+        """
+        Runs the initialization sequence for the pass, will run before
+        `run_pass`.
+        """
+        return False
+
+    def get_analysis_usage(self, AU):
+        """Override to set analysis usage"""
+        pass
+
+    def get_analysis(self, pass_name):
+        """
+        Gets the analysis from a given pass
+        """
+        return self._analysis[pass_name]
+
+
+class SSACompliantMixin(object):
+    """Mixin to indicate a pass is SSA form compliant. Nothing is asserted
+    about this condition at present.
+    """
+
+    pass
+
+
+class FunctionPass(CompilerPass):
+    """Base class for function passes"""
+
+    pass
+
+
+class AnalysisPass(CompilerPass):
+    """Base class for analysis passes (no modification made to state)"""
+
+    pass
+
+
+class LoweringPass(CompilerPass):
+    """Base class for lowering passes"""
+
+    pass
+
+
+class AnalysisUsage(object):
+    """This looks and behaves like LLVM's AnalysisUsage because its like that."""
+
+    def __init__(self):
+        self._required = set()
+        self._preserved = set()
+
+    def get_required_set(self):
+        return self._required
+
+    def get_preserved_set(self):
+        return self._preserved
+
+    def add_required(self, pss):
+        self._required.add(pss)
+
+    def add_preserved(self, pss):
+        self._preserved.add(pss)
+
+    def __str__(self):
+        return "required: %s\n" % self._required
+
+
+_DEBUG = False
+
+
+def debug_print(*args, **kwargs):
+    if _DEBUG:
+        print(*args, **kwargs)
+
+
+pass_timings = namedtuple("pass_timings", "init run finalize")
+
+
+class PassManager(object):
+    """
+    The PassManager is a named instance of a particular compilation pipeline
+    """
+
+    # TODO: Eventually enable this, it enforces self consistency after each pass
+    _ENFORCING = False
+
+    def __init__(self, pipeline_name):
+        """
+        Create a new pipeline with name "pipeline_name"
+        """
+        self.passes = []
+        self.exec_times = OrderedDict()
+        self._finalized = False
+        self._analysis = None
+        self._print_after = None
+        self.pipeline_name = pipeline_name
+
+    def _validate_pass(self, pass_cls):
+        if not (
+            isinstance(pass_cls, str)
+            or (
+                inspect.isclass(pass_cls)
+                and (
+                    issubclass(pass_cls, CompilerPass)
+                    or issubclass(pass_cls, nccm.CompilerPass)
+                )
+            )
+        ):
+            msg = (
+                "Pass must be referenced by name or be a subclass of a "
+                "CompilerPass. Have %s" % pass_cls
+            )
+            raise TypeError(msg)
+        if isinstance(pass_cls, str):
+            pass_cls = _pass_registry.find_by_name(pass_cls)
+        else:
+            if not _pass_registry.is_registered(pass_cls):
+                raise ValueError("Pass %s is not registered" % pass_cls)
+
+    def add_pass(self, pss, description=""):
+        """
+        Append a pass to the PassManager's compilation pipeline
+        """
+        self._validate_pass(pss)
+        func_desc_tuple = (pss, description)
+        self.passes.append(func_desc_tuple)
+        self._finalized = False
+
+    def add_pass_after(self, pass_cls, location):
+        """
+        Add a pass `pass_cls` to the PassManager's compilation pipeline after
+        the pass `location`.
+        """
+        assert self.passes
+        self._validate_pass(pass_cls)
+        self._validate_pass(location)
+        for idx, (x, _) in enumerate(self.passes):
+            if x == location:
+                break
+        else:
+            raise ValueError("Could not find pass %s" % location)
+        self.passes.insert(idx + 1, (pass_cls, str(pass_cls)))
+        # if a pass has been added, it's not finalized
+        self._finalized = False
+
+    def _debug_init(self):
+        # determine after which passes IR dumps should take place
+        def parse(conf_item):
+            print_passes = []
+            if conf_item != "none":
+                if conf_item == "all":
+                    print_passes = [x.name() for (x, _) in self.passes]
+                else:
+                    # we don't validate whether the named passes exist in this
+                    # pipeline the compiler may be used reentrantly and
+                    # different pipelines may contain different passes
+                    splitted = conf_item.split(",")
+                    print_passes = [x.strip() for x in splitted]
+            return print_passes
+
+        ret = (
+            parse(config.DEBUG_PRINT_AFTER),
+            parse(config.DEBUG_PRINT_BEFORE),
+            parse(config.DEBUG_PRINT_WRAP),
+        )
+        return ret
+
+    def finalize(self):
+        """
+        Finalize the PassManager, after which no more passes may be added
+        without re-finalization.
+        """
+        self._analysis = self.dependency_analysis()
+        self._print_after, self._print_before, self._print_wrap = (
+            self._debug_init()
+        )
+        self._finalized = True
+
+    @property
+    def finalized(self):
+        return self._finalized
+
+    def _patch_error(self, desc, exc):
+        """
+        Patches the error to show the stage that it arose in.
+        """
+        newmsg = "{desc}\n{exc}".format(desc=desc, exc=exc)
+        exc.args = (newmsg,)
+        return exc
+
+    @global_compiler_lock  # this need a lock, likely calls LLVM
+    def _runPass(self, index, pss, internal_state):
+        mutated = False
+
+        def check(func, compiler_state):
+            mangled = func(compiler_state)
+            if mangled not in (True, False):
+                msg = (
+                    "CompilerPass implementations should return True/False. "
+                    "CompilerPass with name '%s' did not."
+                )
+                raise ValueError(msg % pss.name())
+            return mangled
+
+        def debug_print(pass_name, print_condition, printable_condition):
+            if pass_name in print_condition:
+                fid = internal_state.func_id
+                args = (
+                    fid.modname,
+                    fid.func_qualname,
+                    self.pipeline_name,
+                    printable_condition,
+                    pass_name,
+                )
+                print(("%s.%s: %s: %s %s" % args).center(120, "-"))
+                if internal_state.func_ir is not None:
+                    internal_state.func_ir.dump()
+                else:
+                    print("func_ir is None")
+
+        # debug print before this pass?
+        debug_print(pss.name(), self._print_before + self._print_wrap, "BEFORE")
+
+        # wire in the analysis info so it's accessible
+        pss.analysis = self._analysis
+
+        qualname = internal_state.func_id.func_qualname
+
+        ev_details = dict(
+            name=f"{pss.name()} [{qualname}]",
+            qualname=qualname,
+            module=internal_state.func_id.modname,
+            flags=utils._lazy_pformat(internal_state.flags.values()),
+            args=str(internal_state.args),
+            return_type=str(internal_state.return_type),
+        )
+        errctx = errors.new_error_context(f"Pass {pss.name()}")
+        with ev.trigger_event("numba:run_pass", data=ev_details), errctx:
+            with SimpleTimer() as init_time:
+                mutated |= check(pss.run_initialization, internal_state)
+            with SimpleTimer() as pass_time:
+                mutated |= check(pss.run_pass, internal_state)
+            with SimpleTimer() as finalize_time:
+                mutated |= check(pss.run_finalizer, internal_state)
+
+        # Check that if the pass is an instance of a FunctionPass that it hasn't
+        # emitted ir.Dels.
+        if isinstance(pss, FunctionPass):
+            enforce_no_dels(internal_state.func_ir)
+
+        if self._ENFORCING:
+            # TODO: Add in self consistency enforcement for
+            # `func_ir._definitions` etc
+            if _pass_registry.get(pss.__class__).mutates_CFG:
+                if mutated:  # block level changes, rebuild all
+                    PostProcessor(internal_state.func_ir).run()
+                else:  # CFG level changes rebuild CFG
+                    internal_state.func_ir.blocks = transforms.canonicalize_cfg(
+                        internal_state.func_ir.blocks
+                    )
+            # Check the func_ir has exactly one Scope instance
+            if not legalize_single_scope(internal_state.func_ir.blocks):
+                raise errors.CompilerError(
+                    f"multiple scope in func_ir detected in {pss}",
+                )
+        # inject runtimes
+        pt = pass_timings(
+            init_time.elapsed, pass_time.elapsed, finalize_time.elapsed
+        )
+        self.exec_times["%s_%s" % (index, pss.name())] = pt
+
+        # debug print after this pass?
+        debug_print(pss.name(), self._print_after + self._print_wrap, "AFTER")
+
+    def run(self, state):
+        """
+        Run the defined pipelines on the state.
+        """
+        from numba.cuda.compiler import _EarlyPipelineCompletion
+
+        if not self.finalized:
+            raise RuntimeError("Cannot run non-finalised pipeline")
+
+        # walk the passes and run them
+        for idx, (pss, pass_desc) in enumerate(self.passes):
+            try:
+                event("-- %s" % pass_desc)
+                pass_inst = _pass_registry.get(pss).pass_inst
+                if isinstance(pass_inst, CompilerPass):
+                    self._runPass(idx, pass_inst, state)
+                else:
+                    raise BaseException("Legacy pass in use")
+            except _EarlyPipelineCompletion as e:
+                raise e
+            except Exception as e:
+                if not isinstance(e, errors.NumbaError):
+                    raise e
+                msg = "Failed in %s mode pipeline (step: %s)" % (
+                    self.pipeline_name,
+                    pass_desc,
+                )
+                patched_exception = self._patch_error(msg, e)
+                raise patched_exception
+
+    def dependency_analysis(self):
+        """
+        Computes dependency analysis
+        """
+        deps = dict()
+        for pss, _ in self.passes:
+            x = _pass_registry.get(pss).pass_inst
+            au = AnalysisUsage()
+            x.get_analysis_usage(au)
+            deps[type(x)] = au
+
+        requires_map = dict()
+        for k, v in deps.items():
+            requires_map[k] = v.get_required_set()
+
+        def resolve_requires(key, rmap):
+            def walk(lkey, rmap):
+                dep_set = rmap[lkey] if lkey in rmap else set()
+                if dep_set:
+                    for x in dep_set:
+                        dep_set |= walk(x, rmap)
+                    return dep_set
+                else:
+                    return set()
+
+            ret = set()
+            for k in key:
+                ret |= walk(k, rmap)
+            return ret
+
+        dep_chain = dict()
+        for k, v in requires_map.items():
+            dep_chain[k] = set(v) | (resolve_requires(v, requires_map))
+
+        return dep_chain
+
+
+pass_info = namedtuple("pass_info", "pass_inst mutates_CFG analysis_only")
+
+
+class PassRegistry(object):
+    """
+    Pass registry singleton class.
+    """
+
+    _id = 0
+
+    _registry = dict()
+
+    def register(self, mutates_CFG, analysis_only):
+        def make_festive(pass_class):
+            assert not self.is_registered(pass_class)
+            assert not self._does_pass_name_alias(pass_class.name())
+            pass_class.pass_id = self._id
+            self._id += 1
+            self._registry[pass_class] = pass_info(
+                pass_class(), mutates_CFG, analysis_only
+            )
+            return pass_class
+
+        return make_festive
+
+    def is_registered(self, clazz):
+        return clazz in self._registry.keys()
+
+    def get(self, clazz):
+        assert self.is_registered(clazz)
+        return self._registry[clazz]
+
+    def _does_pass_name_alias(self, check):
+        for k, v in self._registry.items():
+            if v.pass_inst.name == check:
+                return True
+        return False
+
+    def find_by_name(self, class_name):
+        assert isinstance(class_name, str)
+        for k, v in self._registry.items():
+            if v.pass_inst.name == class_name:
+                return v
+        else:
+            raise ValueError("No pass with name %s is registered" % class_name)
+
+    def dump(self):
+        for k, v in self._registry.items():
+            print("%s: %s" % (k, v))
+
+
+_pass_registry = PassRegistry()
+del PassRegistry
+
+
+"""
+register_pass is used to register a compiler pass class for use with PassManager
+instances.
+"""
+register_pass = _pass_registry.register

--- a/numba_cuda/numba/cuda/core/typed_passes.py
+++ b/numba_cuda/numba/cuda/core/typed_passes.py
@@ -1,0 +1,1145 @@
+import abc
+from contextlib import contextmanager
+from collections import defaultdict, namedtuple
+from functools import partial
+from copy import copy
+import warnings
+
+from numba.core import (
+    errors,
+    types,
+    typing,
+    ir,
+    funcdesc,
+    rewrites,
+    typeinfer,
+    config,
+    lowering,
+)
+
+from numba.parfors.parfor import PreParforPass as _parfor_PreParforPass
+from numba.parfors.parfor import ParforPass as _parfor_ParforPass
+from numba.parfors.parfor import ParforFusionPass as _parfor_ParforFusionPass
+from numba.parfors.parfor import (
+    ParforPreLoweringPass as _parfor_ParforPreLoweringPass,
+)
+from numba.parfors.parfor import Parfor
+from numba.parfors.parfor_lowering import ParforLower
+
+from numba.cuda.core.compiler_machinery import (
+    FunctionPass,
+    LoweringPass,
+    AnalysisPass,
+    register_pass,
+)
+from numba.core.annotations import type_annotations
+from numba.core.ir_utils import (
+    raise_on_unsupported_feature,
+    warn_deprecated,
+    check_and_legalize_ir,
+    guard,
+    dead_code_elimination,
+    simplify_CFG,
+    get_definition,
+    build_definitions,
+    compute_cfg_from_blocks,
+    is_operator_or_getitem,
+    replace_vars,
+)
+from numba.core import postproc
+from llvmlite import binding as llvm
+
+
+# Outputs of type inference pass
+_TypingResults = namedtuple(
+    "_TypingResults",
+    [
+        "typemap",
+        "return_type",
+        "calltypes",
+        "typing_errors",
+    ],
+)
+
+
+@contextmanager
+def fallback_context(state, msg):
+    """
+    Wraps code that would signal a fallback to object mode
+    """
+    try:
+        yield
+    except Exception as e:
+        if not state.status.can_fallback:
+            raise
+        else:
+            # Clear all references attached to the traceback
+            e = e.with_traceback(None)
+            # this emits a warning containing the error message body in the
+            # case of fallback from npm to objmode
+            loop_lift = "" if state.flags.enable_looplift else "OUT"
+            msg_rewrite = (
+                "\nCompilation is falling back to object mode "
+                "WITH%s looplifting enabled because %s" % (loop_lift, msg)
+            )
+            warnings.warn_explicit(
+                "%s due to: %s" % (msg_rewrite, e),
+                errors.NumbaWarning,
+                state.func_id.filename,
+                state.func_id.firstlineno,
+            )
+            raise
+
+
+def type_inference_stage(
+    typingctx,
+    targetctx,
+    interp,
+    args,
+    return_type,
+    locals=None,
+    raise_errors=True,
+):
+    if locals is None:
+        locals = {}
+    if len(args) != interp.arg_count:
+        raise TypeError("Mismatch number of argument types")
+    warnings = errors.WarningsFixer(errors.NumbaWarning)
+
+    infer = typeinfer.TypeInferer(typingctx, interp, warnings)
+    callstack_ctx = typingctx.callstack.register(
+        targetctx.target, infer, interp.func_id, args
+    )
+    # Setup two contexts: 1) callstack setup/teardown 2) flush warnings
+    with callstack_ctx, warnings:
+        # Seed argument types
+        for index, (name, ty) in enumerate(zip(interp.arg_names, args)):
+            infer.seed_argument(name, index, ty)
+
+        # Seed return type
+        if return_type is not None:
+            infer.seed_return(return_type)
+
+        # Seed local types
+        for k, v in locals.items():
+            infer.seed_type(k, v)
+
+        infer.build_constraint()
+        # return errors in case of partial typing
+        errs = infer.propagate(raise_errors=raise_errors)
+        typemap, restype, calltypes = infer.unify(raise_errors=raise_errors)
+
+    return _TypingResults(typemap, restype, calltypes, errs)
+
+
+class BaseTypeInference(FunctionPass):
+    _raise_errors = True
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        """
+        Type inference and legalization
+        """
+        with fallback_context(
+            state,
+            'Function "%s" failed type inference' % (state.func_id.func_name,),
+        ):
+            # Type inference
+            typemap, return_type, calltypes, errs = type_inference_stage(
+                state.typingctx,
+                state.targetctx,
+                state.func_ir,
+                state.args,
+                state.return_type,
+                state.locals,
+                raise_errors=self._raise_errors,
+            )
+            state.typemap = typemap
+            # save errors in case of partial typing
+            state.typing_errors = errs
+            if self._raise_errors:
+                state.return_type = return_type
+            state.calltypes = calltypes
+
+        def legalize_return_type(return_type, interp, targetctx):
+            """
+            Only accept array return type iff it is passed into the function.
+            Reject function object return types if in nopython mode.
+            """
+            if not targetctx.enable_nrt and isinstance(
+                return_type, types.Array
+            ):
+                # Walk IR to discover all arguments and all return statements
+                retstmts = []
+                caststmts = {}
+                argvars = set()
+                for bid, blk in interp.blocks.items():
+                    for inst in blk.body:
+                        if isinstance(inst, ir.Return):
+                            retstmts.append(inst.value.name)
+                        elif isinstance(inst, ir.Assign):
+                            if (
+                                isinstance(inst.value, ir.Expr)
+                                and inst.value.op == "cast"
+                            ):
+                                caststmts[inst.target.name] = inst.value
+                            elif isinstance(inst.value, ir.Arg):
+                                argvars.add(inst.target.name)
+
+                assert retstmts, "No return statements?"
+
+                for var in retstmts:
+                    cast = caststmts.get(var)
+                    if cast is None or cast.value.name not in argvars:
+                        if self._raise_errors:
+                            msg = (
+                                "Only accept returning of array passed into "
+                                "the function as argument"
+                            )
+                            raise errors.NumbaTypeError(msg)
+
+            elif isinstance(return_type, types.Function) or isinstance(
+                return_type, types.Phantom
+            ):
+                if self._raise_errors:
+                    msg = "Can't return function object ({}) in nopython mode"
+                    raise errors.NumbaTypeError(msg.format(return_type))
+
+        with fallback_context(
+            state,
+            'Function "%s" has invalid return type'
+            % (state.func_id.func_name,),
+        ):
+            legalize_return_type(
+                state.return_type, state.func_ir, state.targetctx
+            )
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class NopythonTypeInference(BaseTypeInference):
+    _name = "nopython_type_inference"
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class PartialTypeInference(BaseTypeInference):
+    _name = "partial_type_inference"
+    _raise_errors = False
+
+
+@register_pass(mutates_CFG=False, analysis_only=False)
+class AnnotateTypes(AnalysisPass):
+    _name = "annotate_types"
+
+    def __init__(self):
+        AnalysisPass.__init__(self)
+
+    def get_analysis_usage(self, AU):
+        AU.add_required(IRLegalization)
+
+    def run_pass(self, state):
+        """
+        Create type annotation after type inference
+        """
+        func_ir = state.func_ir.copy()
+        state.type_annotation = type_annotations.TypeAnnotation(
+            func_ir=func_ir,
+            typemap=state.typemap,
+            calltypes=state.calltypes,
+            lifted=state.lifted,
+            lifted_from=state.lifted_from,
+            args=state.args,
+            return_type=state.return_type,
+            html_output=config.HTML,
+        )
+
+        if config.ANNOTATE:
+            print("ANNOTATION".center(80, "-"))
+            print(state.type_annotation)
+            print("=" * 80)
+        if config.HTML:
+            with open(config.HTML, "w") as fout:
+                state.type_annotation.html_annotate(fout)
+
+        return False
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class NopythonRewrites(FunctionPass):
+    _name = "nopython_rewrites"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        """
+        Perform any intermediate representation rewrites after type
+        inference.
+        """
+        # a bunch of these passes are either making assumptions or rely on some
+        # very picky and slightly bizarre state particularly in relation to
+        # ir.Del presence. To accommodate, ir.Dels are added ahead of running
+        # this pass and stripped at the end.
+
+        # Ensure we have an IR and type information.
+        assert state.func_ir
+        assert isinstance(getattr(state, "typemap", None), dict)
+        assert isinstance(getattr(state, "calltypes", None), dict)
+        msg = (
+            "Internal error in post-inference rewriting "
+            "pass encountered during compilation of "
+            'function "%s"' % (state.func_id.func_name,)
+        )
+
+        pp = postproc.PostProcessor(state.func_ir)
+        pp.run(True)
+        with fallback_context(state, msg):
+            rewrites.rewrite_registry.apply("after-inference", state)
+        pp.remove_dels()
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class PreParforPass(FunctionPass):
+    _name = "pre_parfor_pass"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        """
+        Preprocessing for data-parallel computations.
+        """
+        # Ensure we have an IR and type information.
+        assert state.func_ir
+        preparfor_pass = _parfor_PreParforPass(
+            state.func_ir,
+            state.typemap,
+            state.calltypes,
+            state.typingctx,
+            state.targetctx,
+            state.flags.auto_parallel,
+            state.parfor_diagnostics.replaced_fns,
+        )
+
+        preparfor_pass.run()
+        return True
+
+
+# this is here so it pickles and for no other reason
+def _reload_parfors():
+    """Reloader for cached parfors"""
+    # Re-initialize the parallel backend when load from cache.
+    from numba.np.ufunc.parallel import _launch_threads
+
+    _launch_threads()
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class ParforPass(FunctionPass):
+    _name = "parfor_pass"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        """
+        Convert data-parallel computations into Parfor nodes
+        """
+        # Ensure we have an IR and type information.
+        assert state.func_ir
+        parfor_pass = _parfor_ParforPass(
+            state.func_ir,
+            state.typemap,
+            state.calltypes,
+            state.return_type,
+            state.typingctx,
+            state.targetctx,
+            state.flags.auto_parallel,
+            state.flags,
+            state.metadata,
+            state.parfor_diagnostics,
+        )
+        parfor_pass.run()
+
+        # check the parfor pass worked and warn if it didn't
+        has_parfor = False
+        for blk in state.func_ir.blocks.values():
+            for stmnt in blk.body:
+                if isinstance(stmnt, Parfor):
+                    has_parfor = True
+                    break
+            else:
+                continue
+            break
+
+        if not has_parfor:
+            # parfor calls the compiler chain again with a string
+            if not (
+                config.DISABLE_PERFORMANCE_WARNINGS
+                or state.func_ir.loc.filename == "<string>"
+            ):
+                url = (
+                    "https://numba.readthedocs.io/en/stable/user/"
+                    "parallel.html#diagnostics"
+                )
+                msg = (
+                    "\nThe keyword argument 'parallel=True' was specified "
+                    "but no transformation for parallel execution was "
+                    "possible.\n\nTo find out why, try turning on parallel "
+                    "diagnostics, see %s for help." % url
+                )
+                warnings.warn(
+                    errors.NumbaPerformanceWarning(msg, state.func_ir.loc)
+                )
+
+        # Add reload function to initialize the parallel backend.
+        state.reload_init.append(_reload_parfors)
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class ParforFusionPass(FunctionPass):
+    _name = "parfor_fusion_pass"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        """
+        Do fusion of parfor nodes.
+        """
+        # Ensure we have an IR and type information.
+        assert state.func_ir
+        parfor_pass = _parfor_ParforFusionPass(
+            state.func_ir,
+            state.typemap,
+            state.calltypes,
+            state.return_type,
+            state.typingctx,
+            state.targetctx,
+            state.flags.auto_parallel,
+            state.flags,
+            state.metadata,
+            state.parfor_diagnostics,
+        )
+        parfor_pass.run()
+
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class ParforPreLoweringPass(FunctionPass):
+    _name = "parfor_prelowering_pass"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        """
+        Prepare parfors for lowering.
+        """
+        # Ensure we have an IR and type information.
+        assert state.func_ir
+        parfor_pass = _parfor_ParforPreLoweringPass(
+            state.func_ir,
+            state.typemap,
+            state.calltypes,
+            state.return_type,
+            state.typingctx,
+            state.targetctx,
+            state.flags.auto_parallel,
+            state.flags,
+            state.metadata,
+            state.parfor_diagnostics,
+        )
+        parfor_pass.run()
+
+        return True
+
+
+@register_pass(mutates_CFG=False, analysis_only=True)
+class DumpParforDiagnostics(AnalysisPass):
+    _name = "dump_parfor_diagnostics"
+
+    def __init__(self):
+        AnalysisPass.__init__(self)
+
+    def run_pass(self, state):
+        if state.flags.auto_parallel.enabled:
+            if config.PARALLEL_DIAGNOSTICS:
+                if state.parfor_diagnostics is not None:
+                    state.parfor_diagnostics.dump(config.PARALLEL_DIAGNOSTICS)
+                else:
+                    raise RuntimeError("Diagnostics failed.")
+        return True
+
+
+class BaseNativeLowering(abc.ABC, LoweringPass):
+    """The base class for a lowering pass. The lowering functionality must be
+    specified in inheriting classes by providing an appropriate lowering class
+    implementation in the overridden `lowering_class` property."""
+
+    _name = None
+
+    def __init__(self):
+        LoweringPass.__init__(self)
+
+    @property
+    @abc.abstractmethod
+    def lowering_class(self):
+        """Returns the class that performs the lowering of the IR describing the
+        function that is the target of the current compilation."""
+        pass
+
+    def run_pass(self, state):
+        if state.library is None:
+            codegen = state.targetctx.codegen()
+            state.library = codegen.create_library(state.func_id.func_qualname)
+            # Enable object caching upfront, so that the library can
+            # be later serialized.
+            state.library.enable_object_caching()
+
+        library = state.library
+        targetctx = state.targetctx
+        interp = state.func_ir  # why is it called this?!
+        typemap = state.typemap
+        restype = state.return_type
+        calltypes = state.calltypes
+        flags = state.flags
+        metadata = state.metadata
+        pre_stats = llvm.passmanagers.dump_refprune_stats()
+
+        msg = "Function %s failed at nopython mode lowering" % (
+            state.func_id.func_name,
+        )
+        with fallback_context(state, msg):
+            # Lowering
+            fndesc = (
+                funcdesc.PythonFunctionDescriptor.from_specialized_function(
+                    interp,
+                    typemap,
+                    restype,
+                    calltypes,
+                    mangler=targetctx.mangler,
+                    inline=flags.forceinline,
+                    noalias=flags.noalias,
+                    abi_tags=[flags.get_mangle_string()],
+                )
+            )
+
+            with targetctx.push_code_library(library):
+                lower = self.lowering_class(
+                    targetctx, library, fndesc, interp, metadata=metadata
+                )
+                lower.lower()
+                if not flags.no_cpython_wrapper:
+                    lower.create_cpython_wrapper(flags.release_gil)
+
+                if not flags.no_cfunc_wrapper:
+                    # skip cfunc wrapper generation if unsupported
+                    # argument or return types are used
+                    for t in state.args:
+                        if isinstance(t, (types.Omitted, types.Generator)):
+                            break
+                    else:
+                        if isinstance(
+                            restype, (types.Optional, types.Generator)
+                        ):
+                            pass
+                        else:
+                            lower.create_cfunc_wrapper()
+
+                env = lower.env
+                call_helper = lower.call_helper
+                del lower
+
+            from numba.cuda.compiler import _LowerResult  # TODO: move this
+
+            if flags.no_compile:
+                state["cr"] = _LowerResult(
+                    fndesc, call_helper, cfunc=None, env=env
+                )
+            else:
+                # Prepare for execution
+                # Insert native function for use by other jitted-functions.
+                # We also register its library to allow for inlining.
+                cfunc = targetctx.get_executable(library, fndesc, env)
+                targetctx.insert_user_function(cfunc, fndesc, [library])
+                state["cr"] = _LowerResult(
+                    fndesc, call_helper, cfunc=cfunc, env=env
+                )
+
+            # capture pruning stats
+            post_stats = llvm.passmanagers.dump_refprune_stats()
+            metadata["prune_stats"] = post_stats - pre_stats
+
+            # Save the LLVM pass timings
+            metadata["llvm_pass_timings"] = library.recorded_timings
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class NativeLowering(BaseNativeLowering):
+    """Lowering pass for a native function IR described solely in terms of
+    Numba's standard `numba.core.ir` nodes."""
+
+    _name = "native_lowering"
+
+    @property
+    def lowering_class(self):
+        return lowering.Lower
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class NativeParforLowering(BaseNativeLowering):
+    """Lowering pass for a native function IR described using Numba's standard
+    `numba.core.ir` nodes and also parfor.Parfor nodes."""
+
+    _name = "native_parfor_lowering"
+
+    @property
+    def lowering_class(self):
+        return ParforLower
+
+
+@register_pass(mutates_CFG=False, analysis_only=True)
+class NoPythonSupportedFeatureValidation(AnalysisPass):
+    """NoPython Mode check: Validates the IR to ensure that features in use are
+    in a form that is supported"""
+
+    _name = "nopython_supported_feature_validation"
+
+    def __init__(self):
+        AnalysisPass.__init__(self)
+
+    def run_pass(self, state):
+        raise_on_unsupported_feature(state.func_ir, state.typemap)
+        warn_deprecated(state.func_ir, state.typemap)
+        return False
+
+
+@register_pass(mutates_CFG=False, analysis_only=True)
+class IRLegalization(AnalysisPass):
+    _name = "ir_legalization"
+
+    def __init__(self):
+        AnalysisPass.__init__(self)
+
+    def run_pass(self, state):
+        # NOTE: this function call must go last, it checks and fixes invalid IR!
+        check_and_legalize_ir(state.func_ir, flags=state.flags)
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class NoPythonBackend(LoweringPass):
+    _name = "nopython_backend"
+
+    def __init__(self):
+        LoweringPass.__init__(self)
+
+    def run_pass(self, state):
+        """
+        Back-end: Generate LLVM IR from Numba IR, compile to machine code
+        """
+        lowered = state["cr"]
+        signature = typing.signature(state.return_type, *state.args)
+
+        from numba.core.compiler import compile_result
+
+        state.cr = compile_result(
+            typing_context=state.typingctx,
+            target_context=state.targetctx,
+            entry_point=lowered.cfunc,
+            typing_error=state.status.fail_reason,
+            type_annotation=state.type_annotation,
+            library=state.library,
+            call_helper=lowered.call_helper,
+            signature=signature,
+            objectmode=False,
+            lifted=state.lifted,
+            fndesc=lowered.fndesc,
+            environment=lowered.env,
+            metadata=state.metadata,
+            reload_init=state.reload_init,
+        )
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class InlineOverloads(FunctionPass):
+    """
+    This pass will inline a function wrapped by the numba.extending.overload
+    decorator directly into the site of its call depending on the value set in
+    the 'inline' kwarg to the decorator.
+
+    This is a typed pass. CFG simplification and DCE are performed on
+    completion.
+    """
+
+    _name = "inline_overloads"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    _DEBUG = False
+
+    def run_pass(self, state):
+        """Run inlining of overloads"""
+        if self._DEBUG:
+            print("before overload inline".center(80, "-"))
+            print(state.func_id.unique_name)
+            print(state.func_ir.dump())
+            print("".center(80, "-"))
+        from numba.core.inline_closurecall import (
+            InlineWorker,
+            callee_ir_validator,
+        )
+
+        inline_worker = InlineWorker(
+            state.typingctx,
+            state.targetctx,
+            state.locals,
+            state.pipeline,
+            state.flags,
+            callee_ir_validator,
+            state.typemap,
+            state.calltypes,
+        )
+        modified = False
+        work_list = list(state.func_ir.blocks.items())
+        # use a work list, look for call sites via `ir.Expr.op == call` and
+        # then pass these to `self._do_work` to make decisions about inlining.
+        while work_list:
+            label, block = work_list.pop()
+            for i, instr in enumerate(block.body):
+                # TO-DO: other statements (setitem)
+                if isinstance(instr, ir.Assign):
+                    expr = instr.value
+                    if isinstance(expr, ir.Expr):
+                        workfn = self._do_work_expr
+
+                        if guard(
+                            workfn,
+                            state,
+                            work_list,
+                            block,
+                            i,
+                            expr,
+                            inline_worker,
+                        ):
+                            modified = True
+                            break  # because block structure changed
+
+        if self._DEBUG:
+            print("after overload inline".center(80, "-"))
+            print(state.func_id.unique_name)
+            print(state.func_ir.dump())
+            print("".center(80, "-"))
+
+        if modified:
+            # Remove dead blocks, this is safe as it relies on the CFG only.
+            cfg = compute_cfg_from_blocks(state.func_ir.blocks)
+            for dead in cfg.dead_nodes():
+                del state.func_ir.blocks[dead]
+            # clean up blocks
+            dead_code_elimination(state.func_ir, typemap=state.typemap)
+            # clean up unconditional branches that appear due to inlined
+            # functions introducing blocks
+            state.func_ir.blocks = simplify_CFG(state.func_ir.blocks)
+
+        if self._DEBUG:
+            print("after overload inline DCE".center(80, "-"))
+            print(state.func_id.unique_name)
+            print(state.func_ir.dump())
+            print("".center(80, "-"))
+        return True
+
+    def _get_attr_info(self, state, expr):
+        recv_type = state.typemap[expr.value.name]
+        recv_type = types.unliteral(recv_type)
+        matched = state.typingctx.find_matching_getattr_template(
+            recv_type,
+            expr.attr,
+        )
+        if not matched:
+            return None
+
+        template = matched["template"]
+        if getattr(template, "is_method", False):
+            # The attribute template is representing a method.
+            # Don't inline the getattr.
+            return None
+
+        templates = [template]
+        sig = typing.signature(matched["return_type"], recv_type)
+        arg_typs = sig.args
+        is_method = False
+
+        return templates, sig, arg_typs, is_method
+
+    def _get_callable_info(self, state, expr):
+        def get_func_type(state, expr):
+            func_ty = None
+            if expr.op == "call":
+                # check this is a known and typed function
+                try:
+                    func_ty = state.typemap[expr.func.name]
+                except KeyError:
+                    # e.g. Calls to CUDA Intrinsic have no mapped type
+                    # so KeyError
+                    return None
+                if not hasattr(func_ty, "get_call_type"):
+                    return None
+
+            elif is_operator_or_getitem(expr):
+                func_ty = state.typingctx.resolve_value_type(expr.fn)
+            else:
+                return None
+
+            return func_ty
+
+        if expr.op == "call":
+            # try and get a definition for the call, this isn't always
+            # possible as it might be a eval(str)/part generated
+            # awaiting update etc. (parfors)
+            to_inline = None
+            try:
+                to_inline = state.func_ir.get_definition(expr.func)
+            except Exception:
+                return None
+
+            # do not handle closure inlining here, another pass deals with that
+            if getattr(to_inline, "op", False) == "make_function":
+                return None
+
+        func_ty = get_func_type(state, expr)
+        if func_ty is None:
+            return None
+
+        sig = state.calltypes[expr]
+        if not sig:
+            return None
+
+        templates, arg_typs, is_method = None, None, False
+        if getattr(func_ty, "template", None) is not None:
+            # @overload_method
+            is_method = True
+            templates = [func_ty.template]
+            arg_typs = (func_ty.template.this,) + sig.args
+        else:
+            # @overload case
+            templates = getattr(func_ty, "templates", None)
+            arg_typs = sig.args
+
+        return templates, sig, arg_typs, is_method
+
+    def _do_work_expr(self, state, work_list, block, i, expr, inline_worker):
+        def select_template(templates, args):
+            if templates is None:
+                return None
+
+            impl = None
+            for template in templates:
+                inline_type = getattr(template, "_inline", None)
+                if inline_type is None:
+                    # inline not defined
+                    continue
+                if args not in template._inline_overloads:
+                    # skip overloads not matching signature
+                    continue
+                if not inline_type.is_never_inline:
+                    try:
+                        impl = template._overload_func(*args)
+                        if impl is None:
+                            raise Exception  # abort for this template
+                        break
+                    except Exception:
+                        continue
+            else:
+                return None
+
+            return template, inline_type, impl
+
+        inlinee_info = None
+        if expr.op == "getattr":
+            inlinee_info = self._get_attr_info(state, expr)
+        else:
+            inlinee_info = self._get_callable_info(state, expr)
+
+        if not inlinee_info:
+            return False
+
+        templates, sig, arg_typs, is_method = inlinee_info
+        inlinee = select_template(templates, arg_typs)
+        if inlinee is None:
+            return False
+        template, inlinee_type, impl = inlinee
+
+        return self._run_inliner(
+            state,
+            inlinee_type,
+            sig,
+            template,
+            arg_typs,
+            expr,
+            i,
+            impl,
+            block,
+            work_list,
+            is_method,
+            inline_worker,
+        )
+
+    def _run_inliner(
+        self,
+        state,
+        inline_type,
+        sig,
+        template,
+        arg_typs,
+        expr,
+        i,
+        impl,
+        block,
+        work_list,
+        is_method,
+        inline_worker,
+    ):
+        do_inline = True
+        if not inline_type.is_always_inline:
+            from numba.core.typing.templates import _inline_info
+
+            caller_inline_info = _inline_info(
+                state.func_ir, state.typemap, state.calltypes, sig
+            )
+
+            # must be a cost-model function, run the function
+            iinfo = template._inline_overloads[arg_typs]["iinfo"]
+            if inline_type.has_cost_model:
+                do_inline = inline_type.value(expr, caller_inline_info, iinfo)
+            else:
+                assert "unreachable"
+
+        if do_inline:
+            if is_method:
+                if not self._add_method_self_arg(state, expr):
+                    return False
+            arg_typs = template._inline_overloads[arg_typs]["folded_args"]
+            iinfo = template._inline_overloads[arg_typs]["iinfo"]
+            freevars = iinfo.func_ir.func_id.func.__code__.co_freevars
+            _, _, _, new_blocks = inline_worker.inline_ir(
+                state.func_ir,
+                block,
+                i,
+                iinfo.func_ir,
+                freevars,
+                arg_typs=arg_typs,
+            )
+            if work_list is not None:
+                for blk in new_blocks:
+                    work_list.append(blk)
+            return True
+        else:
+            return False
+
+    def _add_method_self_arg(self, state, expr):
+        func_def = guard(get_definition, state.func_ir, expr.func)
+        if func_def is None:
+            return False
+        expr.args.insert(0, func_def.value)
+        return True
+
+
+@register_pass(mutates_CFG=False, analysis_only=False)
+class DeadCodeElimination(FunctionPass):
+    """
+    Does dead code elimination
+    """
+
+    _name = "dead_code_elimination"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        dead_code_elimination(state.func_ir, state.typemap)
+        return True
+
+
+@register_pass(mutates_CFG=False, analysis_only=False)
+class PreLowerStripPhis(FunctionPass):
+    """Remove phi nodes (ir.Expr.phi) introduced by SSA.
+
+    This is needed before Lowering because the phi nodes in Numba IR do not
+    match the semantics of phi nodes in LLVM IR. In Numba IR, phi nodes may
+    expand into multiple LLVM instructions.
+    """
+
+    _name = "strip_phis"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        state.func_ir = self._strip_phi_nodes(state.func_ir)
+        state.func_ir._definitions = build_definitions(state.func_ir.blocks)
+        if "flags" in state and state.flags.auto_parallel.enabled:
+            self._simplify_conditionally_defined_variable(state.func_ir)
+            state.func_ir._definitions = build_definitions(state.func_ir.blocks)
+
+        # Rerun postprocessor to update metadata
+        post_proc = postproc.PostProcessor(state.func_ir)
+        post_proc.run(emit_dels=False)
+
+        # Ensure we are not in objectmode generator
+        if (
+            state.func_ir.generator_info is not None
+            and state.typemap is not None
+        ):
+            # Rebuild generator type
+            # TODO: move this into PostProcessor
+            gentype = state.return_type
+            state_vars = state.func_ir.generator_info.state_vars
+            state_types = [state.typemap[k] for k in state_vars]
+            state.return_type = types.Generator(
+                gen_func=gentype.gen_func,
+                yield_type=gentype.yield_type,
+                arg_types=gentype.arg_types,
+                state_types=state_types,
+                has_finalizer=gentype.has_finalizer,
+            )
+        return True
+
+    def _strip_phi_nodes(self, func_ir):
+        """Strip Phi nodes from ``func_ir``
+
+        For each phi node, put incoming value to their respective incoming
+        basic-block at possibly the latest position (i.e. after the latest
+        assignment to the corresponding variable).
+        """
+        exporters = defaultdict(list)
+        phis = set()
+        # Find all variables that needs to be exported
+        for label, block in func_ir.blocks.items():
+            for assign in block.find_insts(ir.Assign):
+                if isinstance(assign.value, ir.Expr):
+                    if assign.value.op == "phi":
+                        phis.add(assign)
+                        phi = assign.value
+                        for ib, iv in zip(
+                            phi.incoming_blocks, phi.incoming_values
+                        ):
+                            exporters[ib].append((assign.target, iv))
+
+        # Rewrite the blocks with the new exporting assignments
+        newblocks = {}
+        for label, block in func_ir.blocks.items():
+            newblk = copy(block)
+            newblocks[label] = newblk
+
+            # strip phis
+            newblk.body = [stmt for stmt in block.body if stmt not in phis]
+
+            # insert exporters
+            for target, rhs in exporters[label]:
+                # If RHS is undefined
+                if rhs is ir.UNDEFINED:
+                    # Put in a NULL initializer, set the location to be in what
+                    # will eventually materialize as the prologue.
+                    rhs = ir.Expr.null(loc=func_ir.loc)
+
+                assign = ir.Assign(target=target, value=rhs, loc=rhs.loc)
+                # Insert at the earliest possible location; i.e. after the
+                # last assignment to rhs
+                assignments = [
+                    stmt
+                    for stmt in newblk.find_insts(ir.Assign)
+                    if stmt.target == rhs
+                ]
+                if assignments:
+                    last_assignment = assignments[-1]
+                    newblk.insert_after(assign, last_assignment)
+                else:
+                    newblk.prepend(assign)
+
+        func_ir.blocks = newblocks
+        return func_ir
+
+    def _simplify_conditionally_defined_variable(self, func_ir):
+        """
+        Rewrite assignments like:
+
+            ver1 = null()
+            ...
+            ver1 = ver
+            ...
+            uses(ver1)
+
+        into:
+            # delete all assignments to ver1
+            uses(ver)
+
+        This is only needed for parfors because the SSA pass will create extra
+        variable assignments that the parfor code does not expect.
+        This pass helps avoid problems by reverting the effect of SSA.
+        """
+        any_block = next(iter(func_ir.blocks.values()))
+        scope = any_block.scope
+        defs = func_ir._definitions
+
+        def unver_or_undef(unver, defn):
+            # Is the definition undefined or pointing to the unversioned name?
+            if isinstance(defn, ir.Var):
+                if defn.unversioned_name == unver:
+                    return True
+            elif isinstance(defn, ir.Expr):
+                if defn.op == "null":
+                    return True
+            return False
+
+        def legalize_all_versioned_names(var):
+            # Are all versioned names undefined or defined to the same
+            # variable chain?
+            if not var.versioned_names:
+                return False
+            for versioned in var.versioned_names:
+                vs = defs.get(versioned, ())
+                if not all(map(partial(unver_or_undef, k), vs)):
+                    return False
+            return True
+
+        # Find unversioned variables that met the conditions
+        suspects = set()
+        for k in defs:
+            try:
+                # This may fail?
+                var = scope.get_exact(k)
+            except errors.NotDefinedError:
+                continue
+            # is the var name unversioned?
+            if var.unversioned_name == k:
+                if legalize_all_versioned_names(var):
+                    suspects.add(var)
+
+        delete_set = set()
+        replace_map = {}
+        for var in suspects:
+            # rewrite Var uses to the unversioned name
+            for versioned in var.versioned_names:
+                ver_var = scope.get_exact(versioned)
+                # delete assignment to the versioned name
+                delete_set.add(ver_var)
+                # replace references to versioned name with the unversioned
+                replace_map[versioned] = var
+
+        # remove assignments to the versioned names
+        for _label, blk in func_ir.blocks.items():
+            for assign in blk.find_insts(ir.Assign):
+                if assign.target in delete_set:
+                    blk.remove(assign)
+        # do variable replacement
+        replace_vars(func_ir.blocks, replace_map)

--- a/numba_cuda/numba/cuda/core/untyped_passes.py
+++ b/numba_cuda/numba/cuda/core/untyped_passes.py
@@ -1,0 +1,1988 @@
+from collections import defaultdict, namedtuple
+from contextlib import contextmanager
+from copy import deepcopy, copy
+import warnings
+
+from numba.cuda.core.compiler_machinery import (
+    FunctionPass,
+    AnalysisPass,
+    SSACompliantMixin,
+    register_pass,
+)
+from numba.core import (
+    errors,
+    types,
+    ir,
+    bytecode,
+    postproc,
+    rewrites,
+    config,
+    transforms,
+    consts,
+)
+from numba.misc.special import literal_unroll
+from numba.core.analysis import (
+    dead_branch_prune,
+    rewrite_semantic_constants,
+    find_literally_calls,
+    compute_cfg_from_blocks,
+    compute_use_defs,
+)
+from numba.core.ir_utils import (
+    guard,
+    resolve_func_from_module,
+    simplify_CFG,
+    GuardException,
+    convert_code_obj_to_function,
+    build_definitions,
+    replace_var_names,
+    get_name_var_table,
+    compile_to_numba_ir,
+    get_definition,
+    find_max_label,
+    rename_labels,
+    transfer_scope,
+    fixup_var_define_in_scope,
+)
+from numba.core.ssa import reconstruct_ssa
+from numba.core import interpreter
+
+
+@contextmanager
+def fallback_context(state, msg):
+    """
+    Wraps code that would signal a fallback to object mode
+    """
+    try:
+        yield
+    except Exception as e:
+        if not state.status.can_fallback:
+            raise
+        else:
+            # Clear all references attached to the traceback
+            e = e.with_traceback(None)
+            # this emits a warning containing the error message body in the
+            # case of fallback from npm to objmode
+            loop_lift = "" if state.flags.enable_looplift else "OUT"
+            msg_rewrite = (
+                "\nCompilation is falling back to object mode "
+                "WITH%s looplifting enabled because %s" % (loop_lift, msg)
+            )
+            warnings.warn_explicit(
+                "%s due to: %s" % (msg_rewrite, e),
+                errors.NumbaWarning,
+                state.func_id.filename,
+                state.func_id.firstlineno,
+            )
+            raise
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class ExtractByteCode(FunctionPass):
+    _name = "extract_bytecode"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        """
+        Extract bytecode from function
+        """
+        func_id = state["func_id"]
+        bc = bytecode.ByteCode(func_id)
+        if config.DUMP_BYTECODE:
+            print(bc.dump())
+
+        state["bc"] = bc
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class TranslateByteCode(FunctionPass):
+    _name = "translate_bytecode"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        """
+        Analyze bytecode and translating to Numba IR
+        """
+        func_id = state["func_id"]
+        bc = state["bc"]
+        interp = interpreter.Interpreter(func_id)
+        func_ir = interp.interpret(bc)
+        state["func_ir"] = func_ir
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class FixupArgs(FunctionPass):
+    _name = "fixup_args"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        state["nargs"] = state["func_ir"].arg_count
+        if not state["args"] and state["flags"].force_pyobject:
+            # Allow an empty argument types specification when object mode
+            # is explicitly requested.
+            state["args"] = (types.pyobject,) * state["nargs"]
+        elif len(state["args"]) != state["nargs"]:
+            raise TypeError(
+                "Signature mismatch: %d argument types given, "
+                "but function takes %d arguments"
+                % (len(state["args"]), state["nargs"])
+            )
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class IRProcessing(FunctionPass):
+    _name = "ir_processing"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        func_ir = state["func_ir"]
+        post_proc = postproc.PostProcessor(func_ir)
+        post_proc.run()
+
+        if config.DEBUG or config.DUMP_IR:
+            name = func_ir.func_id.func_qualname
+            print(("IR DUMP: %s" % name).center(80, "-"))
+            func_ir.dump()
+            if func_ir.is_generator:
+                print(("GENERATOR INFO: %s" % name).center(80, "-"))
+                func_ir.dump_generator_info()
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class RewriteSemanticConstants(FunctionPass):
+    _name = "rewrite_semantic_constants"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        """
+        This prunes dead branches, a dead branch is one which is derivable as
+        not taken at compile time purely based on const/literal evaluation.
+        """
+        assert state.func_ir
+        msg = (
+            "Internal error in pre-inference dead branch pruning "
+            "pass encountered during compilation of "
+            'function "%s"' % (state.func_id.func_name,)
+        )
+        with fallback_context(state, msg):
+            rewrite_semantic_constants(state.func_ir, state.args)
+
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class DeadBranchPrune(SSACompliantMixin, FunctionPass):
+    _name = "dead_branch_prune"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        """
+        This prunes dead branches, a dead branch is one which is derivable as
+        not taken at compile time purely based on const/literal evaluation.
+        """
+
+        # purely for demonstration purposes, obtain the analysis from a pass
+        # declare as a required dependent
+        semantic_const_analysis = self.get_analysis(type(self))  # noqa
+
+        assert state.func_ir
+        msg = (
+            "Internal error in pre-inference dead branch pruning "
+            "pass encountered during compilation of "
+            'function "%s"' % (state.func_id.func_name,)
+        )
+        with fallback_context(state, msg):
+            dead_branch_prune(state.func_ir, state.args)
+
+        return True
+
+    def get_analysis_usage(self, AU):
+        AU.add_required(RewriteSemanticConstants)
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class InlineClosureLikes(FunctionPass):
+    _name = "inline_closure_likes"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        # Ensure we have an IR and type information.
+        assert state.func_ir
+
+        # if the return type is a pyobject, there's no type info available and
+        # no ability to resolve certain typed function calls in the array
+        # inlining code, use this variable to indicate
+        typed_pass = not isinstance(state.return_type, types.misc.PyObject)
+        from numba.core.inline_closurecall import InlineClosureCallPass
+
+        inline_pass = InlineClosureCallPass(
+            state.func_ir,
+            state.flags.auto_parallel,
+            state.parfor_diagnostics.replaced_fns,
+            typed_pass,
+        )
+        inline_pass.run()
+
+        # Remove all Dels, and re-run postproc
+        post_proc = postproc.PostProcessor(state.func_ir)
+        post_proc.run()
+
+        fixup_var_define_in_scope(state.func_ir.blocks)
+
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class GenericRewrites(FunctionPass):
+    _name = "generic_rewrites"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        """
+        Perform any intermediate representation rewrites before type
+        inference.
+        """
+        assert state.func_ir
+        msg = (
+            "Internal error in pre-inference rewriting "
+            "pass encountered during compilation of "
+            'function "%s"' % (state.func_id.func_name,)
+        )
+        with fallback_context(state, msg):
+            rewrites.rewrite_registry.apply("before-inference", state)
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class WithLifting(FunctionPass):
+    _name = "with_lifting"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        """
+        Extract with-contexts
+        """
+        main, withs = transforms.with_lifting(
+            func_ir=state.func_ir,
+            typingctx=state.typingctx,
+            targetctx=state.targetctx,
+            flags=state.flags,
+            locals=state.locals,
+        )
+        if withs:
+            from numba.cuda.compiler import compile_ir, _EarlyPipelineCompletion
+
+            cres = compile_ir(
+                state.typingctx,
+                state.targetctx,
+                main,
+                state.args,
+                state.return_type,
+                state.flags,
+                state.locals,
+                lifted=tuple(withs),
+                lifted_from=None,
+                pipeline_class=type(state.pipeline),
+            )
+            raise _EarlyPipelineCompletion(cres)
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class InlineInlinables(FunctionPass):
+    """
+    This pass will inline a function wrapped by the numba.jit decorator directly
+    into the site of its call depending on the value set in the 'inline' kwarg
+    to the decorator.
+
+    This is an untyped pass. CFG simplification is performed at the end of the
+    pass but no block level clean up is performed on the mutated IR (typing
+    information is not available to do so).
+    """
+
+    _name = "inline_inlinables"
+    _DEBUG = False
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        """Run inlining of inlinables"""
+        if self._DEBUG:
+            print("before inline".center(80, "-"))
+            print(state.func_ir.dump())
+            print("".center(80, "-"))
+
+        from numba.core.inline_closurecall import (
+            InlineWorker,
+            callee_ir_validator,
+        )
+
+        inline_worker = InlineWorker(
+            state.typingctx,
+            state.targetctx,
+            state.locals,
+            state.pipeline,
+            state.flags,
+            validator=callee_ir_validator,
+        )
+
+        modified = False
+        # use a work list, look for call sites via `ir.Expr.op == call` and
+        # then pass these to `self._do_work` to make decisions about inlining.
+        work_list = list(state.func_ir.blocks.items())
+        while work_list:
+            label, block = work_list.pop()
+            for i, instr in enumerate(block.body):
+                if isinstance(instr, ir.Assign):
+                    expr = instr.value
+                    if isinstance(expr, ir.Expr) and expr.op == "call":
+                        if guard(
+                            self._do_work,
+                            state,
+                            work_list,
+                            block,
+                            i,
+                            expr,
+                            inline_worker,
+                        ):
+                            modified = True
+                            break  # because block structure changed
+
+        if modified:
+            # clean up unconditional branches that appear due to inlined
+            # functions introducing blocks
+            cfg = compute_cfg_from_blocks(state.func_ir.blocks)
+            for dead in cfg.dead_nodes():
+                del state.func_ir.blocks[dead]
+            post_proc = postproc.PostProcessor(state.func_ir)
+            post_proc.run()
+            state.func_ir.blocks = simplify_CFG(state.func_ir.blocks)
+
+        if self._DEBUG:
+            print("after inline".center(80, "-"))
+            print(state.func_ir.dump())
+            print("".center(80, "-"))
+        return True
+
+    def _do_work(self, state, work_list, block, i, expr, inline_worker):
+        from numba.core.compiler import run_frontend
+        from numba.core.cpu import InlineOptions
+
+        # try and get a definition for the call, this isn't always possible as
+        # it might be a eval(str)/part generated awaiting update etc. (parfors)
+        to_inline = None
+        try:
+            to_inline = state.func_ir.get_definition(expr.func)
+        except Exception:
+            if self._DEBUG:
+                print("Cannot find definition for %s" % expr.func)
+            return False
+        # do not handle closure inlining here, another pass deals with that.
+        if getattr(to_inline, "op", False) == "make_function":
+            return False
+
+        # see if the definition is a "getattr", in which case walk the IR to
+        # try and find the python function via the module from which it's
+        # imported, this should all be encoded in the IR.
+        if getattr(to_inline, "op", False) == "getattr":
+            val = resolve_func_from_module(state.func_ir, to_inline)
+        else:
+            # This is likely a freevar or global
+            #
+            # NOTE: getattr 'value' on a call may fail if it's an ir.Expr as
+            # getattr is overloaded to look in _kws.
+            try:
+                val = getattr(to_inline, "value", False)
+            except Exception:
+                raise GuardException
+
+        # if something was found...
+        if val:
+            # check it's dispatcher-like, the targetoptions attr holds the
+            # kwargs supplied in the jit decorator and is where 'inline' will
+            # be if it is present.
+            topt = getattr(val, "targetoptions", False)
+            if topt:
+                inline_type = topt.get("inline", None)
+                # has 'inline' been specified?
+                if inline_type is not None:
+                    inline_opt = InlineOptions(inline_type)
+                    # Could this be inlinable?
+                    if not inline_opt.is_never_inline:
+                        # yes, it could be inlinable
+                        do_inline = True
+                        pyfunc = val.py_func
+                        # Has it got an associated cost model?
+                        if inline_opt.has_cost_model:
+                            # yes, it has a cost model, use it to determine
+                            # whether to do the inline
+                            py_func_ir = run_frontend(pyfunc)
+                            do_inline = inline_type(
+                                expr, state.func_ir, py_func_ir
+                            )
+                        # if do_inline is True then inline!
+                        if do_inline:
+                            _, _, _, new_blocks = inline_worker.inline_function(
+                                state.func_ir,
+                                block,
+                                i,
+                                pyfunc,
+                            )
+                            if work_list is not None:
+                                for blk in new_blocks:
+                                    work_list.append(blk)
+                            return True
+        return False
+
+
+@register_pass(mutates_CFG=False, analysis_only=False)
+class PreserveIR(AnalysisPass):
+    """
+    Preserves the IR in the metadata
+    """
+
+    _name = "preserve_ir"
+
+    def __init__(self):
+        AnalysisPass.__init__(self)
+
+    def run_pass(self, state):
+        state.metadata["preserved_ir"] = state.func_ir.copy()
+        return False
+
+
+@register_pass(mutates_CFG=False, analysis_only=True)
+class FindLiterallyCalls(FunctionPass):
+    """Find calls to `numba.literally()` and signal if its requirement is not
+    satisfied.
+    """
+
+    _name = "find_literally"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        find_literally_calls(state.func_ir, state.args)
+        return False
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class CanonicalizeLoopExit(FunctionPass):
+    """A pass to canonicalize loop exit by splitting it from function exit."""
+
+    _name = "canonicalize_loop_exit"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        fir = state.func_ir
+        cfg = compute_cfg_from_blocks(fir.blocks)
+        status = False
+        for loop in cfg.loops().values():
+            for exit_label in loop.exits:
+                if exit_label in cfg.exit_points():
+                    self._split_exit_block(fir, cfg, exit_label)
+                    status = True
+
+        fir._reset_analysis_variables()
+
+        vlt = postproc.VariableLifetime(fir.blocks)
+        fir.variable_lifetime = vlt
+        return status
+
+    def _split_exit_block(self, fir, cfg, exit_label):
+        curblock = fir.blocks[exit_label]
+        newlabel = exit_label + 1
+        newlabel = find_max_label(fir.blocks) + 1
+        fir.blocks[newlabel] = curblock
+        newblock = ir.Block(scope=curblock.scope, loc=curblock.loc)
+        newblock.append(ir.Jump(newlabel, loc=curblock.loc))
+        fir.blocks[exit_label] = newblock
+        # Rename all labels
+        fir.blocks = rename_labels(fir.blocks)
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class CanonicalizeLoopEntry(FunctionPass):
+    """A pass to canonicalize loop header by splitting it from function entry.
+
+    This is needed for loop-lifting; esp in py3.8
+    """
+
+    _name = "canonicalize_loop_entry"
+    _supported_globals = {range, enumerate, zip}
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        fir = state.func_ir
+        cfg = compute_cfg_from_blocks(fir.blocks)
+        status = False
+        for loop in cfg.loops().values():
+            if len(loop.entries) == 1:
+                [entry_label] = loop.entries
+                if entry_label == cfg.entry_point():
+                    self._split_entry_block(fir, cfg, loop, entry_label)
+                    status = True
+        fir._reset_analysis_variables()
+
+        vlt = postproc.VariableLifetime(fir.blocks)
+        fir.variable_lifetime = vlt
+        return status
+
+    def _split_entry_block(self, fir, cfg, loop, entry_label):
+        # Find iterator inputs into the for-loop header
+        header_block = fir.blocks[loop.header]
+        deps = set()
+        for expr in header_block.find_exprs(op="iternext"):
+            deps.add(expr.value)
+        # Find the getiter for each iterator
+        entry_block = fir.blocks[entry_label]
+
+        # Find the start of loop entry statement that needs to be included.
+        startpt = None
+        list_of_insts = list(entry_block.find_insts(ir.Assign))
+        for assign in reversed(list_of_insts):
+            if assign.target in deps:
+                rhs = assign.value
+                if isinstance(rhs, ir.Var):
+                    if rhs.is_temp:
+                        deps.add(rhs)
+                elif isinstance(rhs, ir.Expr):
+                    expr = rhs
+                    if expr.op == "getiter":
+                        startpt = assign
+                        if expr.value.is_temp:
+                            deps.add(expr.value)
+                    elif expr.op == "call":
+                        defn = guard(get_definition, fir, expr.func)
+                        if isinstance(defn, ir.Global):
+                            if expr.func.is_temp:
+                                deps.add(expr.func)
+                elif (
+                    isinstance(rhs, ir.Global)
+                    and rhs.value in self._supported_globals
+                ):
+                    startpt = assign
+
+        if startpt is None:
+            return
+
+        splitpt = entry_block.body.index(startpt)
+        new_block = entry_block.copy()
+        new_block.body = new_block.body[splitpt:]
+        new_block.loc = new_block.body[0].loc
+        new_label = find_max_label(fir.blocks) + 1
+        entry_block.body = entry_block.body[:splitpt]
+        entry_block.append(ir.Jump(new_label, loc=new_block.loc))
+
+        fir.blocks[new_label] = new_block
+        # Rename all labels
+        fir.blocks = rename_labels(fir.blocks)
+
+
+@register_pass(mutates_CFG=False, analysis_only=True)
+class PrintIRCFG(FunctionPass):
+    _name = "print_ir_cfg"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+        self._ver = 0
+
+    def run_pass(self, state):
+        fir = state.func_ir
+        self._ver += 1
+        fir.render_dot(filename_prefix="v{}".format(self._ver)).render()
+        return False
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class MakeFunctionToJitFunction(FunctionPass):
+    """
+    This swaps an ir.Expr.op == "make_function" i.e. a closure, for a compiled
+    function containing the closure body and puts it in ir.Global. It's a 1:1
+    statement value swap. `make_function` is already untyped
+    """
+
+    _name = "make_function_op_code_to_jit_function"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        from numba import njit
+
+        func_ir = state.func_ir
+        mutated = False
+        for idx, blk in func_ir.blocks.items():
+            for stmt in blk.body:
+                if isinstance(stmt, ir.Assign):
+                    if isinstance(stmt.value, ir.Expr):
+                        if stmt.value.op == "make_function":
+                            node = stmt.value
+                            getdef = func_ir.get_definition
+                            kw_default = getdef(node.defaults)
+                            ok = False
+                            if kw_default is None or isinstance(
+                                kw_default, ir.Const
+                            ):
+                                ok = True
+                            elif isinstance(kw_default, tuple):
+                                ok = all(
+                                    [
+                                        isinstance(getdef(x), ir.Const)
+                                        for x in kw_default
+                                    ]
+                                )
+                            elif isinstance(kw_default, ir.Expr):
+                                if kw_default.op != "build_tuple":
+                                    continue
+                                ok = all(
+                                    [
+                                        isinstance(getdef(x), ir.Const)
+                                        for x in kw_default.items
+                                    ]
+                                )
+                            if not ok:
+                                continue
+
+                            pyfunc = convert_code_obj_to_function(node, func_ir)
+                            func = njit()(pyfunc)
+                            new_node = ir.Global(
+                                node.code.co_name, func, stmt.loc
+                            )
+                            stmt.value = new_node
+                            mutated |= True
+
+        # if a change was made the del ordering is probably wrong, patch up
+        if mutated:
+            post_proc = postproc.PostProcessor(func_ir)
+            post_proc.run()
+
+        return mutated
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class TransformLiteralUnrollConstListToTuple(FunctionPass):
+    """This pass spots a `literal_unroll([<constant values>])` and rewrites it
+    as a `literal_unroll(tuple(<constant values>))`.
+    """
+
+    _name = "transform_literal_unroll_const_list_to_tuple"
+
+    _accepted_types = (types.BaseTuple, types.LiteralList)
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        mutated = False
+        func_ir = state.func_ir
+        for label, blk in func_ir.blocks.items():
+            calls = [_ for _ in blk.find_exprs("call")]
+            for call in calls:
+                glbl = guard(get_definition, func_ir, call.func)
+                if glbl and isinstance(glbl, (ir.Global, ir.FreeVar)):
+                    # find a literal_unroll
+                    if glbl.value is literal_unroll:
+                        if len(call.args) > 1:
+                            msg = "literal_unroll takes one argument, found %s"
+                            raise errors.UnsupportedError(
+                                msg % len(call.args), call.loc
+                            )
+                        # get the arg, make sure its a build_list
+                        unroll_var = call.args[0]
+                        to_unroll = guard(get_definition, func_ir, unroll_var)
+                        if (
+                            isinstance(to_unroll, ir.Expr)
+                            and to_unroll.op == "build_list"
+                        ):
+                            # make sure they are all const items in the list
+                            for i, item in enumerate(to_unroll.items):
+                                val = guard(get_definition, func_ir, item)
+                                if not val:
+                                    msg = (
+                                        "multiple definitions for variable "
+                                        "%s, cannot resolve constant"
+                                    )
+                                    raise errors.UnsupportedError(
+                                        msg % item, to_unroll.loc
+                                    )
+                                if not isinstance(val, ir.Const):
+                                    msg = (
+                                        "Found non-constant value at "
+                                        "position %s in a list argument to "
+                                        "literal_unroll" % i
+                                    )
+                                    raise errors.UnsupportedError(
+                                        msg, to_unroll.loc
+                                    )
+                            # The above appears ok, now swap the build_list for
+                            # a built tuple.
+
+                            # find the assignment for the unroll target
+                            to_unroll_lhs = guard(
+                                get_definition,
+                                func_ir,
+                                unroll_var,
+                                lhs_only=True,
+                            )
+
+                            if to_unroll_lhs is None:
+                                msg = (
+                                    "multiple definitions for variable "
+                                    "%s, cannot resolve constant"
+                                )
+                                raise errors.UnsupportedError(
+                                    msg % unroll_var, to_unroll.loc
+                                )
+                            # scan all blocks looking for the LHS
+                            for b in func_ir.blocks.values():
+                                asgn = b.find_variable_assignment(
+                                    to_unroll_lhs.name
+                                )
+                                if asgn is not None:
+                                    break
+                            else:
+                                msg = (
+                                    "Cannot find assignment for known "
+                                    "variable %s"
+                                ) % to_unroll_lhs.name
+                                raise errors.CompilerError(msg, to_unroll.loc)
+
+                            # Create a tuple with the list items as contents
+                            tup = ir.Expr.build_tuple(
+                                to_unroll.items, to_unroll.loc
+                            )
+
+                            # swap the list for the tuple
+                            asgn.value = tup
+                            mutated = True
+                        elif (
+                            isinstance(to_unroll, ir.Expr)
+                            and to_unroll.op == "build_tuple"
+                        ):
+                            # this is fine, do nothing
+                            pass
+                        elif isinstance(
+                            to_unroll, (ir.Global, ir.FreeVar)
+                        ) and isinstance(to_unroll.value, tuple):
+                            # this is fine, do nothing
+                            pass
+                        elif isinstance(to_unroll, ir.Arg):
+                            # this is only fine if the arg is a tuple
+                            ty = state.typemap[to_unroll.name]
+                            if not isinstance(ty, self._accepted_types):
+                                msg = (
+                                    "Invalid use of literal_unroll with a "
+                                    "function argument, only tuples are "
+                                    "supported as function arguments, found "
+                                    "%s"
+                                ) % ty
+                                raise errors.UnsupportedError(
+                                    msg, to_unroll.loc
+                                )
+                        else:
+                            extra = None
+                            if isinstance(to_unroll, ir.Expr):
+                                # probably a slice
+                                if to_unroll.op == "getitem":
+                                    ty = state.typemap[to_unroll.value.name]
+                                    # check if this is a tuple slice
+                                    if not isinstance(ty, self._accepted_types):
+                                        extra = "operation %s" % to_unroll.op
+                                        loc = to_unroll.loc
+                            elif isinstance(to_unroll, ir.Arg):
+                                extra = "non-const argument %s" % to_unroll.name
+                                loc = to_unroll.loc
+                            else:
+                                if to_unroll is None:
+                                    extra = (
+                                        "multiple definitions of "
+                                        'variable "%s".' % unroll_var.name
+                                    )
+                                    loc = unroll_var.loc
+                                else:
+                                    loc = to_unroll.loc
+                                    extra = "unknown problem"
+
+                            if extra:
+                                msg = (
+                                    "Invalid use of literal_unroll, "
+                                    "argument should be a tuple or a list "
+                                    "of constant values. Failure reason: "
+                                    "found %s" % extra
+                                )
+                                raise errors.UnsupportedError(msg, loc)
+        return mutated
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class MixedContainerUnroller(FunctionPass):
+    _name = "mixed_container_unroller"
+
+    _DEBUG = False
+
+    _accepted_types = (types.BaseTuple, types.LiteralList)
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def analyse_tuple(self, tup):
+        """
+        Returns a map of type->list(indexes) for a typed tuple
+        """
+        d = defaultdict(list)
+        for i, ty in enumerate(tup):
+            d[ty].append(i)
+        return d
+
+    def add_offset_to_labels_w_ignore(self, blocks, offset, ignore=None):
+        """add an offset to all block labels and jump/branch targets
+        don't add an offset to anything in the ignore list
+        """
+        if ignore is None:
+            ignore = set()
+
+        new_blocks = {}
+        for l, b in blocks.items():
+            # some parfor last blocks might be empty
+            term = None
+            if b.body:
+                term = b.body[-1]
+            if isinstance(term, ir.Jump):
+                if term.target not in ignore:
+                    b.body[-1] = ir.Jump(term.target + offset, term.loc)
+            if isinstance(term, ir.Branch):
+                if term.truebr not in ignore:
+                    new_true = term.truebr + offset
+                else:
+                    new_true = term.truebr
+
+                if term.falsebr not in ignore:
+                    new_false = term.falsebr + offset
+                else:
+                    new_false = term.falsebr
+                b.body[-1] = ir.Branch(term.cond, new_true, new_false, term.loc)
+            new_blocks[l + offset] = b
+        return new_blocks
+
+    def inject_loop_body(
+        self, switch_ir, loop_ir, caller_max_label, dont_replace, switch_data
+    ):
+        """
+        Injects the "loop body" held in `loop_ir` into `switch_ir` where ever
+        there is a statement of the form `SENTINEL.<int> = RHS`. It also:
+        * Finds and then deliberately does not relabel non-local jumps so as to
+          make the switch table suitable for injection into the IR from which
+          the loop body was derived.
+        * Looks for `typed_getitem` and wires them up to loop body version
+          specific variables or, if possible, directly writes in their constant
+          value at their use site.
+
+        Args:
+        - switch_ir, the switch table with SENTINELS as generated by
+          self.gen_switch
+        - loop_ir, the IR of the loop blocks (derived from the original func_ir)
+        - caller_max_label, the maximum label in the func_ir caller
+        - dont_replace, variables that should not be renamed (to handle
+          references to variables that are incoming at the loop head/escaping at
+          the loop exit.
+        - switch_data, the switch table data used to generated the switch_ir,
+          can be generated by self.analyse_tuple.
+
+        Returns:
+        - A type specific switch table with each case containing a versioned
+          loop body suitable for injection as a replacement for the loop_ir.
+        """
+
+        # Switch IR came from code gen, immediately relabel to prevent
+        # collisions with IR derived from the user code (caller)
+        switch_ir.blocks = self.add_offset_to_labels_w_ignore(
+            switch_ir.blocks, caller_max_label + 1
+        )
+
+        # Find the sentinels and validate the form
+        sentinel_exits = set()
+        sentinel_blocks = []
+        for lbl, blk in switch_ir.blocks.items():
+            for i, stmt in enumerate(blk.body):
+                if isinstance(stmt, ir.Assign):
+                    if "SENTINEL" in stmt.target.name:
+                        sentinel_blocks.append(lbl)
+                        sentinel_exits.add(blk.body[-1].target)
+                        break
+
+        assert len(sentinel_exits) == 1  # should only be 1 exit
+        switch_ir.blocks.pop(sentinel_exits.pop())  # kill the exit, it's dead
+
+        # find jumps that are non-local, we won't relabel these
+        ignore_set = set()
+        local_lbl = [x for x in loop_ir.blocks.keys()]
+        for lbl, blk in loop_ir.blocks.items():
+            for i, stmt in enumerate(blk.body):
+                if isinstance(stmt, ir.Jump):
+                    if stmt.target not in local_lbl:
+                        ignore_set.add(stmt.target)
+                if isinstance(stmt, ir.Branch):
+                    if stmt.truebr not in local_lbl:
+                        ignore_set.add(stmt.truebr)
+                    if stmt.falsebr not in local_lbl:
+                        ignore_set.add(stmt.falsebr)
+
+        # make sure the generated switch table matches the switch data
+        assert len(sentinel_blocks) == len(switch_data)
+
+        # replace the sentinel_blocks with the loop body
+        for lbl, branch_ty in zip(sentinel_blocks, switch_data.keys()):
+            loop_blocks = deepcopy(loop_ir.blocks)
+            # relabel blocks WRT switch table, each block replacement will shift
+            # the maximum label
+            max_label = max(switch_ir.blocks.keys())
+            loop_blocks = self.add_offset_to_labels_w_ignore(
+                loop_blocks, max_label + 1, ignore_set
+            )
+
+            # start label
+            loop_start_lbl = min(loop_blocks.keys())
+
+            # fix the typed_getitem locations in the loop blocks
+            for blk in loop_blocks.values():
+                new_body = []
+                for stmt in blk.body:
+                    if isinstance(stmt, ir.Assign):
+                        if (
+                            isinstance(stmt.value, ir.Expr)
+                            and stmt.value.op == "typed_getitem"
+                        ):
+                            if isinstance(branch_ty, types.Literal):
+                                scope = switch_ir.blocks[lbl].scope
+                                new_const_name = scope.redefine(
+                                    "branch_const", stmt.loc
+                                ).name
+                                new_const_var = ir.Var(
+                                    blk.scope, new_const_name, stmt.loc
+                                )
+                                new_const_val = ir.Const(
+                                    branch_ty.literal_value, stmt.loc
+                                )
+                                const_assign = ir.Assign(
+                                    new_const_val, new_const_var, stmt.loc
+                                )
+                                new_assign = ir.Assign(
+                                    new_const_var, stmt.target, stmt.loc
+                                )
+                                new_body.append(const_assign)
+                                new_body.append(new_assign)
+                                dont_replace.append(new_const_name)
+                            else:
+                                orig = stmt.value
+                                new_typed_getitem = ir.Expr.typed_getitem(
+                                    value=orig.value,
+                                    dtype=branch_ty,
+                                    index=orig.index,
+                                    loc=orig.loc,
+                                )
+                                new_assign = ir.Assign(
+                                    new_typed_getitem, stmt.target, stmt.loc
+                                )
+                                new_body.append(new_assign)
+                        else:
+                            new_body.append(stmt)
+                    else:
+                        new_body.append(stmt)
+                blk.body = new_body
+
+            # rename
+            var_table = get_name_var_table(loop_blocks)
+            drop_keys = []
+            for k, v in var_table.items():
+                if v.name in dont_replace:
+                    drop_keys.append(k)
+            for k in drop_keys:
+                var_table.pop(k)
+
+            new_var_dict = {}
+            for name, var in var_table.items():
+                scope = switch_ir.blocks[lbl].scope
+                try:
+                    scope.get_exact(name)
+                except errors.NotDefinedError:
+                    # In case the scope doesn't have the variable, we need to
+                    # define it prior creating new copies of it! This is
+                    # because the scope of the function and the scope of the
+                    # loop are different and the variable needs to be redefined
+                    # within the scope of the loop.
+                    scope.define(name, var.loc)
+                new_var_dict[name] = scope.redefine(name, var.loc).name
+            replace_var_names(loop_blocks, new_var_dict)
+
+            # clobber the sentinel body and then stuff in the rest
+            switch_ir.blocks[lbl] = deepcopy(loop_blocks[loop_start_lbl])
+            remaining_keys = [y for y in loop_blocks.keys()]
+            remaining_keys.remove(loop_start_lbl)
+            for k in remaining_keys:
+                switch_ir.blocks[k] = deepcopy(loop_blocks[k])
+
+        if self._DEBUG:
+            print("-" * 80 + "EXIT STUFFER")
+            switch_ir.dump()
+            print("-" * 80)
+
+        return switch_ir
+
+    def gen_switch(self, data, index):
+        """
+        Generates a function with a switch table like
+        def foo():
+            if PLACEHOLDER_INDEX in (<integers>):
+                SENTINEL = None
+            elif PLACEHOLDER_INDEX in (<integers>):
+                SENTINEL = None
+            ...
+            else:
+                raise RuntimeError
+
+        The data is a map of (type : indexes) for example:
+        (int64, int64, float64)
+        might give:
+        {int64: [0, 1], float64: [2]}
+
+        The index is the index variable for the driving range loop over the
+        mixed tuple.
+        """
+        elif_tplt = "\n\telif PLACEHOLDER_INDEX in (%s,):\n\t\tSENTINEL = None"
+
+        # Note regarding the insertion of the garbage/defeat variables below:
+        # These values have been designed and inserted to defeat a specific
+        # behaviour of the cpython optimizer. The optimization was introduced
+        # in Python 3.10.
+
+        # The URL for the BPO is:
+        # https://bugs.python.org/issue44626
+        # The code for the optimization can be found at:
+        # https://github.com/python/cpython/blob/d41abe8/Python/compile.c#L7533-L7557
+
+        # Essentially the CPython optimizer will inline the exit block under
+        # certain circumstances and thus replace the jump with a return if the
+        # exit block is small enough.  This is an issue for unroller, as it
+        # looks for a jump, not a return, when it inserts the generated switch
+        # table.
+
+        # Part of the condition for this optimization to be applied is that the
+        # exit block not exceed a certain (4 at the time of writing) number of
+        # bytecode instructions. We defeat the optimizer by inserting a
+        # sufficient number of instructions so that the exit block is big
+        # enough. We don't care about this garbage, because the generated exit
+        # block is discarded anyway when we smash the switch table into the
+        # original function and so all the inserted garbage is dropped again.
+
+        # The final lines of the stacktrace w/o this will look like:
+        #
+        #  File "/numba/numba/core/untyped_passes.py", line 830, \
+        #       in inject_loop_body
+        #   sentinel_exits.add(blk.body[-1].target)
+        # AttributeError: Failed in nopython mode pipeline \
+        #       (step: handles literal_unroll)
+        # Failed in literal_unroll_subpipeline mode pipeline \
+        #       (step: performs mixed container unroll)
+        # 'Return' object has no attribute 'target'
+        #
+        # Which indicates that a Return has been found instead of a Jump
+
+        b = (
+            "def foo():\n\tif PLACEHOLDER_INDEX in (%s,):\n\t\t"
+            "SENTINEL = None\n%s\n\telse:\n\t\t"
+            'raise RuntimeError("Unreachable")\n\t'
+            "py310_defeat1 = 1\n\t"
+            "py310_defeat2 = 2\n\t"
+            "py310_defeat3 = 3\n\t"
+            "py310_defeat4 = 4\n\t"
+        )
+        keys = [k for k in data.keys()]
+
+        elifs = []
+        for i in range(1, len(keys)):
+            elifs.append(elif_tplt % ",".join(map(str, data[keys[i]])))
+        src = b % (",".join(map(str, data[keys[0]])), "".join(elifs))
+        wstr = src
+        l = {}
+        exec(wstr, {}, l)
+        bfunc = l["foo"]
+        branches = compile_to_numba_ir(bfunc, {})
+        for lbl, blk in branches.blocks.items():
+            for stmt in blk.body:
+                if isinstance(stmt, ir.Assign):
+                    if isinstance(stmt.value, ir.Global):
+                        if stmt.value.name == "PLACEHOLDER_INDEX":
+                            stmt.value = index
+        return branches
+
+    def apply_transform(self, state):
+        # compute new CFG
+        func_ir = state.func_ir
+        cfg = compute_cfg_from_blocks(func_ir.blocks)
+        # find loops
+        loops = cfg.loops()
+
+        # 0. Find the loops containing literal_unroll and store this
+        #    information
+        unroll_info = namedtuple(
+            "unroll_info", ["loop", "call", "arg", "getitem"]
+        )
+
+        def get_call_args(init_arg, want):
+            # Chases the assignment of a called value back through a specific
+            # call to a global function "want" and returns the arguments
+            # supplied to that function's call
+            some_call = get_definition(func_ir, init_arg)
+            if not isinstance(some_call, ir.Expr):
+                raise GuardException
+            if not some_call.op == "call":
+                raise GuardException
+            the_global = get_definition(func_ir, some_call.func)
+            if not isinstance(the_global, ir.Global):
+                raise GuardException
+            if the_global.value is not want:
+                raise GuardException
+            return some_call
+
+        def find_unroll_loops(loops):
+            """This finds loops which are compliant with the form:
+            for i in range(len(literal_unroll(<something>>)))"""
+            unroll_loops = {}
+            for header_lbl, loop in loops.items():
+                # TODO: check the loop head has literal_unroll, if it does but
+                # does not conform to the following then raise
+
+                # scan loop header
+                iternexts = [
+                    _
+                    for _ in func_ir.blocks[loop.header].find_exprs("iternext")
+                ]
+                # needs to be an single iternext driven loop
+                if len(iternexts) != 1:
+                    continue
+                for iternext in iternexts:
+                    # Walk the canonicalised loop structure and check it
+                    # Check loop form range(literal_unroll(container)))
+                    phi = guard(get_definition, func_ir, iternext.value)
+                    if phi is None:
+                        continue
+
+                    # check call global "range"
+                    range_call = guard(get_call_args, phi.value, range)
+                    if range_call is None:
+                        continue
+                    range_arg = range_call.args[0]
+
+                    # check call global "len"
+                    len_call = guard(get_call_args, range_arg, len)
+                    if len_call is None:
+                        continue
+                    len_arg = len_call.args[0]
+
+                    # check literal_unroll
+                    literal_unroll_call = guard(
+                        get_definition, func_ir, len_arg
+                    )
+                    if literal_unroll_call is None:
+                        continue
+                    if not isinstance(literal_unroll_call, ir.Expr):
+                        continue
+                    if literal_unroll_call.op != "call":
+                        continue
+                    literal_func = getattr(literal_unroll_call, "func", None)
+                    if not literal_func:
+                        continue
+                    call_func = guard(
+                        get_definition, func_ir, literal_unroll_call.func
+                    )
+                    if call_func is None:
+                        continue
+                    call_func_value = call_func.value
+
+                    if call_func_value is literal_unroll:
+                        assert len(literal_unroll_call.args) == 1
+                        unroll_loops[loop] = literal_unroll_call
+            return unroll_loops
+
+        def ensure_no_nested_unroll(unroll_loops):
+            # Validate loop nests, nested literal_unroll loops are unsupported.
+            # This doesn't check that there's a getitem or anything else
+            # required for the transform to work, simply just that there's no
+            # nesting.
+            for test_loop in unroll_loops:
+                for ref_loop in unroll_loops:
+                    if test_loop == ref_loop:  # comparing to self! skip
+                        continue
+                    if test_loop.header in ref_loop.body:
+                        msg = "Nesting of literal_unroll is unsupported"
+                        loc = func_ir.blocks[test_loop.header].loc
+                        raise errors.UnsupportedError(msg, loc)
+
+        def collect_literal_unroll_info(literal_unroll_loops):
+            """Finds the loops induced by `literal_unroll`, returns a list of
+            unroll_info namedtuples for use in the transform pass.
+            """
+
+            literal_unroll_info = []
+            for loop, literal_unroll_call in literal_unroll_loops.items():
+                arg = literal_unroll_call.args[0]
+                typemap = state.typemap
+                resolved_arg = guard(
+                    get_definition, func_ir, arg, lhs_only=True
+                )
+                ty = typemap[resolved_arg.name]
+                assert isinstance(ty, self._accepted_types)
+                # loop header is spelled ok, now make sure the body
+                # actually contains a getitem
+
+                # find a "getitem"... only looks in the blocks that belong
+                # _solely_ to this literal_unroll (there should not be nested
+                # literal_unroll loops, this is unsupported).
+                tuple_getitem = None
+                for lbli in loop.body:
+                    blk = func_ir.blocks[lbli]
+                    for stmt in blk.body:
+                        if isinstance(stmt, ir.Assign):
+                            if (
+                                isinstance(stmt.value, ir.Expr)
+                                and stmt.value.op == "getitem"
+                            ):
+                                # check for something like a[i]
+                                if stmt.value.value != arg:
+                                    # that failed, so check for the
+                                    # definition
+                                    dfn = guard(
+                                        get_definition,
+                                        func_ir,
+                                        stmt.value.value,
+                                    )
+                                    if dfn is None:
+                                        continue
+                                    try:
+                                        args = getattr(dfn, "args", False)
+                                    except KeyError:
+                                        continue
+                                    if not args:
+                                        continue
+                                    if not args[0] == arg:
+                                        continue
+                                target_ty = state.typemap[arg.name]
+                                if not isinstance(
+                                    target_ty, self._accepted_types
+                                ):
+                                    continue
+                                tuple_getitem = stmt
+                                break
+                    if tuple_getitem:
+                        break
+                else:
+                    continue  # no getitem in this loop
+
+                ui = unroll_info(loop, literal_unroll_call, arg, tuple_getitem)
+                literal_unroll_info.append(ui)
+            return literal_unroll_info
+
+        # 1. Collect info about the literal_unroll loops, ensure they are legal
+        literal_unroll_loops = find_unroll_loops(loops)
+        # validate
+        ensure_no_nested_unroll(literal_unroll_loops)
+        # assemble info
+        literal_unroll_info = collect_literal_unroll_info(literal_unroll_loops)
+        if not literal_unroll_info:
+            return False
+
+        # 2. Do the unroll, get a loop and process it!
+        info = literal_unroll_info[0]
+        self.unroll_loop(state, info)
+
+        # 3. Rebuild the state, the IR has taken a hammering
+        func_ir.blocks = simplify_CFG(func_ir.blocks)
+        post_proc = postproc.PostProcessor(func_ir)
+        post_proc.run()
+        if self._DEBUG:
+            print("-" * 80 + "END OF PASS, SIMPLIFY DONE")
+            func_ir.dump()
+        func_ir._definitions = build_definitions(func_ir.blocks)
+        return True
+
+    def unroll_loop(self, state, loop_info):
+        # The general idea here is to:
+        # 1. Find *a* getitem that conforms to the literal_unroll semantic,
+        #    i.e. one that is targeting a tuple with a loop induced index
+        # 2. Compute a structure from the tuple that describes which
+        #    iterations of a loop will have which type
+        # 3. Generate a switch table in IR form for the structure in 2
+        # 4. Switch out getitems for the tuple for a `typed_getitem`
+        # 5. Inject switch table as replacement loop body
+        # 6. Patch up
+        func_ir = state.func_ir
+        getitem_target = loop_info.arg
+        target_ty = state.typemap[getitem_target.name]
+        assert isinstance(target_ty, self._accepted_types)
+
+        # 1. find a "getitem" that conforms
+        tuple_getitem = []
+        for lbl in loop_info.loop.body:
+            blk = func_ir.blocks[lbl]
+            for stmt in blk.body:
+                if isinstance(stmt, ir.Assign):
+                    if (
+                        isinstance(stmt.value, ir.Expr)
+                        and stmt.value.op == "getitem"
+                    ):
+                        # try a couple of spellings... a[i] and ref(a)[i]
+                        if stmt.value.value != getitem_target:
+                            dfn = func_ir.get_definition(stmt.value.value)
+                            try:
+                                args = getattr(dfn, "args", False)
+                            except KeyError:
+                                continue
+                            if not args:
+                                continue
+                            if not args[0] == getitem_target:
+                                continue
+                        target_ty = state.typemap[getitem_target.name]
+                        if not isinstance(target_ty, self._accepted_types):
+                            continue
+                        tuple_getitem.append(stmt)
+
+        if not tuple_getitem:
+            msg = (
+                "Loop unrolling analysis has failed, there's no getitem "
+                "in loop body that conforms to literal_unroll "
+                "requirements."
+            )
+            LOC = func_ir.blocks[loop_info.loop.header].loc
+            raise errors.CompilerError(msg, LOC)
+
+        # 2. get switch data
+        switch_data = self.analyse_tuple(target_ty)
+
+        # 3. generate switch IR
+        index = func_ir._definitions[tuple_getitem[0].value.index.name][0]
+        branches = self.gen_switch(switch_data, index)
+
+        # 4. swap getitems for a typed_getitem, these are actually just
+        # placeholders at this point. When the loop is duplicated they can
+        # be swapped for a typed_getitem of the correct type or if the item
+        # is literal it can be shoved straight into the duplicated loop body
+        for item in tuple_getitem:
+            old = item.value
+            new = ir.Expr.typed_getitem(
+                old.value, types.void, old.index, old.loc
+            )
+            item.value = new
+
+        # 5. Inject switch table
+
+        # Find the actual loop without the header (that won't get replaced)
+        # and derive some new IR for this set of blocks
+        this_loop = loop_info.loop
+        this_loop_body = this_loop.body - set([this_loop.header])
+        loop_blocks = {x: func_ir.blocks[x] for x in this_loop_body}
+        new_ir = func_ir.derive(loop_blocks)
+
+        # Work out what is live on entry and exit so as to prevent
+        # replacement (defined vars can escape, used vars live at the header
+        # need to remain as-is so their references are correct, they can
+        # also escape).
+
+        usedefs = compute_use_defs(func_ir.blocks)
+        idx = this_loop.header
+        keep = set()
+        keep |= usedefs.usemap[idx] | usedefs.defmap[idx]
+        keep |= func_ir.variable_lifetime.livemap[idx]
+        dont_replace = [x for x in (keep)]
+
+        # compute the unrolled body
+        unrolled_body = self.inject_loop_body(
+            branches,
+            new_ir,
+            max(func_ir.blocks.keys()) + 1,
+            dont_replace,
+            switch_data,
+        )
+
+        # 6. Patch in the unrolled body and fix up
+        blks = state.func_ir.blocks
+        the_scope = next(iter(blks.values())).scope
+        orig_lbl = tuple(this_loop_body)
+
+        replace, *delete = orig_lbl
+        unroll, header_block = unrolled_body, this_loop.header
+        unroll_lbl = [x for x in sorted(unroll.blocks.keys())]
+        blks[replace] = transfer_scope(unroll.blocks[unroll_lbl[0]], the_scope)
+        [blks.pop(d) for d in delete]
+        for k in unroll_lbl[1:]:
+            blks[k] = transfer_scope(unroll.blocks[k], the_scope)
+        # stitch up the loop predicate true -> new loop body jump
+        blks[header_block].body[-1].truebr = replace
+
+    def run_pass(self, state):
+        mutated = False
+        func_ir = state.func_ir
+        # first limit the work by squashing the CFG if possible
+        func_ir.blocks = simplify_CFG(func_ir.blocks)
+
+        if self._DEBUG:
+            print("-" * 80 + "PASS ENTRY")
+            func_ir.dump()
+            print("-" * 80)
+
+        # limitations:
+        # 1. No nested unrolls
+        # 2. Opt in via `numba.literal_unroll`
+        # 3. No multiple mix-tuple use
+
+        # keep running the transform loop until it reports no more changes
+        while True:
+            stat = self.apply_transform(state)
+            mutated |= stat
+            if not stat:
+                break
+
+        # reset type inference now we are done with the partial results
+        state.typemap = {}
+        state.calltypes = None
+
+        return mutated
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class IterLoopCanonicalization(FunctionPass):
+    """Transforms loops that are induced by `getiter` into range() driven loops
+    If the typemap is available this will only impact Tuple and UniTuple, if it
+    is not available it will impact all matching loops.
+    """
+
+    _name = "iter_loop_canonicalisation"
+
+    _DEBUG = False
+
+    # if partial typing info is available it will only look at these types
+    _accepted_types = (types.BaseTuple, types.LiteralList)
+    _accepted_calls = (literal_unroll,)
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def assess_loop(self, loop, func_ir, partial_typemap=None):
+        # it's a iter loop if:
+        # - loop header is driven by an iternext
+        # - the iternext value is a phi derived from getiter()
+
+        # check header
+        iternexts = [
+            _ for _ in func_ir.blocks[loop.header].find_exprs("iternext")
+        ]
+        if len(iternexts) != 1:
+            return False
+        for iternext in iternexts:
+            phi = guard(get_definition, func_ir, iternext.value)
+            if phi is None:
+                return False
+            if getattr(phi, "op", False) == "getiter":
+                if partial_typemap:
+                    # check that the call site is accepted, until we're
+                    # confident that tuple unrolling is behaving require opt-in
+                    # guard of `literal_unroll`, remove this later!
+                    phi_val_defn = guard(get_definition, func_ir, phi.value)
+                    if not isinstance(phi_val_defn, ir.Expr):
+                        return False
+                    if not phi_val_defn.op == "call":
+                        return False
+                    call = guard(get_definition, func_ir, phi_val_defn)
+                    if call is None or len(call.args) != 1:
+                        return False
+                    func_var = guard(get_definition, func_ir, call.func)
+                    func = guard(get_definition, func_ir, func_var)
+                    if func is None or not isinstance(
+                        func, (ir.Global, ir.FreeVar)
+                    ):
+                        return False
+                    if (
+                        func.value is None
+                        or func.value not in self._accepted_calls
+                    ):
+                        return False
+
+                    # now check the type is supported
+                    ty = partial_typemap.get(call.args[0].name, None)
+                    if ty and isinstance(ty, self._accepted_types):
+                        return len(loop.entries) == 1
+                else:
+                    return len(loop.entries) == 1
+
+    def transform(self, loop, func_ir, cfg):
+        def get_range(a):
+            return range(len(a))
+
+        iternext = [
+            _ for _ in func_ir.blocks[loop.header].find_exprs("iternext")
+        ][0]
+        LOC = func_ir.blocks[loop.header].loc
+        scope = func_ir.blocks[loop.header].scope
+        get_range_var = scope.redefine("CANONICALISER_get_range_gbl", LOC)
+        get_range_global = ir.Global("get_range", get_range, LOC)
+        assgn = ir.Assign(get_range_global, get_range_var, LOC)
+
+        loop_entry = tuple(loop.entries)[0]
+        entry_block = func_ir.blocks[loop_entry]
+        entry_block.body.insert(0, assgn)
+
+        iterarg = guard(get_definition, func_ir, iternext.value)
+        if iterarg is not None:
+            iterarg = iterarg.value
+
+        # look for iternext
+        idx = 0
+        for stmt in entry_block.body:
+            if isinstance(stmt, ir.Assign):
+                if (
+                    isinstance(stmt.value, ir.Expr)
+                    and stmt.value.op == "getiter"
+                ):
+                    break
+            idx += 1
+        else:
+            raise ValueError("problem")
+
+        # create a range(len(tup)) and inject it
+        call_get_range_var = scope.redefine("CANONICALISER_call_get_range", LOC)
+        make_call = ir.Expr.call(get_range_var, (stmt.value.value,), (), LOC)
+        assgn_call = ir.Assign(make_call, call_get_range_var, LOC)
+        entry_block.body.insert(idx, assgn_call)
+        entry_block.body[idx + 1].value.value = call_get_range_var
+
+        glbls = copy(func_ir.func_id.func.__globals__)
+        from numba.core.inline_closurecall import inline_closure_call
+
+        inline_closure_call(
+            func_ir,
+            glbls,
+            entry_block,
+            idx,
+            get_range,
+        )
+        kill = entry_block.body.index(assgn)
+        entry_block.body.pop(kill)
+
+        # find the induction variable + references in the loop header
+        # fixed point iter to do this, it's a bit clunky
+        induction_vars = set()
+        header_block = func_ir.blocks[loop.header]
+
+        # find induction var
+        ind = [x for x in header_block.find_exprs("pair_first")]
+        for x in ind:
+            induction_vars.add(func_ir.get_assignee(x, loop.header))
+        # find aliases of the induction var
+        tmp = set()
+        for x in induction_vars:
+            try:  # there's not always an alias, e.g. loop from inlined closure
+                tmp.add(func_ir.get_assignee(x, loop.header))
+            except ValueError:
+                pass
+        induction_vars |= tmp
+        induction_var_names = set([x.name for x in induction_vars])
+
+        # Find the downstream blocks that might reference the induction var
+        succ = set()
+        for lbl in loop.exits:
+            succ |= set([x[0] for x in cfg.successors(lbl)])
+        check_blocks = (loop.body | loop.exits | succ) ^ {loop.header}
+
+        # replace RHS use of induction var with getitem
+        for lbl in check_blocks:
+            for stmt in func_ir.blocks[lbl].body:
+                if isinstance(stmt, ir.Assign):
+                    # check for aliases
+                    try:
+                        lookup = getattr(stmt.value, "name", None)
+                    except KeyError:
+                        continue
+                    if lookup and lookup in induction_var_names:
+                        stmt.value = ir.Expr.getitem(
+                            iterarg, stmt.value, stmt.loc
+                        )
+
+        post_proc = postproc.PostProcessor(func_ir)
+        post_proc.run()
+
+    def run_pass(self, state):
+        func_ir = state.func_ir
+        cfg = compute_cfg_from_blocks(func_ir.blocks)
+        loops = cfg.loops()
+
+        mutated = False
+        for header, loop in loops.items():
+            stat = self.assess_loop(loop, func_ir, state.typemap)
+            if stat:
+                if self._DEBUG:
+                    print("Canonicalising loop", loop)
+                self.transform(loop, func_ir, cfg)
+                mutated = True
+            else:
+                if self._DEBUG:
+                    print("NOT Canonicalising loop", loop)
+
+        func_ir.blocks = simplify_CFG(func_ir.blocks)
+        return mutated
+
+
+@register_pass(mutates_CFG=False, analysis_only=False)
+class PropagateLiterals(FunctionPass):
+    """Implement literal propagation based on partial type inference"""
+
+    _name = "PropagateLiterals"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def get_analysis_usage(self, AU):
+        AU.add_required(ReconstructSSA)
+
+    def run_pass(self, state):
+        func_ir = state.func_ir
+        typemap = state.typemap
+        flags = state.flags
+
+        accepted_functions = ("isinstance", "hasattr")
+
+        if not hasattr(func_ir, "_definitions") and not flags.enable_ssa:
+            func_ir._definitions = build_definitions(func_ir.blocks)
+
+        changed = False
+
+        for block in func_ir.blocks.values():
+            for assign in block.find_insts(ir.Assign):
+                value = assign.value
+                if isinstance(value, (ir.Arg, ir.Const, ir.FreeVar, ir.Global)):
+                    continue
+
+                # 1) Don't change return stmt in the form
+                # $return_xyz = cast(value=ABC)
+                # 2) Don't propagate literal values that are not primitives
+                if isinstance(value, ir.Expr) and value.op in (
+                    "cast",
+                    "build_map",
+                    "build_list",
+                    "build_tuple",
+                    "build_set",
+                ):
+                    continue
+
+                target = assign.target
+                if not flags.enable_ssa:
+                    # SSA is disabled when doing inlining
+                    if guard(get_definition, func_ir, target.name) is None:  # noqa: E501
+                        continue
+
+                # Numba cannot safely determine if an isinstance call
+                # with a PHI node is True/False. For instance, in
+                # the case below, the partial type inference step can coerce
+                # '$z' to float, so any call to 'isinstance(z, int)' would fail.
+                #
+                #   def fn(x):
+                #       if x > 4:
+                #           z = 1
+                #       else:
+                #           z = 3.14
+                #       if isinstance(z, int):
+                #           print('int')
+                #       else:
+                #           print('float')
+                #
+                # At the moment, one avoid propagating the literal
+                # value if the argument is a PHI node
+
+                if isinstance(value, ir.Expr) and value.op == "call":
+                    fn = guard(get_definition, func_ir, value.func.name)
+                    if fn is None:
+                        continue
+
+                    if not (
+                        isinstance(fn, ir.Global)
+                        and fn.name in accepted_functions
+                    ):
+                        continue
+
+                    for arg in value.args:
+                        # check if any of the args to isinstance is a PHI node
+                        iv = func_ir._definitions[arg.name]
+                        assert len(iv) == 1  # SSA!
+                        if isinstance(iv[0], ir.Expr) and iv[0].op == "phi":
+                            msg = (
+                                f"{fn.name}() cannot determine the "
+                                f'type of variable "{arg.unversioned_name}" '
+                                "due to a branch."
+                            )
+                            raise errors.NumbaTypeError(msg, loc=assign.loc)
+
+                # Only propagate a PHI node if all arguments are the same
+                # constant
+                if isinstance(value, ir.Expr) and value.op == "phi":
+                    # typemap will return None in case `inc.name` not in typemap
+                    v = [typemap.get(inc.name) for inc in value.incoming_values]
+                    # stop if the elements in `v` do not hold the same value
+                    if v[0] is not None and any([v[0] != vi for vi in v]):
+                        continue
+
+                lit = typemap.get(target.name, None)
+                if lit and isinstance(lit, types.Literal):
+                    # replace assign instruction by ir.Const(lit) iff
+                    # lit is a literal value
+                    rhs = ir.Const(lit.literal_value, assign.loc)
+                    new_assign = ir.Assign(rhs, target, assign.loc)
+
+                    # replace instruction
+                    block.insert_after(new_assign, assign)
+                    block.remove(assign)
+
+                    changed = True
+
+        # reset type inference now we are done with the partial results
+        state.typemap = None
+        state.calltypes = None
+
+        if changed:
+            # Rebuild definitions
+            func_ir._definitions = build_definitions(func_ir.blocks)
+
+        return changed
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class LiteralPropagationSubPipelinePass(FunctionPass):
+    """Implement literal propagation based on partial type inference"""
+
+    _name = "LiteralPropagation"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        # Determine whether to even attempt this pass... if there's no
+        # `isinstance` as a global or as a freevar then just skip.
+
+        found = False
+        func_ir = state.func_ir
+        for blk in func_ir.blocks.values():
+            for asgn in blk.find_insts(ir.Assign):
+                if isinstance(asgn.value, (ir.Global, ir.FreeVar)):
+                    value = asgn.value.value
+                    if value is isinstance or value is hasattr:
+                        found = True
+                        break
+            if found:
+                break
+        if not found:
+            return False
+
+        # run as subpipeline
+        from numba.cuda.core.compiler_machinery import PassManager
+        from numba.cuda.core.typed_passes import PartialTypeInference
+
+        pm = PassManager("literal_propagation_subpipeline")
+
+        pm.add_pass(PartialTypeInference, "performs partial type inference")
+        pm.add_pass(PropagateLiterals, "performs propagation of literal values")
+
+        # rewrite consts / dead branch pruning
+        pm.add_pass(RewriteSemanticConstants, "rewrite semantic constants")
+        pm.add_pass(DeadBranchPrune, "dead branch pruning")
+
+        pm.finalize()
+        pm.run(state)
+        return True
+
+    def get_analysis_usage(self, AU):
+        AU.add_required(ReconstructSSA)
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class LiteralUnroll(FunctionPass):
+    """Implement the literal_unroll semantics"""
+
+    _name = "literal_unroll"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        # Determine whether to even attempt this pass... if there's no
+        # `literal_unroll` as a global or as a freevar then just skip.
+        found = False
+        func_ir = state.func_ir
+        for blk in func_ir.blocks.values():
+            for asgn in blk.find_insts(ir.Assign):
+                if isinstance(asgn.value, (ir.Global, ir.FreeVar)):
+                    if asgn.value.value is literal_unroll:
+                        found = True
+                        break
+            if found:
+                break
+        if not found:
+            return False
+
+        # run as subpipeline
+        from numba.cuda.compiler_machinery import PassManager
+        from numba.cuda.core.typed_passes import PartialTypeInference
+
+        pm = PassManager("literal_unroll_subpipeline")
+        # get types where possible to help with list->tuple change
+        pm.add_pass(PartialTypeInference, "performs partial type inference")
+        # make const lists tuples
+        pm.add_pass(
+            TransformLiteralUnrollConstListToTuple,
+            "switch const list for tuples",
+        )
+        # recompute partial typemap following IR change
+        pm.add_pass(PartialTypeInference, "performs partial type inference")
+        # canonicalise loops
+        pm.add_pass(
+            IterLoopCanonicalization, "switch iter loops for range driven loops"
+        )
+        # rewrite consts
+        pm.add_pass(RewriteSemanticConstants, "rewrite semantic constants")
+        # do the unroll
+        pm.add_pass(MixedContainerUnroller, "performs mixed container unroll")
+        # rewrite dynamic getitem to static getitem as it's possible some more
+        # getitems will now be statically resolvable
+        pm.add_pass(GenericRewrites, "Generic Rewrites")
+        pm.add_pass(RewriteSemanticConstants, "rewrite semantic constants")
+        pm.finalize()
+        pm.run(state)
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class SimplifyCFG(FunctionPass):
+    """Perform CFG simplification"""
+
+    _name = "simplify_cfg"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        blks = state.func_ir.blocks
+        new_blks = simplify_CFG(blks)
+        state.func_ir.blocks = new_blks
+        mutated = blks != new_blks
+        return mutated
+
+
+@register_pass(mutates_CFG=False, analysis_only=False)
+class ReconstructSSA(FunctionPass):
+    """Perform SSA-reconstruction
+
+    Produces minimal SSA.
+    """
+
+    _name = "reconstruct_ssa"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        state.func_ir = reconstruct_ssa(state.func_ir)
+        self._patch_locals(state)
+
+        # Rebuild definitions
+        state.func_ir._definitions = build_definitions(state.func_ir.blocks)
+
+        # Rerun postprocessor to update metadata
+        # example generator_info
+        post_proc = postproc.PostProcessor(state.func_ir)
+        post_proc.run(emit_dels=False)
+
+        if config.DEBUG or config.DUMP_SSA:
+            name = state.func_ir.func_id.func_qualname
+            print(f"SSA IR DUMP: {name}".center(80, "-"))
+            state.func_ir.dump()
+
+        return True  # XXX detect if it actually got changed
+
+    def _patch_locals(self, state):
+        # Fix dispatcher locals dictionary type annotation
+        locals_dict = state.get("locals")
+        if locals_dict is None:
+            return
+
+        first_blk, *_ = state.func_ir.blocks.values()
+        scope = first_blk.scope
+        for parent, redefs in scope.var_redefinitions.items():
+            if parent in locals_dict:
+                typ = locals_dict[parent]
+                for derived in redefs:
+                    locals_dict[derived] = typ
+
+
+@register_pass(mutates_CFG=False, analysis_only=False)
+class RewriteDynamicRaises(FunctionPass):
+    """Replace existing raise statements by dynamic raises in Numba IR."""
+
+    _name = "Rewrite dynamic raises"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        func_ir = state.func_ir
+        changed = False
+
+        for block in func_ir.blocks.values():
+            for raise_ in block.find_insts((ir.Raise, ir.TryRaise)):
+                call_inst = guard(get_definition, func_ir, raise_.exception)
+                if call_inst is None:
+                    continue
+                exc_type = func_ir.infer_constant(call_inst.func.name)
+                exc_args = []
+                for exc_arg in call_inst.args:
+                    try:
+                        const = func_ir.infer_constant(exc_arg)
+                        exc_args.append(const)
+                    except consts.ConstantInferenceError:
+                        exc_args.append(exc_arg)
+                loc = raise_.loc
+
+                cls = {
+                    ir.TryRaise: ir.DynamicTryRaise,
+                    ir.Raise: ir.DynamicRaise,
+                }[type(raise_)]
+
+                dyn_raise = cls(exc_type, tuple(exc_args), loc)
+                block.insert_after(dyn_raise, raise_)
+                block.remove(raise_)
+                changed = True
+        return changed

--- a/numba_cuda/numba/cuda/dispatcher.py
+++ b/numba_cuda/numba/cuda/dispatcher.py
@@ -6,7 +6,7 @@ import functools
 
 from numba.core import config, serialize, sigutils, types, typing, utils
 from numba.core.caching import Cache, CacheImpl
-from numba.core.compiler_lock import global_compiler_lock
+from numba.cuda.core.compiler_lock import global_compiler_lock
 from numba.core.dispatcher import Dispatcher
 from numba.core.errors import NumbaPerformanceWarning
 from numba.core.typing.typeof import Purpose, typeof

--- a/numba_cuda/numba/cuda/flags.py
+++ b/numba_cuda/numba/cuda/flags.py
@@ -1,4 +1,139 @@
-from numba.core.compiler import Flags, Option
+from numba.core.targetconfig import TargetConfig, Option
+
+from numba.core import cpu
+
+
+class Flags(TargetConfig):
+    __slots__ = ()
+
+    enable_looplift = Option(
+        type=bool,
+        default=False,
+        doc="Enable loop-lifting",
+    )
+    enable_pyobject = Option(
+        type=bool,
+        default=False,
+        doc="Enable pyobject mode (in general)",
+    )
+    enable_pyobject_looplift = Option(
+        type=bool,
+        default=False,
+        doc="Enable pyobject mode inside lifted loops",
+    )
+    enable_ssa = Option(
+        type=bool,
+        default=True,
+        doc="Enable SSA",
+    )
+    force_pyobject = Option(
+        type=bool,
+        default=False,
+        doc="Force pyobject mode inside the whole function",
+    )
+    release_gil = Option(
+        type=bool,
+        default=False,
+        doc="Release GIL inside the native function",
+    )
+    no_compile = Option(
+        type=bool,
+        default=False,
+        doc="TODO",
+    )
+    debuginfo = Option(
+        type=bool,
+        default=False,
+        doc="TODO",
+    )
+    boundscheck = Option(
+        type=bool,
+        default=False,
+        doc="TODO",
+    )
+    forceinline = Option(
+        type=bool,
+        default=False,
+        doc="Force inlining of the function. Overrides _dbg_optnone.",
+    )
+    no_cpython_wrapper = Option(
+        type=bool,
+        default=False,
+        doc="TODO",
+    )
+    no_cfunc_wrapper = Option(
+        type=bool,
+        default=False,
+        doc="TODO",
+    )
+    auto_parallel = Option(
+        type=cpu.ParallelOptions,
+        default=cpu.ParallelOptions(False),
+        doc="""Enable automatic parallel optimization, can be fine-tuned by
+taking a dictionary of sub-options instead of a boolean, see parfor.py for
+detail""",
+    )
+    nrt = Option(
+        type=bool,
+        default=False,
+        doc="TODO",
+    )
+    no_rewrites = Option(
+        type=bool,
+        default=False,
+        doc="TODO",
+    )
+    error_model = Option(
+        type=str,
+        default="python",
+        doc="TODO",
+    )
+    fastmath = Option(
+        type=cpu.FastMathOptions,
+        default=cpu.FastMathOptions(False),
+        doc="TODO",
+    )
+    noalias = Option(
+        type=bool,
+        default=False,
+        doc="TODO",
+    )
+    inline = Option(
+        type=cpu.InlineOptions,
+        default=cpu.InlineOptions("never"),
+        doc="TODO",
+    )
+
+    dbg_extend_lifetimes = Option(
+        type=bool,
+        default=False,
+        doc=(
+            "Extend variable lifetime for debugging. "
+            "This automatically turns on with debug=True."
+        ),
+    )
+
+    dbg_optnone = Option(
+        type=bool,
+        default=False,
+        doc=(
+            "Disable optimization for debug. "
+            "Equivalent to adding optnone attribute in the LLVM Function."
+        ),
+    )
+
+    dbg_directives_only = Option(
+        type=bool,
+        default=False,
+        doc=(
+            "Make debug emissions directives-only. "
+            "Used when generating lineinfo."
+        ),
+    )
+
+
+DEFAULT_FLAGS = Flags()
+DEFAULT_FLAGS.nrt = True
 
 
 def _nvvm_options_type(x):

--- a/numba_cuda/numba/cuda/target.py
+++ b/numba_cuda/numba/cuda/target.py
@@ -13,7 +13,7 @@ from numba.core import (
     types,
     typing,
 )
-from numba.core.compiler_lock import global_compiler_lock
+from numba.cuda.core.compiler_lock import global_compiler_lock
 from numba.core.dispatcher import Dispatcher
 from numba.core.errors import NumbaWarning
 from numba.core.base import BaseContext

--- a/numba_cuda/numba/cuda/tests/test_compiler_lock.py
+++ b/numba_cuda/numba/cuda/tests/test_compiler_lock.py
@@ -1,0 +1,23 @@
+import unittest
+from numba.cuda.compiler_lock import (
+    global_compiler_lock,
+    require_global_compiler_lock,
+)
+from numba.tests.support import TestCase
+
+
+class TestCompilerLock(TestCase):
+    def test_gcl_as_context_manager(self):
+        with global_compiler_lock:
+            require_global_compiler_lock()
+
+    def test_gcl_as_decorator(self):
+        @global_compiler_lock
+        def func():
+            require_global_compiler_lock()
+
+        func()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This change vendors in the Pass Manager to ease future CUDA-specific optimizations. This requires also vendoring in all of the passes in the default and Numba CUDA pipelines to maintain the pass registry, as well as the compiler lock machinery.