### PR TITLE
Add locals attribute to _FunctionCompiler

### DIFF
--- a/numba_cuda/numba/cuda/dispatcher.py
+++ b/numba_cuda/numba/cuda/dispatcher.py
@@ -773,6 +773,7 @@ class _FunctionCompiler(object):
         self.py_func = py_func
         self.targetdescr = targetdescr
         self.targetoptions = targetoptions
+        self.locals = {}
         self.pysig = utils.pysignature(self.py_func)
         self.pipeline_class = pipeline_class
         # Remember key=(args, return_type) combinations that will fail
@@ -843,7 +844,7 @@ class _FunctionCompiler(object):
             args=args,
             return_type=return_type,
             flags=flags,
-            locals={},
+            locals=self.locals,
             pipeline_class=self.pipeline_class,
         )
         # Check typing error if object mode is used

--- a/numba_cuda/numba/cuda/tests/cudapy/test_compiler.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_compiler.py
@@ -252,6 +252,21 @@ class TestCompile(unittest.TestCase):
                 output=illegal_output,
             )
 
+    def test_functioncompiler_locals(self):
+        # Tests against regression fixed in:
+        # https://github.com/NVIDIA/numba-cuda/pull/381
+        #
+        # "AttributeError: '_FunctionCompiler' object has no attribute
+        # 'locals'"
+        cond = None
+
+        @cuda.jit("void(float32[::1])")
+        def f(b_arg):
+            b_smem = cuda.shared.array(shape=(1,), dtype=float32)
+
+            if cond:
+                b_smem[0] = b_arg[0]
+
 
 @skip_on_cudasim("Compilation unsupported in the simulator")
 class TestCompileForCurrentDevice(CUDATestCase):


### PR DESCRIPTION
We had initially removed the `locals` attribute from `_FunctionCompiler` while vendoring it in for CUDA-Specific changes in https://github.com/NVIDIA/numba-cuda/pull/338. This seemed to have caused `AttributeError` for a nvmath-python test https://github.com/NVIDIA/nvmath-python/blob/main/tests/nvmath_tests/device/test_cublasdx_numba.py. This PR restores this `locals` attribute and initializes it to `{}`