### PR TITLE
Migrate test infra to pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you want to manage all run-time dependencies yourself, also pass the `--no-de
 ## Running tests
 
 ```
-python -m numba.runtests numba.cuda.tests
+pytest --pyargs numba.cuda.tests -v
 ```
 
 This should discover the `numba.cuda` module from the `numba_cuda` package. You

--- a/ci/test_conda.sh
+++ b/ci/test_conda.sh
@@ -76,7 +76,7 @@ fi
 
 
 rapids-logger "Run Tests"
-python -m numba.runtests numba.cuda.tests -v
+pytest --pyargs numba.cuda.tests -v
 
 popd
 

--- a/ci/test_conda_ctypes_binding.sh
+++ b/ci/test_conda_ctypes_binding.sh
@@ -64,7 +64,7 @@ popd
 
 
 rapids-logger "Run Tests"
-NUMBA_CUDA_USE_NVIDIA_BINDING=0 NUMBA_CUDA_TEST_BIN_DIR=$NUMBA_CUDA_TEST_BIN_DIR python -m numba.runtests numba.cuda.tests -v
+NUMBA_CUDA_USE_NVIDIA_BINDING=0 NUMBA_CUDA_TEST_BIN_DIR=$NUMBA_CUDA_TEST_BIN_DIR pytest --pyargs numba.cuda.tests -v
 
 popd
 

--- a/ci/test_simulator.sh
+++ b/ci/test_simulator.sh
@@ -35,7 +35,7 @@ set +e
 
 rapids-logger "Run Tests"
 export NUMBA_ENABLE_CUDASIM=1
-python -m numba.runtests numba.cuda.tests -v
+pytest --pyargs numba.cuda.tests -v
 
 popd
 

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -44,6 +44,6 @@ rapids-logger "Show Numba system info"
 python -m numba --sysinfo
 
 rapids-logger "Run Tests"
-pytest --pyargs numba.cuda.tests -v
+python -m pytest --pyargs numba.cuda.tests -v
 
 popd

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -44,6 +44,6 @@ rapids-logger "Show Numba system info"
 python -m numba --sysinfo
 
 rapids-logger "Run Tests"
-python -m numba.runtests numba.cuda.tests -v
+pytest --pyargs numba.cuda.tests -v
 
 popd

--- a/ci/test_wheel_ctypes_binding.sh
+++ b/ci/test_wheel_ctypes_binding.sh
@@ -37,6 +37,6 @@ rapids-logger "Show Numba system info"
 NUMBA_CUDA_USE_NVIDIA_BINDING=0 python -m numba --sysinfo
 
 rapids-logger "Run Tests"
-NUMBA_CUDA_USE_NVIDIA_BINDING=0 NUMBA_CUDA_TEST_BIN_DIR=$NUMBA_CUDA_TEST_BIN_DIR pytest --pyargs numba.cuda.tests -v
+NUMBA_CUDA_USE_NVIDIA_BINDING=0 NUMBA_CUDA_TEST_BIN_DIR=$NUMBA_CUDA_TEST_BIN_DIR python -m pytest --pyargs numba.cuda.tests -v
 
 popd

--- a/ci/test_wheel_ctypes_binding.sh
+++ b/ci/test_wheel_ctypes_binding.sh
@@ -37,6 +37,6 @@ rapids-logger "Show Numba system info"
 NUMBA_CUDA_USE_NVIDIA_BINDING=0 python -m numba --sysinfo
 
 rapids-logger "Run Tests"
-NUMBA_CUDA_USE_NVIDIA_BINDING=0 NUMBA_CUDA_TEST_BIN_DIR=$NUMBA_CUDA_TEST_BIN_DIR python -m numba.runtests numba.cuda.tests -v
+NUMBA_CUDA_USE_NVIDIA_BINDING=0 NUMBA_CUDA_TEST_BIN_DIR=$NUMBA_CUDA_TEST_BIN_DIR pytest --pyargs numba.cuda.tests -v
 
 popd

--- a/ci/test_wheel_deps_wheels.sh
+++ b/ci/test_wheel_deps_wheels.sh
@@ -45,6 +45,6 @@ apt remove --purge `dpkg --get-selections | grep cuda-nvvm | awk '{print $1}'` -
 apt remove --purge `dpkg --get-selections | grep cuda-nvrtc | awk '{print $1}'` -y
 
 rapids-logger "Run Tests"
-NUMBA_CUDA_ENABLE_PYNVJITLINK=1 NUMBA_CUDA_TEST_BIN_DIR=$NUMBA_CUDA_TEST_BIN_DIR python -m numba.runtests numba.cuda.tests -v
+NUMBA_CUDA_ENABLE_PYNVJITLINK=1 NUMBA_CUDA_TEST_BIN_DIR=$NUMBA_CUDA_TEST_BIN_DIR pytest --pyargs numba.cuda.tests -v
 
 popd

--- a/ci/test_wheel_deps_wheels.sh
+++ b/ci/test_wheel_deps_wheels.sh
@@ -45,6 +45,6 @@ apt remove --purge `dpkg --get-selections | grep cuda-nvvm | awk '{print $1}'` -
 apt remove --purge `dpkg --get-selections | grep cuda-nvrtc | awk '{print $1}'` -y
 
 rapids-logger "Run Tests"
-NUMBA_CUDA_ENABLE_PYNVJITLINK=1 NUMBA_CUDA_TEST_BIN_DIR=$NUMBA_CUDA_TEST_BIN_DIR pytest --pyargs numba.cuda.tests -v
+NUMBA_CUDA_ENABLE_PYNVJITLINK=1 NUMBA_CUDA_TEST_BIN_DIR=$NUMBA_CUDA_TEST_BIN_DIR python -m pytest --pyargs numba.cuda.tests -v
 
 popd

--- a/docs/source/user/external-memory.rst
+++ b/docs/source/user/external-memory.rst
@@ -278,7 +278,7 @@ Numba test suite with an EMM Plugin, e.g.:
 
 .. code::
 
-   $ NUMBA_CUDA_MEMORY_MANAGER=rmm python -m numba.runtests numba.cuda.tests
+   $ NUMBA_CUDA_MEMORY_MANAGER=rmm pytest --pyargs numba.cuda.tests -v
 
 
 Function

--- a/numba_cuda/numba/cuda/__init__.py
+++ b/numba_cuda/numba/cuda/__init__.py
@@ -1,5 +1,4 @@
 import importlib
-from numba import runtests
 from numba.core import config
 from .utils import _readenv
 import warnings
@@ -94,10 +93,3 @@ numba_cuda_default_ptx_cc = (7, 5)
 
 if numba_cuda_default_ptx_cc > config_default_cc:
     config.CUDA_DEFAULT_PTX_CC = numba_cuda_default_ptx_cc
-
-
-def test(*args, **kwargs):
-    if not is_available():
-        raise cuda_error()
-
-    return runtests.main("numba.cuda.tests", *args, **kwargs)

--- a/numba_cuda/numba/cuda/tests/cudapy/test_intrinsics.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_intrinsics.py
@@ -174,27 +174,27 @@ def hlt_func_2(x, y):
     return cuda.fp16.hlt(x, y)
 
 
-def test_multiple_hcmp_1(r, a, b, c):
+def multiple_hcmp_1(r, a, b, c):
     # float16 predicates used in two separate functions
     r[0] = hlt_func_1(a, b) and hlt_func_2(b, c)
 
 
-def test_multiple_hcmp_2(r, a, b, c):
+def multiple_hcmp_2(r, a, b, c):
     # The same float16 predicate used in the caller and callee
     r[0] = hlt_func_1(a, b) and cuda.fp16.hlt(b, c)
 
 
-def test_multiple_hcmp_3(r, a, b, c):
+def multiple_hcmp_3(r, a, b, c):
     # Different float16 predicates used in the caller and callee
     r[0] = hlt_func_1(a, b) and cuda.fp16.hge(c, b)
 
 
-def test_multiple_hcmp_4(r, a, b, c):
+def multiple_hcmp_4(r, a, b, c):
     # The same float16 predicates used twice in a function
     r[0] = cuda.fp16.hlt(a, b) and cuda.fp16.hlt(b, c)
 
 
-def test_multiple_hcmp_5(r, a, b, c):
+def multiple_hcmp_5(r, a, b, c):
     # Different float16 predicates used in a function
     r[0] = cuda.fp16.hlt(a, b) and cuda.fp16.hge(c, b)
 
@@ -908,11 +908,11 @@ class TestCudaIntrinsic(CUDATestCase):
     @skip_unless_cc_53
     def test_multiple_float16_comparisons(self):
         functions = (
-            test_multiple_hcmp_1,
-            test_multiple_hcmp_2,
-            test_multiple_hcmp_3,
-            test_multiple_hcmp_4,
-            test_multiple_hcmp_5,
+            multiple_hcmp_1,
+            multiple_hcmp_2,
+            multiple_hcmp_3,
+            multiple_hcmp_4,
+            multiple_hcmp_5,
         )
         for fn in functions:
             with self.subTest(fn=fn):

--- a/numba_cuda/numba/cuda/tests/cudapy/test_operator.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_operator.py
@@ -87,27 +87,27 @@ def hlt_func_2(x, y):
     return x < y
 
 
-def test_multiple_hcmp_1(r, a, b, c):
+def multiple_hcmp_1(r, a, b, c):
     # float16 predicates used in two separate functions
     r[0] = hlt_func_1(a, b) and hlt_func_2(b, c)
 
 
-def test_multiple_hcmp_2(r, a, b, c):
+def multiple_hcmp_2(r, a, b, c):
     # The same float16 predicate used in the caller and callee
     r[0] = hlt_func_1(a, b) and b < c
 
 
-def test_multiple_hcmp_3(r, a, b, c):
+def multiple_hcmp_3(r, a, b, c):
     # Different float16 predicates used in the caller and callee
     r[0] = hlt_func_1(a, b) and c >= b
 
 
-def test_multiple_hcmp_4(r, a, b, c):
+def multiple_hcmp_4(r, a, b, c):
     # The same float16 predicates used twice in a function
     r[0] = a < b and b < c
 
 
-def test_multiple_hcmp_5(r, a, b, c):
+def multiple_hcmp_5(r, a, b, c):
     # Different float16 predicates used in a function
     r[0] = a < b and c >= b
 
@@ -331,11 +331,11 @@ class TestOperatorModule(CUDATestCase):
     @skip_unless_cc_53
     def test_multiple_float16_comparisons(self):
         functions = (
-            test_multiple_hcmp_1,
-            test_multiple_hcmp_2,
-            test_multiple_hcmp_3,
-            test_multiple_hcmp_4,
-            test_multiple_hcmp_5,
+            multiple_hcmp_1,
+            multiple_hcmp_2,
+            multiple_hcmp_3,
+            multiple_hcmp_4,
+            multiple_hcmp_5,
         )
         for fn in functions:
             with self.subTest(fn=fn):
@@ -350,11 +350,11 @@ class TestOperatorModule(CUDATestCase):
     @skip_unless_cc_53
     def test_multiple_float16_comparisons_false(self):
         functions = (
-            test_multiple_hcmp_1,
-            test_multiple_hcmp_2,
-            test_multiple_hcmp_3,
-            test_multiple_hcmp_4,
-            test_multiple_hcmp_5,
+            multiple_hcmp_1,
+            multiple_hcmp_2,
+            multiple_hcmp_3,
+            multiple_hcmp_4,
+            multiple_hcmp_5,
         )
         for fn in functions:
             with self.subTest(fn=fn):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,11 @@ include = ["numba_cuda*"]
 [tool.setuptools.package-data]
 "*" = ["*.cu", "*.h", "*.hpp", "*.ptx", "*.cuh", "VERSION", "Makefile"]
 
+[tool.pytest.ini_options]
+minversion = "8.0"
+testpaths = ["numba_cuda/numba/cuda/tests"]
+consider_namespace_packages = true
+
 [tool.ruff]
 line-length = 80
 


### PR DESCRIPTION
Apparently `pytest` was already in dependencies but it was not working. There was no configuration and pytest could not recognize the layout. Now you can both run as file and as a package. Everything works:
```
pytest ./
pytest --pyargs numba.cuda.tests -v
pytest numba_cuda/numba/cuda/tests/cudapy/test_operator.py
```