### PR TITLE
Relax subclass check in vendored in typing templates

### DIFF
--- a/numba_cuda/numba/cuda/typing/templates.py
+++ b/numba_cuda/numba/cuda/typing/templates.py
@@ -1355,12 +1355,18 @@ class Registry(object):
         self.globals = []
 
     def register(self, item):
-        assert issubclass(item, FunctionTemplate)
+        assert issubclass(
+            item,
+            (FunctionTemplate, numba.core.typing.templates.FunctionTemplate),
+        )
         self.functions.append(item)
         return item
 
     def register_attr(self, item):
-        assert issubclass(item, AttributeTemplate)
+        assert issubclass(
+            item,
+            (AttributeTemplate, numba.core.typing.templates.AttributeTemplate),
+        )
         self.attributes.append(item)
         return item
 


### PR DESCRIPTION
Relaxes subclass check for Function and AbstractTemplate as an interim solution for nvmath-python until next release of Numba CUDA.