### PR TITLE
Remove remaining references/dependencies on `pynvjitlink`

### DIFF
--- a/ci/test_wheel_deps_wheels.sh
+++ b/ci/test_wheel_deps_wheels.sh
@@ -45,6 +45,6 @@ apt remove --purge `dpkg --get-selections | grep cuda-nvvm | awk '{print $1}'` -
 apt remove --purge `dpkg --get-selections | grep cuda-nvrtc | awk '{print $1}'` -y
 
 rapids-logger "Run Tests"
-NUMBA_CUDA_ENABLE_PYNVJITLINK=1 NUMBA_CUDA_TEST_BIN_DIR=$NUMBA_CUDA_TEST_BIN_DIR python -m pytest --pyargs numba.cuda.tests -v
+NUMBA_CUDA_TEST_BIN_DIR=$NUMBA_CUDA_TEST_BIN_DIR python -m pytest --pyargs numba.cuda.tests -v
 
 popd

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -125,11 +125,6 @@ target.
       ``cubinlinker`` and ``ptxcompiler`` packages to be installed. Provides minor
       version compatibility for driver versions less than 12.0.
 
-.. envvar:: NUMBA_CUDA_ENABLE_PYNVJITLINK
-
-   Use ``pynvjitlink`` for minor version compatibility. Requires the ``pynvjitlink``
-   package to be installed. Provides minor version compatibility for driver versions
-   greater than 12.0.
 
 .. envvar:: NUMBA_CUDA_NVRTC_EXTRA_SEARCH_PATHS
 

--- a/docs/source/user/minor_version_compatibility.rst
+++ b/docs/source/user/minor_version_compatibility.rst
@@ -10,8 +10,7 @@ supported by the driver, provided that the Toolkit and driver both have the same
 major version. For example, use of CUDA Toolkit 11.5 with CUDA driver 450 (CUDA
 version 11.0) is supported through MVC.
 
-Numba supports MVC for CUDA 12 on Linux using the external ``pynvjitlink``
-package.
+Numba supports MVC for CUDA 12 on Linux using the `nvjitlink` library.
 
 Numba supports MVC for CUDA 11 on Linux using the external ``cubinlinker`` and
 ``ptxcompiler`` packages, subject to the following limitations:
@@ -45,8 +44,8 @@ To install with pip, use the NVIDIA package index:
 CUDA 12
 ~~~~~~~
 
-For CUDA 12, MVC is provied by default through the ``pynvjitlink``  package,
-which ``numba-cuda`` depends on directly, so no additional installation
+For CUDA 12, MVC is provied by default through the ``nvjitlink``  package,
+which ``numba-cuda[cu12]`` depends on directly, so no additional installation
 steps are required.
 
 Enabling MVC Support
@@ -70,22 +69,6 @@ Numba:
    config.CUDA_ENABLE_MINOR_VERSION_COMPATIBILITY = True
 
 
-CUDA 12
-~~~~~~~
-
-For CUDA 12, MVC support is enabled by default but may be disabled by setting the
-following environment variable or config setting respectively:
-
-.. code:: bash
-
-   export NUMBA_CUDA_ENABLE_PYNVJITLINK=0
-
-or
-
-.. code:: python
-
-   from numba import config
-   config.CUDA_ENABLE_PYNVJITLINK = False
 
 
 References
@@ -95,7 +78,5 @@ Further information about Minor Version Compatibility may be found in:
 
 - The `CUDA Compatibility Guide
   <https://docs.nvidia.com/deploy/cuda-compatibility/index.html>`_.
-- The `README for pynvjitlink
-  <https://github.com/rapidsai/pynvjitlink/blob/main/README.md>`_.
 - The `README for ptxcompiler
   <https://github.com/rapidsai/ptxcompiler/blob/main/README.md>`_.

--- a/numba_cuda/numba/cuda/__init__.py
+++ b/numba_cuda/numba/cuda/__init__.py
@@ -50,7 +50,7 @@ if config.CUDA_USE_NVIDIA_BINDING:
         )
 
 if config.CUDA_ENABLE_PYNVJITLINK:
-    if USE_NV_BINDING:
+    if USE_NV_BINDING and not pynvjitlink_auto_enabled:
         warnings.warn(
             "Explicitly enabling pynvjitlink is no longer necessary. "
             "NVIDIA bindings are enabled. cuda.core will be used "

--- a/numba_cuda/numba/cuda/cudadrv/driver.py
+++ b/numba_cuda/numba/cuda/cudadrv/driver.py
@@ -54,12 +54,6 @@ from .linkable_code import LinkableCode, LTOIR, Fatbin, Object
 from numba.cuda.utils import cached_file_read
 from numba.cuda.cudadrv import enums, drvapi, nvrtc
 
-try:
-    from pynvjitlink.api import NvJitLinker, NvJitLinkError
-except ImportError:
-    NvJitLinker, NvJitLinkError = None, None
-
-
 USE_NV_BINDING = config.CUDA_USE_NVIDIA_BINDING
 
 if USE_NV_BINDING:

--- a/numba_cuda/numba/cuda/decorators.py
+++ b/numba_cuda/numba/cuda/decorators.py
@@ -86,7 +86,7 @@ def jit(
                           number of threads per block.
     :type launch_bounds: int | tuple[int]
     :param lto: Whether to enable LTO. If unspecified, LTO is enabled by
-                default when pynvjitlink is available, except for kernels where
+                default when nvjitlink is available, except for kernels where
                 ``debug=True``.
     :type lto: bool
     """
@@ -143,7 +143,7 @@ def jit(
         raise ValueError("link keyword invalid for device function")
 
     if lto is None:
-        # Default to using LTO if pynvjitlink is available and we're not debugging
+        # Default to using LTO if nvjitlink is available and we're not debugging
         lto = _have_nvjitlink() and not debug
     else:
         if lto and not _have_nvjitlink():

--- a/numba_cuda/numba/cuda/simulator/cudadrv/driver.py
+++ b/numba_cuda/numba/cuda/simulator/cudadrv/driver.py
@@ -3,8 +3,6 @@ Most of the driver API is unsupported in the simulator, but some stubs are
 provided to allow tests to import correctly.
 """
 
-from numba import config
-
 
 def device_memset(dst, val, size, stream=0):
     dst.view("u1")[:size].fill(bytes([val])[0])
@@ -62,11 +60,6 @@ def launch_kernel(*args, **kwargs):
 
 
 USE_NV_BINDING = False
-
-PyNvJitLinker = None
-
-if config.ENABLE_CUDASIM:
-    config.CUDA_ENABLE_PYNVJITLINK = False
 
 
 def _have_nvjitlink():

--- a/numba_cuda/numba/cuda/tests/cudapy/test_errors.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_errors.py
@@ -90,7 +90,7 @@ class TestJitErrors(CUDATestCase):
         self.assertIn("resolving callee type: type(CUDADispatcher", excstr)
         self.assertIn("NameError: name 'floor' is not defined", excstr)
 
-    @skip_on_cudasim("Simulator does not use pynvjitlink")
+    @skip_on_cudasim("Simulator does not use nvjitlink")
     @unittest.skipIf(
         config.CUDA_USE_NVIDIA_BINDING, "NVIDIA cuda bindings enabled"
     )

--- a/numba_cuda/numba/cuda/tests/test_binary_generation/Makefile
+++ b/numba_cuda/numba/cuda/tests/test_binary_generation/Makefile
@@ -1,4 +1,4 @@
-# Generates the input files used by the pynvjitlink binding test suite
+# Generates the input files used by the nvjitlink tests
 
 # Test binaries are built taking into account the CC of the GPU in the test machine
 GPU_CC := $(shell nvidia-smi --query-gpu=compute_cap --format=csv | grep -v compute_cap | head -n 1 | sed 's/\.//')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ test-cu11 = [
 test-cu12 = [
     "numba-cuda[test]",
     "nvidia-curand-cu12",
-    "pynvjitlink-cu12",
 ]
 dev = [
     "pre-commit",


### PR DESCRIPTION
- Removes any straggling references to `pynvjitlink` from the codebase and tests
- Clean up a place where we still depend on it for our wheel
- Fix logic that shouldn't warn if it happens to be present