### PR TITLE
Fix package clobbering in thirdparty CI tests

### DIFF
--- a/ci/test_thirdparty.sh
+++ b/ci/test_thirdparty.sh
@@ -5,6 +5,15 @@ set -euo pipefail
 
 CUDA_VER_MAJOR_MINOR=${CUDA_VER%.*}
 
+rapids-logger "Install cuDF Wheel"
+pip install \
+    --extra-index-url=https://pypi.nvidia.com \
+    "cudf-cu12==25.6.*"
+
+
+rapids-logger "Remove Extraneous numba-cuda"
+pip uninstall -y numba-cuda
+
 rapids-logger "Install wheel with test dependencies"
 package=$(realpath wheel/numba_cuda*.whl)
 echo "Package path: ${package}"
@@ -13,11 +22,6 @@ python -m pip install \
     "cuda-python==${CUDA_VER_MAJOR_MINOR%.*}.*" \
     "cuda-core==0.3.*" \
 
-
-rapids-logger "Install cuDF Wheel"
-pip install \
-    --extra-index-url=https://pypi.nvidia.com \
-    "cudf-cu12==25.6.*"
 
 rapids-logger "Shallow clone cuDF repository"
 git clone --single-branch --branch 'branch-25.06' https://github.com/rapidsai/cudf.git


### PR DESCRIPTION
In our thirdparty CI tests, installation of the cuDF package is clobbering the branch version of numba-cuda we actually want to test. Ran into this when cuDF failed to import locally using `main` and trying to track down why it didn't show up in CI.

This PR will include fixes for things that are broken, currently cuDF fails to import due to an instance check against upstream numba's `AttributeTemplate` class. 