### PR TITLE
[REVIEW][NFC] Vendor in the MinimalCallConv used by CUDACallConv to allow for future CUDA-specific refactoring and changes

### DIFF
--- a/numba_cuda/numba/cuda/core/callconv.py
+++ b/numba_cuda/numba/cuda/core/callconv.py
@@ -1,10 +1,34 @@
 from numba.core import cgutils, types
+from collections import namedtuple
 
 from llvmlite import ir
 
 int32_t = ir.IntType(32)
 int64_t = ir.IntType(64)
 errcode_t = int32_t
+
+
+Status = namedtuple(
+    "Status",
+    (
+        "code",
+        # If the function returned ok (a value or None)
+        "is_ok",
+        # If the function returned None
+        "is_none",
+        # If the function errored out (== not is_ok)
+        "is_error",
+        # If the generator exited with StopIteration
+        "is_stop_iteration",
+        # If the function errored with an already set exception
+        "is_python_exc",
+        # If the function errored with a user exception
+        "is_user_exc",
+        # The pointer to the exception info structure (for user
+        # exceptions)
+        "excinfoptr",
+    ),
+)
 
 
 def _const_int(code):
@@ -132,3 +156,182 @@ class BaseCallConv(object):
         Get an argument packer for the given argument types.
         """
         return self.context.get_arg_packer(argtypes)
+
+
+class MinimalCallConv(BaseCallConv):
+    """
+    A minimal calling convention, suitable for e.g. GPU targets.
+    The implemented function signature is:
+
+        retcode_t (<Python return type>*, ... <Python arguments>)
+
+    The return code will be one of the RETCODE_* constants or a
+    function-specific user exception id (>= RETCODE_USEREXC).
+
+    Caller is responsible for allocating a slot for the return value
+    (passed as a pointer in the first argument).
+    """
+
+    def _make_call_helper(self, builder):
+        return _MinimalCallHelper()
+
+    def return_value(self, builder, retval):
+        retptr = builder.function.args[0]
+        assert retval.type == retptr.type.pointee, (
+            str(retval.type),
+            str(retptr.type.pointee),
+        )
+        builder.store(retval, retptr)
+        self._return_errcode_raw(builder, RETCODE_OK)
+
+    def return_user_exc(
+        self, builder, exc, exc_args=None, loc=None, func_name=None
+    ):
+        if exc is not None and not issubclass(exc, BaseException):
+            raise TypeError(
+                "exc should be None or exception class, got %r" % (exc,)
+            )
+        if exc_args is not None and not isinstance(exc_args, tuple):
+            raise TypeError(
+                "exc_args should be None or tuple, got %r" % (exc_args,)
+            )
+
+        # Build excinfo struct
+        if loc is not None:
+            fname = loc._raw_function_name()
+            if fname is None:
+                # could be exec(<string>) or REPL, try func_name
+                fname = func_name
+
+            locinfo = (fname, loc.filename, loc.line)
+            if None in locinfo:
+                locinfo = None
+        else:
+            locinfo = None
+
+        call_helper = self._get_call_helper(builder)
+        exc_id = call_helper._add_exception(exc, exc_args, locinfo)
+        self._return_errcode_raw(builder, _const_int(exc_id))
+
+    def return_status_propagate(self, builder, status):
+        self._return_errcode_raw(builder, status.code)
+
+    def _return_errcode_raw(self, builder, code):
+        if isinstance(code, int):
+            code = _const_int(code)
+        builder.ret(code)
+
+    def _get_return_status(self, builder, code):
+        """
+        Given a return *code*, get a Status instance.
+        """
+        norm = builder.icmp_signed("==", code, RETCODE_OK)
+        none = builder.icmp_signed("==", code, RETCODE_NONE)
+        ok = builder.or_(norm, none)
+        err = builder.not_(ok)
+        exc = builder.icmp_signed("==", code, RETCODE_EXC)
+        is_stop_iteration = builder.icmp_signed("==", code, RETCODE_STOPIT)
+        is_user_exc = builder.icmp_signed(">=", code, RETCODE_USEREXC)
+
+        status = Status(
+            code=code,
+            is_ok=ok,
+            is_error=err,
+            is_python_exc=exc,
+            is_none=none,
+            is_user_exc=is_user_exc,
+            is_stop_iteration=is_stop_iteration,
+            excinfoptr=None,
+        )
+        return status
+
+    def get_function_type(self, restype, argtypes):
+        """
+        Get the implemented Function type for *restype* and *argtypes*.
+        """
+        arginfo = self._get_arg_packer(argtypes)
+        argtypes = list(arginfo.argument_types)
+        resptr = self.get_return_type(restype)
+        fnty = ir.FunctionType(errcode_t, [resptr] + argtypes)
+        return fnty
+
+    def decorate_function(self, fn, args, fe_argtypes, noalias=False):
+        """
+        Set names and attributes of function arguments.
+        """
+        assert not noalias
+        arginfo = self._get_arg_packer(fe_argtypes)
+        arginfo.assign_names(self.get_arguments(fn), ["arg." + a for a in args])
+        fn.args[0].name = ".ret"
+
+    def get_arguments(self, func):
+        """
+        Get the Python-level arguments of LLVM *func*.
+        """
+        return func.args[1:]
+
+    def call_function(self, builder, callee, resty, argtys, args):
+        """
+        Call the Numba-compiled *callee*.
+        """
+        retty = callee.args[0].type.pointee
+        retvaltmp = cgutils.alloca_once(builder, retty)
+        # initialize return value
+        builder.store(cgutils.get_null_value(retty), retvaltmp)
+
+        arginfo = self._get_arg_packer(argtys)
+        args = arginfo.as_arguments(builder, args)
+        realargs = [retvaltmp] + list(args)
+        code = builder.call(callee, realargs)
+        status = self._get_return_status(builder, code)
+        retval = builder.load(retvaltmp)
+        out = self.context.get_returned_value(builder, resty, retval)
+        return status, out
+
+
+class _MinimalCallHelper(object):
+    """
+    A call helper object for the "minimal" calling convention.
+    User exceptions are represented as integer codes and stored in
+    a mapping for retrieval from the caller.
+    """
+
+    def __init__(self):
+        self.exceptions = {}
+
+    def _add_exception(self, exc, exc_args, locinfo):
+        """
+        Add a new user exception to this helper. Returns an integer that can be
+        used to refer to the added exception in future.
+
+        Parameters
+        ----------
+        exc :
+            exception type
+        exc_args : None or tuple
+            exception args
+        locinfo : tuple
+            location information
+        """
+        exc_id = len(self.exceptions) + FIRST_USEREXC
+        self.exceptions[exc_id] = exc, exc_args, locinfo
+        return exc_id
+
+    def get_exception(self, exc_id):
+        """
+        Get information about a user exception. Returns a tuple of
+        (exception type, exception args, location information).
+
+        Parameters
+        ----------
+        id : integer
+            The ID of the exception to look up
+        """
+        try:
+            return self.exceptions[exc_id]
+        except KeyError:
+            msg = "unknown error %d in native function" % exc_id
+            exc = SystemError
+            exc_args = (msg,)
+            locinfo = None
+            return exc, exc_args, locinfo

--- a/numba_cuda/numba/cuda/target.py
+++ b/numba_cuda/numba/cuda/target.py
@@ -17,8 +17,7 @@ from numba.core.compiler_lock import global_compiler_lock
 from numba.core.dispatcher import Dispatcher
 from numba.core.errors import NumbaWarning
 from numba.core.base import BaseContext
-from numba.core.callconv import MinimalCallConv
-from numba.cuda.core.callconv import BaseCallConv
+from numba.cuda.core.callconv import BaseCallConv, MinimalCallConv
 from numba.core.typing import cmathdecl
 from numba.core import datamodel
 


### PR DESCRIPTION
The MinimalCallConv class and relevant helpers are moved into the Numba CUDA repo. This is an incremental NFC change (so no extra unit tests).