### PR TITLE
Disable tests that deadlock due to #317

### DIFF
--- a/numba_cuda/numba/cuda/tests/cudadrv/test_streams.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_streams.py
@@ -19,6 +19,7 @@ def with_asyncio_loop(f):
     return runner
 
 
+@unittest.skip("Disabled temporarily due to Issue #317")
 @skip_on_cudasim("CUDA Driver API unsupported in the simulator")
 class TestCudaStream(CUDATestCase):
     def test_add_callback(self):


### PR DESCRIPTION
Temporary until #317 is resolved, because it's creating confusion / hassle with CI and local tests.