### PR TITLE
[Refactor] Vendor in typing.npydecl, typing.BaseContext, typing.Context for CUDA-specific changes

### DIFF
--- a/numba_cuda/numba/cuda/core/ir_utils.py
+++ b/numba_cuda/numba/cuda/core/ir_utils.py
@@ -12,7 +12,8 @@ import warnings
 
 import numba
 from numba.core.extending import _Intrinsic
-from numba.core import types, typing, ir, analysis, postproc, rewrites, config
+from numba.core import types, ir, analysis, postproc, rewrites, config
+from numba.cuda import typing
 from numba.core.typing.templates import signature
 from numba.core.analysis import (
     compute_live_map,

--- a/numba_cuda/numba/cuda/cudadecl.py
+++ b/numba_cuda/numba/cuda/cudadecl.py
@@ -1,5 +1,5 @@
 from numba.core import errors, types
-from numba.core.typing.npydecl import (
+from numba.cuda.typing.npydecl import (
     parse_dtype,
     parse_shape,
     register_number_classes,

--- a/numba_cuda/numba/cuda/cudaimpl.py
+++ b/numba_cuda/numba/cuda/cudaimpl.py
@@ -7,7 +7,7 @@ from llvmlite import ir
 import llvmlite.binding as ll
 
 from numba.core.imputils import Registry
-from numba.core.typing.npydecl import parse_dtype
+from numba.cuda.typing.npydecl import parse_dtype
 from numba.core.datamodel import models
 from numba.core import types
 from numba.cuda import cgutils

--- a/numba_cuda/numba/cuda/dispatcher.py
+++ b/numba_cuda/numba/cuda/dispatcher.py
@@ -8,8 +8,8 @@ import types as pytypes
 import weakref
 import uuid
 
-from numba.core import compiler, types, typing, config
-from numba.cuda import serialize, utils
+from numba.core import compiler, types, config
+from numba.cuda import serialize, utils, typing
 from numba.cuda.core.caching import Cache, CacheImpl, NullCache
 from numba.core.compiler_lock import global_compiler_lock
 from numba.core.dispatcher import _DispatcherBase

--- a/numba_cuda/numba/cuda/target.py
+++ b/numba_cuda/numba/cuda/target.py
@@ -9,7 +9,6 @@ from numba.core import (
     config,
     targetconfig,
     types,
-    typing,
 )
 from numba.core.compiler_lock import global_compiler_lock
 from numba.core.dispatcher import Dispatcher
@@ -20,7 +19,7 @@ from numba.core.typing import cmathdecl
 from numba.core import datamodel
 
 from .cudadrv import nvvm
-from numba.cuda import codegen, ufuncs
+from numba.cuda import codegen, ufuncs, typing
 from numba.cuda.debuginfo import CUDADIBuilder
 from numba.cuda.flags import CUDAFlags
 from numba.cuda.models import cuda_data_manager

--- a/numba_cuda/numba/cuda/typing/__init__.py
+++ b/numba_cuda/numba/cuda/typing/__init__.py
@@ -4,5 +4,13 @@ from .templates import (
     Signature,
     fold_arguments,
 )
+from .context import BaseContext, Context
 
-__all__ = ["signature", "make_concrete_template", "Signature", "fold_arguments"]
+__all__ = [
+    "signature",
+    "make_concrete_template",
+    "Signature",
+    "fold_arguments",
+    "BaseContext",
+    "Context",
+]

--- a/numba_cuda/numba/cuda/typing/context.py
+++ b/numba_cuda/numba/cuda/typing/context.py
@@ -1,0 +1,748 @@
+from collections import defaultdict
+from collections.abc import Sequence
+import types as pytypes
+import weakref
+import threading
+import contextlib
+import operator
+
+from numba.core import types, errors
+from numba.core.typeconv import Conversion, rules
+from numba.core.typing.typeof import typeof, Purpose
+from numba.core.typing import templates
+from numba.cuda import utils
+from numba.cuda.utils import order_by_target_specificity
+
+
+class Rating(object):
+    __slots__ = "promote", "safe_convert", "unsafe_convert"
+
+    def __init__(self):
+        self.promote = 0
+        self.safe_convert = 0
+        self.unsafe_convert = 0
+
+    def astuple(self):
+        """Returns a tuple suitable for comparing with the worse situation
+        start first.
+        """
+        return (self.unsafe_convert, self.safe_convert, self.promote)
+
+    def __add__(self, other):
+        if type(self) is not type(other):
+            return NotImplemented
+        rsum = Rating()
+        rsum.promote = self.promote + other.promote
+        rsum.safe_convert = self.safe_convert + other.safe_convert
+        rsum.unsafe_convert = self.unsafe_convert + other.unsafe_convert
+        return rsum
+
+
+class CallStack(Sequence):
+    """
+    A compile-time call stack
+    """
+
+    def __init__(self):
+        self._stack = []
+        self._lock = threading.RLock()
+
+    def __getitem__(self, index):
+        """
+        Returns item in the stack where index=0 is the top and index=1 is
+        the second item from the top.
+        """
+        return self._stack[len(self) - index - 1]
+
+    def __len__(self):
+        return len(self._stack)
+
+    @contextlib.contextmanager
+    def register(self, target, typeinfer, func_id, args):
+        # guard compiling the same function with the same signature
+        if self.match(func_id.func, args):
+            msg = "compiler re-entrant to the same function signature"
+            raise errors.NumbaRuntimeError(msg)
+        self._lock.acquire()
+        self._stack.append(CallFrame(target, typeinfer, func_id, args))
+        try:
+            yield
+        finally:
+            self._stack.pop()
+            self._lock.release()
+
+    def finditer(self, py_func):
+        """
+        Yields frame that matches the function object starting from the top
+        of stack.
+        """
+        for frame in self:
+            if frame.func_id.func is py_func:
+                yield frame
+
+    def findfirst(self, py_func):
+        """
+        Returns the first result from `.finditer(py_func)`; or None if no match.
+        """
+        try:
+            return next(self.finditer(py_func))
+        except StopIteration:
+            return
+
+    def match(self, py_func, args):
+        """
+        Returns first function that matches *py_func* and the arguments types in
+        *args*; or, None if no match.
+        """
+        for frame in self.finditer(py_func):
+            if frame.args == args:
+                return frame
+
+
+class CallFrame(object):
+    """
+    A compile-time call frame
+    """
+
+    def __init__(self, target, typeinfer, func_id, args):
+        self.typeinfer = typeinfer
+        self.func_id = func_id
+        self.args = args
+        self.target = target
+        self._inferred_retty = set()
+
+    def __repr__(self):
+        return "CallFrame({}, {})".format(self.func_id, self.args)
+
+    def add_return_type(self, return_type):
+        """Add *return_type* to the list of inferred return-types.
+        If there are too many, raise `TypingError`.
+        """
+        # The maximum limit is picked arbitrarily.
+        # Don't think that this needs to be user configurable.
+        RETTY_LIMIT = 16
+        self._inferred_retty.add(return_type)
+        if len(self._inferred_retty) >= RETTY_LIMIT:
+            m = "Return type of recursive function does not converge"
+            raise errors.TypingError(m)
+
+
+class BaseContext(object):
+    """A typing context for storing function typing constrain template."""
+
+    def __init__(self):
+        # A list of installed registries
+        self._registries = {}
+        # Typing declarations extracted from the registries or other sources
+        self._functions = defaultdict(list)
+        self._attributes = defaultdict(list)
+        self._globals = utils.UniqueDict()
+        self.tm = rules.default_type_manager
+        self.callstack = CallStack()
+
+        # Initialize
+        self.init()
+
+    def init(self):
+        """
+        Initialize the typing context.  Can be overridden by subclasses.
+        """
+
+    def refresh(self):
+        """
+        Refresh context with new declarations from known registries.
+        Useful for third-party extensions.
+        """
+        self.load_additional_registries()
+        # Some extensions may have augmented the builtin registry
+        self._load_builtins()
+
+    def explain_function_type(self, func):
+        """
+        Returns a string description of the type of a function
+        """
+        desc = []
+        defns = []
+        param = False
+        if isinstance(func, types.Callable):
+            sigs, param = func.get_call_signatures()
+            defns.extend(sigs)
+
+        elif func in self._functions:
+            for tpl in self._functions[func]:
+                param = param or hasattr(tpl, "generic")
+                defns.extend(getattr(tpl, "cases", []))
+
+        else:
+            msg = "No type info available for {func!r} as a callable."
+            desc.append(msg.format(func=func))
+
+        if defns:
+            desc = ["Known signatures:"]
+            for sig in defns:
+                desc.append(" * {0}".format(sig))
+
+        return "\n".join(desc)
+
+    def resolve_function_type(self, func, args, kws):
+        """
+        Resolve function type *func* for argument types *args* and *kws*.
+        A signature is returned.
+        """
+        # Prefer user definition first
+        try:
+            res = self._resolve_user_function_type(func, args, kws)
+        except errors.TypingError as e:
+            # Capture any typing error
+            last_exception = e
+            res = None
+        else:
+            last_exception = None
+
+        # Return early we know there's a working user function
+        if res is not None:
+            return res
+
+        # Check builtin functions
+        res = self._resolve_builtin_function_type(func, args, kws)
+
+        # Re-raise last_exception if no function type has been found
+        if res is None and last_exception is not None:
+            raise last_exception
+
+        return res
+
+    def _resolve_builtin_function_type(self, func, args, kws):
+        # NOTE: we should reduce usage of this
+        if func in self._functions:
+            # Note: Duplicating code with types.Function.get_call_type().
+            #       *defns* are CallTemplates.
+            defns = self._functions[func]
+            for defn in defns:
+                for support_literals in [True, False]:
+                    if support_literals:
+                        res = defn.apply(args, kws)
+                    else:
+                        fixedargs = [types.unliteral(a) for a in args]
+                        res = defn.apply(fixedargs, kws)
+                    if res is not None:
+                        return res
+
+    def _resolve_user_function_type(self, func, args, kws, literals=None):
+        # It's not a known function type, perhaps it's a global?
+        functy = self._lookup_global(func)
+        if functy is not None:
+            func = functy
+
+        if isinstance(func, types.Type):
+            # If it's a type, it may support a __call__ method
+            func_type = self.resolve_getattr(func, "__call__")
+            if func_type is not None:
+                # The function has a __call__ method, type its call.
+                return self.resolve_function_type(func_type, args, kws)
+
+        if isinstance(func, types.Callable):
+            # XXX fold this into the __call__ attribute logic?
+            return func.get_call_type(self, args, kws)
+
+    def _get_attribute_templates(self, typ):
+        """
+        Get matching AttributeTemplates for the Numba type.
+        """
+        if typ in self._attributes:
+            for attrinfo in self._attributes[typ]:
+                yield attrinfo
+        else:
+            for cls in type(typ).__mro__:
+                if cls in self._attributes:
+                    for attrinfo in self._attributes[cls]:
+                        yield attrinfo
+
+    def resolve_getattr(self, typ, attr):
+        """
+        Resolve getting the attribute *attr* (a string) on the Numba type.
+        The attribute's type is returned, or None if resolution failed.
+        """
+
+        def core(typ):
+            out = self.find_matching_getattr_template(typ, attr)
+            if out:
+                return out["return_type"]
+
+        out = core(typ)
+        if out is not None:
+            return out
+
+        # Try again without literals
+        out = core(types.unliteral(typ))
+        if out is not None:
+            return out
+
+        if isinstance(typ, types.Module):
+            attrty = self.resolve_module_constants(typ, attr)
+            if attrty is not None:
+                return attrty
+
+    def find_matching_getattr_template(self, typ, attr):
+        templates = list(self._get_attribute_templates(typ))
+
+        # get the order in which to try templates
+        from numba.core.target_extension import get_local_target  # circular
+
+        target_hw = get_local_target(self)
+        order = order_by_target_specificity(target_hw, templates, fnkey=attr)
+
+        for template in order:
+            return_type = template.resolve(typ, attr)
+            if return_type is not None:
+                return {
+                    "template": template,
+                    "return_type": return_type,
+                }
+
+    def resolve_setattr(self, target, attr, value):
+        """
+        Resolve setting the attribute *attr* (a string) on the *target* type
+        to the given *value* type.
+        A function signature is returned, or None if resolution failed.
+        """
+        for attrinfo in self._get_attribute_templates(target):
+            expectedty = attrinfo.resolve(target, attr)
+            # NOTE: convertibility from *value* to *expectedty* is left to
+            # the caller.
+            if expectedty is not None:
+                return templates.signature(types.void, target, expectedty)
+
+    def resolve_static_getitem(self, value, index):
+        assert not isinstance(index, types.Type), index
+        args = value, index
+        kws = ()
+        return self.resolve_function_type("static_getitem", args, kws)
+
+    def resolve_static_setitem(self, target, index, value):
+        assert not isinstance(index, types.Type), index
+        args = target, index, value
+        kws = {}
+        return self.resolve_function_type("static_setitem", args, kws)
+
+    def resolve_setitem(self, target, index, value):
+        assert isinstance(index, types.Type), index
+        fnty = self.resolve_value_type(operator.setitem)
+        sig = fnty.get_call_type(self, (target, index, value), {})
+        return sig
+
+    def resolve_delitem(self, target, index):
+        args = target, index
+        kws = {}
+        fnty = self.resolve_value_type(operator.delitem)
+        sig = fnty.get_call_type(self, args, kws)
+        return sig
+
+    def resolve_module_constants(self, typ, attr):
+        """
+        Resolve module-level global constants.
+        Return None or the attribute type
+        """
+        assert isinstance(typ, types.Module)
+        attrval = getattr(typ.pymod, attr)
+        try:
+            return self.resolve_value_type(attrval)
+        except ValueError:
+            pass
+
+    def resolve_value_type(self, val):
+        """
+        Return the numba type of a Python value that is being used
+        as a runtime constant.
+        ValueError is raised for unsupported types.
+        """
+        try:
+            ty = typeof(val, Purpose.constant)
+        except ValueError as e:
+            # Make sure the exception doesn't hold a reference to the user
+            # value.
+            typeof_exc = utils.erase_traceback(e)
+        else:
+            return ty
+
+        if isinstance(val, types.ExternalFunction):
+            return val
+
+        # Try to look up target specific typing information
+        ty = self._get_global_type(val)
+        if ty is not None:
+            return ty
+
+        raise typeof_exc
+
+    def resolve_value_type_prefer_literal(self, value):
+        """Resolve value type and prefer Literal types whenever possible."""
+        lit = types.maybe_literal(value)
+        if lit is None:
+            return self.resolve_value_type(value)
+        else:
+            return lit
+
+    def _get_global_type(self, gv):
+        ty = self._lookup_global(gv)
+        if ty is not None:
+            return ty
+        if isinstance(gv, pytypes.ModuleType):
+            return types.Module(gv)
+
+    def _load_builtins(self):
+        # Initialize declarations
+        from numba.core.typing import builtins, arraydecl, npdatetime  # noqa: F401, E501
+        from numba.core.typing import ctypes_utils, bufproto  # noqa: F401, E501
+        from numba.core.unsafe import eh  # noqa: F401
+
+        self.install_registry(templates.builtin_registry)
+
+    def load_additional_registries(self):
+        """
+        Load target-specific registries.  Can be overridden by subclasses.
+        """
+
+    def install_registry(self, registry):
+        """
+        Install a *registry* (a templates.Registry instance) of function,
+        attribute and global declarations.
+        """
+        try:
+            loader = self._registries[registry]
+        except KeyError:
+            loader = templates.RegistryLoader(registry)
+            self._registries[registry] = loader
+
+        from numba.core.target_extension import (
+            get_local_target,
+            resolve_target_str,
+        )
+
+        current_target = get_local_target(self)
+
+        def is_for_this_target(ftcls):
+            metadata = getattr(ftcls, "metadata", None)
+            if metadata is None:
+                return True
+
+            target_str = metadata.get("target")
+            if target_str is None:
+                return True
+
+            # There may be pending registrations for nonexistent targets.
+            # Ideally it would be impossible to leave a registration pending
+            # for an invalid target, but in practice this is exceedingly
+            # difficult to guard against - many things are registered at import
+            # time, and eagerly reporting an error when registering for invalid
+            # targets would require that all target registration code is
+            # executed prior to all typing registrations during the import
+            # process; attempting to enforce this would impose constraints on
+            # execution order during import that would be very difficult to
+            # resolve and maintain in the presence of typical code maintenance.
+            # Furthermore, these constraints would be imposed not only on
+            # Numba internals, but also on its dependents.
+            #
+            # Instead of that enforcement, we simply catch any occurrences of
+            # registrations for targets that don't exist, and report that
+            # they're not for this target. They will then not be encountered
+            # again during future typing context refreshes (because the
+            # loader's new registrations are a stream_list that doesn't yield
+            # previously-yielded items).
+            try:
+                ft_target = resolve_target_str(target_str)
+            except errors.NonexistentTargetError:
+                return False
+
+            return current_target.inherits_from(ft_target)
+
+        for ftcls in loader.new_registrations("functions"):
+            if not is_for_this_target(ftcls):
+                continue
+            self.insert_function(ftcls(self))
+        for ftcls in loader.new_registrations("attributes"):
+            if not is_for_this_target(ftcls):
+                continue
+            self.insert_attributes(ftcls(self))
+        for gv, gty in loader.new_registrations("globals"):
+            existing = self._lookup_global(gv)
+            if existing is None:
+                self.insert_global(gv, gty)
+            else:
+                # A type was already inserted, see if we can add to it
+                newty = existing.augment(gty)
+                if newty is None:
+                    raise TypeError(
+                        "cannot augment %s with %s" % (existing, gty)
+                    )
+                self._remove_global(gv)
+                self._insert_global(gv, newty)
+
+    def _lookup_global(self, gv):
+        """
+        Look up the registered type for global value *gv*.
+        """
+        try:
+            gv = weakref.ref(gv)
+        except TypeError:
+            pass
+        try:
+            return self._globals.get(gv, None)
+        except TypeError:
+            # Unhashable type
+            return None
+
+    def _insert_global(self, gv, gty):
+        """
+        Register type *gty* for value *gv*.  Only a weak reference
+        to *gv* is kept, if possible.
+        """
+
+        def on_disposal(wr, pop=self._globals.pop):
+            # pop() is pre-looked up to avoid a crash late at shutdown on 3.5
+            # (https://bugs.python.org/issue25217)
+            pop(wr)
+
+        try:
+            gv = weakref.ref(gv, on_disposal)
+        except TypeError:
+            pass
+        self._globals[gv] = gty
+
+    def _remove_global(self, gv):
+        """
+        Remove the registered type for global value *gv*.
+        """
+        try:
+            gv = weakref.ref(gv)
+        except TypeError:
+            pass
+        del self._globals[gv]
+
+    def insert_global(self, gv, gty):
+        self._insert_global(gv, gty)
+
+    def insert_attributes(self, at):
+        key = at.key
+        self._attributes[key].append(at)
+
+    def insert_function(self, ft):
+        key = ft.key
+        self._functions[key].append(ft)
+
+    def insert_user_function(self, fn, ft):
+        """Insert a user function.
+
+        Args
+        ----
+        - fn:
+            object used as callee
+        - ft:
+            function template
+        """
+        self._insert_global(fn, types.Function(ft))
+
+    def can_convert(self, fromty, toty):
+        """
+        Check whether conversion is possible from *fromty* to *toty*.
+        If successful, return a numba.typeconv.Conversion instance;
+        otherwise None is returned.
+        """
+        if fromty == toty:
+            return Conversion.exact
+        else:
+            # First check with the type manager (some rules are registered
+            # at startup there, see numba.typeconv.rules)
+            conv = self.tm.check_compatible(fromty, toty)
+            if conv is not None:
+                return conv
+
+            # Fall back on type-specific rules
+            forward = fromty.can_convert_to(self, toty)
+            backward = toty.can_convert_from(self, fromty)
+            if backward is None:
+                return forward
+            elif forward is None:
+                return backward
+            else:
+                return min(forward, backward)
+
+    def _rate_arguments(
+        self,
+        actualargs,
+        formalargs,
+        unsafe_casting=True,
+        exact_match_required=False,
+    ):
+        """
+        Rate the actual arguments for compatibility against the formal
+        arguments.  A Rating instance is returned, or None if incompatible.
+        """
+        if len(actualargs) != len(formalargs):
+            return None
+        rate = Rating()
+        for actual, formal in zip(actualargs, formalargs):
+            conv = self.can_convert(actual, formal)
+            if conv is None:
+                return None
+            elif not unsafe_casting and conv >= Conversion.unsafe:
+                return None
+            elif exact_match_required and conv != Conversion.exact:
+                return None
+
+            if conv == Conversion.promote:
+                rate.promote += 1
+            elif conv == Conversion.safe:
+                rate.safe_convert += 1
+            elif conv == Conversion.unsafe:
+                rate.unsafe_convert += 1
+            elif conv == Conversion.exact:
+                pass
+            else:
+                raise AssertionError("unreachable", conv)
+
+        return rate
+
+    def install_possible_conversions(self, actualargs, formalargs):
+        """
+        Install possible conversions from the actual argument types to
+        the formal argument types in the C++ type manager.
+        Return True if all arguments can be converted.
+        """
+        if len(actualargs) != len(formalargs):
+            return False
+        for actual, formal in zip(actualargs, formalargs):
+            if self.tm.check_compatible(actual, formal) is not None:
+                # This conversion is already known
+                continue
+            conv = self.can_convert(actual, formal)
+            if conv is None:
+                return False
+            assert conv is not Conversion.exact
+            self.tm.set_compatible(actual, formal, conv)
+        return True
+
+    def resolve_overload(
+        self,
+        key,
+        cases,
+        args,
+        kws,
+        allow_ambiguous=True,
+        unsafe_casting=True,
+        exact_match_required=False,
+    ):
+        """
+        Given actual *args* and *kws*, find the best matching
+        signature in *cases*, or None if none matches.
+        *key* is used for error reporting purposes.
+        If *allow_ambiguous* is False, a tie in the best matches
+        will raise an error.
+        If *unsafe_casting* is False, unsafe casting is forbidden.
+        """
+        assert not kws, "Keyword arguments are not supported, yet"
+        options = {
+            "unsafe_casting": unsafe_casting,
+            "exact_match_required": exact_match_required,
+        }
+        # Rate each case
+        candidates = []
+        for case in cases:
+            if len(args) == len(case.args):
+                rating = self._rate_arguments(args, case.args, **options)
+                if rating is not None:
+                    candidates.append((rating.astuple(), case))
+
+        # Find the best case
+        candidates.sort(key=lambda i: i[0])
+        if candidates:
+            best_rate, best = candidates[0]
+            if not allow_ambiguous:
+                # Find whether there is a tie and if so, raise an error
+                tied = []
+                for rate, case in candidates:
+                    if rate != best_rate:
+                        break
+                    tied.append(case)
+                if len(tied) > 1:
+                    args = (key, args, "\n".join(map(str, tied)))
+                    msg = "Ambiguous overloading for %s %s:\n%s" % args
+                    raise TypeError(msg)
+            # Simply return the best matching candidate in order.
+            # If there is a tie, since list.sort() is stable, the first case
+            # in the original order is returned.
+            # (this can happen if e.g. a function template exposes
+            #  (int32, int32) -> int32 and (int64, int64) -> int64,
+            #  and you call it with (int16, int16) arguments)
+            return best
+
+    def unify_types(self, *typelist):
+        # Sort the type list according to bit width before doing
+        # pairwise unification (with thanks to aterrel).
+        def keyfunc(obj):
+            """Uses bitwidth to order numeric-types.
+            Fallback to stable, deterministic sort.
+            """
+            return getattr(obj, "bitwidth", 0)
+
+        typelist = sorted(typelist, key=keyfunc)
+        unified = typelist[0]
+        for tp in typelist[1:]:
+            unified = self.unify_pairs(unified, tp)
+            if unified is None:
+                break
+        return unified
+
+    def unify_pairs(self, first, second):
+        """
+        Try to unify the two given types.  A third type is returned,
+        or None in case of failure.
+        """
+        if first == second:
+            return first
+
+        if first is types.undefined:
+            return second
+        elif second is types.undefined:
+            return first
+
+        # Types with special unification rules
+        unified = first.unify(self, second)
+        if unified is not None:
+            return unified
+
+        unified = second.unify(self, first)
+        if unified is not None:
+            return unified
+
+        # Other types with simple conversion rules
+        conv = self.can_convert(fromty=first, toty=second)
+        if conv is not None and conv <= Conversion.safe:
+            # Can convert from first to second
+            return second
+
+        conv = self.can_convert(fromty=second, toty=first)
+        if conv is not None and conv <= Conversion.safe:
+            # Can convert from second to first
+            return first
+
+        if isinstance(first, types.Literal) or isinstance(
+            second, types.Literal
+        ):
+            first = types.unliteral(first)
+            second = types.unliteral(second)
+            return self.unify_pairs(first, second)
+
+        # Cannot unify
+        return None
+
+
+class Context(BaseContext):
+    # This list will be extended to include all the registries
+    # that are needed for CUDA
+    def load_additional_registries(self):
+        from . import (
+            npydecl,
+        )
+
+        self.install_registry(npydecl.registry)

--- a/numba_cuda/numba/cuda/typing/npydecl.py
+++ b/numba_cuda/numba/cuda/typing/npydecl.py
@@ -1,0 +1,657 @@
+import numpy as np
+import operator
+
+from numba.cuda.typing.templates import AbstractTemplate, Registry, signature
+from numba.core import types
+from numba.cuda import utils
+from numba.core.errors import TypingError, NumbaTypeError
+from numba import pndindex
+from numba.np.numpy_support import (
+    ufunc_find_matching_loop,
+    supported_ufunc_loop,
+    from_dtype,
+    as_dtype,
+    resolve_output_type,
+    _ufunc_loop_sig,
+)
+
+registry = Registry()
+infer = registry.register
+infer_global = registry.register_global
+infer_getattr = registry.register_attr
+
+
+class Numpy_rules_ufunc(AbstractTemplate):
+    @classmethod
+    def _handle_inputs(cls, ufunc, args, kws):
+        """
+        Process argument types to a given *ufunc*.
+        Returns a (base types, explicit outputs, ndims, layout) tuple where:
+        - `base types` is a tuple of scalar types for each input
+        - `explicit outputs` is a tuple of explicit output types (arrays)
+        - `ndims` is the number of dimensions of the loop and also of
+          any outputs, explicit or implicit
+        - `layout` is the layout for any implicit output to be allocated
+        """
+        nin = ufunc.nin
+        nout = ufunc.nout
+        nargs = ufunc.nargs
+
+        # preconditions
+        assert nargs == nin + nout
+
+        if len(args) < nin:
+            msg = "ufunc '{0}': not enough arguments ({1} found, {2} required)"
+            raise TypingError(msg=msg.format(ufunc.__name__, len(args), nin))
+
+        if len(args) > nargs:
+            msg = "ufunc '{0}': too many arguments ({1} found, {2} maximum)"
+            raise TypingError(msg=msg.format(ufunc.__name__, len(args), nargs))
+
+        args = [
+            a.as_array if isinstance(a, types.ArrayCompatible) else a
+            for a in args
+        ]
+        arg_ndims = [
+            a.ndim if isinstance(a, types.ArrayCompatible) else 0 for a in args
+        ]
+        ndims = max(arg_ndims)
+
+        # explicit outputs must be arrays (no explicit scalar return values supported)
+        explicit_outputs = args[nin:]
+
+        if not all(
+            isinstance(output, types.ArrayCompatible)
+            for output in explicit_outputs
+        ):
+            msg = "ufunc '{0}' called with an explicit output that is not an array"
+            raise TypingError(msg=msg.format(ufunc.__name__))
+
+        if not all(output.mutable for output in explicit_outputs):
+            msg = "ufunc '{0}' called with an explicit output that is read-only"
+            raise TypingError(msg=msg.format(ufunc.__name__))
+
+        # find the kernel to use, based only in the input types (as does NumPy)
+        base_types = [
+            x.dtype if isinstance(x, types.ArrayCompatible) else x for x in args
+        ]
+
+        # Figure out the output array layout, if needed.
+        layout = None
+        if ndims > 0 and (len(explicit_outputs) < ufunc.nout):
+            layout = "C"
+            layouts = [
+                x.layout if isinstance(x, types.ArrayCompatible) else ""
+                for x in args
+            ]
+
+            # Prefer C contig if any array is C contig.
+            # Next, prefer F contig.
+            # Defaults to C contig if not layouts are C/F.
+            if "C" not in layouts and "F" in layouts:
+                layout = "F"
+
+        return base_types, explicit_outputs, ndims, layout
+
+    @property
+    def ufunc(self):
+        return self.key
+
+    def generic(self, args, kws):
+        # First, strip optional types, ufunc loops are typed on concrete types
+        args = [x.type if isinstance(x, types.Optional) else x for x in args]
+
+        ufunc = self.ufunc
+        base_types, explicit_outputs, ndims, layout = self._handle_inputs(
+            ufunc, args, kws
+        )
+        ufunc_loop = ufunc_find_matching_loop(ufunc, base_types)
+        if ufunc_loop is None:
+            raise TypingError(
+                "can't resolve ufunc {0} for types {1}".format(
+                    ufunc.__name__, args
+                )
+            )
+
+        # check if all the types involved in the ufunc loop are supported in this mode
+        if not supported_ufunc_loop(ufunc, ufunc_loop):
+            msg = "ufunc '{0}' using the loop '{1}' not supported in this mode"
+            raise TypingError(
+                msg=msg.format(ufunc.__name__, ufunc_loop.ufunc_sig)
+            )
+
+        # if there is any explicit output type, check that it is valid
+        explicit_outputs_np = [as_dtype(tp.dtype) for tp in explicit_outputs]
+
+        # Numpy will happily use unsafe conversions (although it will actually warn)
+        if not all(
+            np.can_cast(fromty, toty, "unsafe")
+            for (fromty, toty) in zip(
+                ufunc_loop.numpy_outputs, explicit_outputs_np
+            )
+        ):
+            msg = "ufunc '{0}' can't cast result to explicit result type"
+            raise TypingError(msg=msg.format(ufunc.__name__))
+
+        # A valid loop was found that is compatible. The result of type inference should
+        # be based on the explicit output types, and when not available with the type given
+        # by the selected NumPy loop
+        out = list(explicit_outputs)
+        implicit_output_count = ufunc.nout - len(explicit_outputs)
+        if implicit_output_count > 0:
+            # XXX this is sometimes wrong for datetime64 and timedelta64,
+            # as ufunc_find_matching_loop() doesn't do any type inference
+            ret_tys = ufunc_loop.outputs[-implicit_output_count:]
+            if ndims > 0:
+                assert layout is not None
+                # If either of the types involved in the ufunc operation have a
+                # __array_ufunc__ method then invoke the first such one to
+                # determine the output type of the ufunc.
+                array_ufunc_type = None
+                for a in args:
+                    if hasattr(a, "__array_ufunc__"):
+                        array_ufunc_type = a
+                        break
+                output_type = types.Array
+                if array_ufunc_type is not None:
+                    output_type = array_ufunc_type.__array_ufunc__(
+                        ufunc, "__call__", *args, **kws
+                    )
+                    if output_type is NotImplemented:
+                        msg = (
+                            f"unsupported use of ufunc {ufunc} on "
+                            f"{array_ufunc_type}"
+                        )
+                        # raise TypeError here because
+                        # NumpyRulesArrayOperator.generic is capturing
+                        # TypingError
+                        raise NumbaTypeError(msg)
+                    elif not issubclass(output_type, types.Array):
+                        msg = (
+                            f"ufunc {ufunc} on {array_ufunc_type}"
+                            f"cannot return non-array {output_type}"
+                        )
+                        # raise TypeError here because
+                        # NumpyRulesArrayOperator.generic is capturing
+                        # TypingError
+                        raise NumbaTypeError(msg)
+
+                ret_tys = [
+                    output_type(dtype=ret_ty, ndim=ndims, layout=layout)
+                    for ret_ty in ret_tys
+                ]
+                ret_tys = [
+                    resolve_output_type(self.context, args, ret_ty)
+                    for ret_ty in ret_tys
+                ]
+            out.extend(ret_tys)
+
+        return _ufunc_loop_sig(out, args)
+
+
+class NumpyRulesArrayOperator(Numpy_rules_ufunc):
+    _op_map = {
+        operator.add: "add",
+        operator.sub: "subtract",
+        operator.mul: "multiply",
+        operator.truediv: "true_divide",
+        operator.floordiv: "floor_divide",
+        operator.mod: "remainder",
+        operator.pow: "power",
+        operator.lshift: "left_shift",
+        operator.rshift: "right_shift",
+        operator.and_: "bitwise_and",
+        operator.or_: "bitwise_or",
+        operator.xor: "bitwise_xor",
+        operator.eq: "equal",
+        operator.gt: "greater",
+        operator.ge: "greater_equal",
+        operator.lt: "less",
+        operator.le: "less_equal",
+        operator.ne: "not_equal",
+    }
+
+    @property
+    def ufunc(self):
+        return getattr(np, self._op_map[self.key])
+
+    @classmethod
+    def install_operations(cls):
+        for op, ufunc_name in cls._op_map.items():
+            infer_global(op)(
+                type(
+                    "NumpyRulesArrayOperator_" + ufunc_name,
+                    (cls,),
+                    dict(key=op),
+                )
+            )
+
+    def generic(self, args, kws):
+        """Overloads and calls base class generic() method, returning
+        None if a TypingError occurred.
+
+        Returning None for operators is important since operators are
+        heavily overloaded, and by suppressing type errors, we allow
+        type inference to check other possibilities before giving up
+        (particularly user-defined operators).
+        """
+        try:
+            sig = super(NumpyRulesArrayOperator, self).generic(args, kws)
+        except TypingError:
+            return None
+        if sig is None:
+            return None
+        args = sig.args
+        # Only accept at least one array argument, otherwise the operator
+        # doesn't involve Numpy's ufunc machinery.
+        if not any(isinstance(arg, types.ArrayCompatible) for arg in args):
+            return None
+        return sig
+
+
+_binop_map = NumpyRulesArrayOperator._op_map
+
+
+class NumpyRulesInplaceArrayOperator(NumpyRulesArrayOperator):
+    _op_map = {
+        operator.iadd: "add",
+        operator.isub: "subtract",
+        operator.imul: "multiply",
+        operator.itruediv: "true_divide",
+        operator.ifloordiv: "floor_divide",
+        operator.imod: "remainder",
+        operator.ipow: "power",
+        operator.ilshift: "left_shift",
+        operator.irshift: "right_shift",
+        operator.iand: "bitwise_and",
+        operator.ior: "bitwise_or",
+        operator.ixor: "bitwise_xor",
+    }
+
+    def generic(self, args, kws):
+        # Type the inplace operator as if an explicit output was passed,
+        # to handle type resolution correctly.
+        # (for example int8[:] += int16[:] should use an int8[:] output,
+        #  not int16[:])
+        lhs, rhs = args
+        if not isinstance(lhs, types.ArrayCompatible):
+            return
+        args = args + (lhs,)
+        sig = super(NumpyRulesInplaceArrayOperator, self).generic(args, kws)
+        # Strip off the fake explicit output
+        assert len(sig.args) == 3
+        real_sig = signature(sig.return_type, *sig.args[:2])
+        return real_sig
+
+
+class NumpyRulesUnaryArrayOperator(NumpyRulesArrayOperator):
+    _op_map = {
+        operator.pos: "positive",
+        operator.neg: "negative",
+        operator.invert: "invert",
+    }
+
+    def generic(self, args, kws):
+        assert not kws
+        if len(args) == 1 and isinstance(args[0], types.ArrayCompatible):
+            return super(NumpyRulesUnaryArrayOperator, self).generic(args, kws)
+
+
+# list of unary ufuncs to register
+
+math_operations = [
+    "add",
+    "subtract",
+    "multiply",
+    "logaddexp",
+    "logaddexp2",
+    "true_divide",
+    "floor_divide",
+    "negative",
+    "positive",
+    "power",
+    "float_power",
+    "remainder",
+    "fmod",
+    "absolute",
+    "rint",
+    "sign",
+    "conjugate",
+    "exp",
+    "exp2",
+    "log",
+    "log2",
+    "log10",
+    "expm1",
+    "log1p",
+    "sqrt",
+    "square",
+    "cbrt",
+    "reciprocal",
+    "divide",
+    "mod",
+    "divmod",
+    "abs",
+    "fabs",
+    "gcd",
+    "lcm",
+]
+
+trigonometric_functions = [
+    "sin",
+    "cos",
+    "tan",
+    "arcsin",
+    "arccos",
+    "arctan",
+    "arctan2",
+    "hypot",
+    "sinh",
+    "cosh",
+    "tanh",
+    "arcsinh",
+    "arccosh",
+    "arctanh",
+    "deg2rad",
+    "rad2deg",
+    "degrees",
+    "radians",
+]
+
+bit_twiddling_functions = [
+    "bitwise_and",
+    "bitwise_or",
+    "bitwise_xor",
+    "invert",
+    "left_shift",
+    "right_shift",
+    "bitwise_not",
+]
+
+comparison_functions = [
+    "greater",
+    "greater_equal",
+    "less",
+    "less_equal",
+    "not_equal",
+    "equal",
+    "logical_and",
+    "logical_or",
+    "logical_xor",
+    "logical_not",
+    "maximum",
+    "minimum",
+    "fmax",
+    "fmin",
+]
+
+floating_functions = [
+    "isfinite",
+    "isinf",
+    "isnan",
+    "signbit",
+    "copysign",
+    "nextafter",
+    "modf",
+    "ldexp",
+    "frexp",
+    "floor",
+    "ceil",
+    "trunc",
+    "spacing",
+]
+
+logic_functions = ["isnat"]
+
+
+# This is a set of the ufuncs that are not yet supported by Lowering. In order
+# to trigger no-python mode we must not register them until their Lowering is
+# implemented.
+#
+# It also works as a nice TODO list for ufunc support :)
+_unsupported = set(
+    [
+        "frexp",
+        "modf",
+    ]
+)
+
+
+def register_numpy_ufunc(name, register_global=infer_global):
+    func = getattr(np, name)
+
+    class typing_class(Numpy_rules_ufunc):
+        key = func
+
+    typing_class.__name__ = "resolve_{0}".format(name)
+
+    # A list of ufuncs that are in fact aliases of other ufuncs. They need to
+    # insert the resolve method, but not register the ufunc itself
+    aliases = ("abs", "bitwise_not", "divide", "abs")
+
+    if name not in aliases:
+        register_global(func, types.Function(typing_class))
+
+
+all_ufuncs = sum(
+    [
+        math_operations,
+        trigonometric_functions,
+        bit_twiddling_functions,
+        comparison_functions,
+        floating_functions,
+        logic_functions,
+    ],
+    [],
+)
+
+supported_ufuncs = [x for x in all_ufuncs if x not in _unsupported]
+
+for func in supported_ufuncs:
+    register_numpy_ufunc(func)
+
+all_ufuncs = [getattr(np, name) for name in all_ufuncs]
+supported_ufuncs = [getattr(np, name) for name in supported_ufuncs]
+
+NumpyRulesUnaryArrayOperator.install_operations()
+NumpyRulesArrayOperator.install_operations()
+NumpyRulesInplaceArrayOperator.install_operations()
+
+supported_array_operators = (
+    set(NumpyRulesUnaryArrayOperator._op_map.keys())
+    .union(NumpyRulesArrayOperator._op_map.keys())
+    .union(NumpyRulesInplaceArrayOperator._op_map.keys())
+)
+
+del _unsupported
+
+
+# -----------------------------------------------------------------------------
+# Install global helpers for array methods.
+
+
+class Numpy_method_redirection(AbstractTemplate):
+    """
+    A template redirecting a Numpy global function (e.g. np.sum) to an
+    array method of the same name (e.g. ndarray.sum).
+    """
+
+    # Arguments like *axis* can specialize on literals but also support
+    # non-literals
+    prefer_literal = True
+
+    def generic(self, args, kws):
+        pysig = None
+        if kws:
+            if self.method_name == "sum":
+                if "axis" in kws and "dtype" not in kws:
+
+                    def sum_stub(arr, axis):
+                        pass
+
+                    pysig = utils.pysignature(sum_stub)
+                elif "dtype" in kws and "axis" not in kws:
+
+                    def sum_stub(arr, dtype):
+                        pass
+
+                    pysig = utils.pysignature(sum_stub)
+                elif "dtype" in kws and "axis" in kws:
+
+                    def sum_stub(arr, axis, dtype):
+                        pass
+
+                    pysig = utils.pysignature(sum_stub)
+            elif self.method_name == "argsort":
+
+                def argsort_stub(arr, kind="quicksort"):
+                    pass
+
+                pysig = utils.pysignature(argsort_stub)
+            else:
+                fmt = "numba doesn't support kwarg for {}"
+                raise TypingError(fmt.format(self.method_name))
+
+        arr = args[0]
+        # This will return a BoundFunction
+        meth_ty = self.context.resolve_getattr(arr, self.method_name)
+        # Resolve arguments on the bound function
+        meth_sig = self.context.resolve_function_type(meth_ty, args[1:], kws)
+        if meth_sig is not None:
+            return meth_sig.as_function().replace(pysig=pysig)
+
+
+# Function to glue attributes onto the numpy-esque object
+def _numpy_redirect(fname):
+    numpy_function = getattr(np, fname)
+    cls = type(
+        "Numpy_redirect_{0}".format(fname),
+        (Numpy_method_redirection,),
+        dict(key=numpy_function, method_name=fname),
+    )
+    infer_global(numpy_function, types.Function(cls))
+
+
+for func in ["sum", "argsort", "nonzero", "ravel"]:
+    _numpy_redirect(func)
+
+
+# -----------------------------------------------------------------------------
+# Numpy scalar constructors
+
+# Register np.int8, etc. as converters to the equivalent Numba types
+np_types = set(getattr(np, str(nb_type)) for nb_type in types.number_domain)
+np_types.add(np.bool_)
+# Those may or may not be aliases (depending on the Numpy build / version)
+np_types.add(np.intc)
+np_types.add(np.intp)
+np_types.add(np.uintc)
+np_types.add(np.uintp)
+
+
+def register_number_classes(register_global):
+    for np_type in np_types:
+        nb_type = getattr(types, np_type.__name__)
+
+        register_global(np_type, types.NumberClass(nb_type))
+
+
+register_number_classes(infer_global)
+
+# -----------------------------------------------------------------------------
+# Numpy array constructors
+
+
+def parse_shape(shape):
+    """
+    Given a shape, return the number of dimensions.
+    """
+    ndim = None
+    if isinstance(shape, types.Integer):
+        ndim = 1
+    elif isinstance(shape, (types.Tuple, types.UniTuple)):
+        int_tys = (types.Integer, types.IntEnumMember)
+        if all(isinstance(s, int_tys) for s in shape):
+            ndim = len(shape)
+    return ndim
+
+
+def parse_dtype(dtype):
+    """
+    Return the dtype of a type, if it is either a DtypeSpec (used for most
+    dtypes) or a TypeRef (used for record types).
+    """
+    if isinstance(dtype, types.DTypeSpec):
+        return dtype.dtype
+    elif isinstance(dtype, types.TypeRef):
+        return dtype.instance_type
+    elif isinstance(dtype, types.StringLiteral):
+        dtstr = dtype.literal_value
+        try:
+            dt = np.dtype(dtstr)
+        except TypeError:
+            msg = f"Invalid NumPy dtype specified: '{dtstr}'"
+            raise TypingError(msg)
+        return from_dtype(dt)
+
+
+# -----------------------------------------------------------------------------
+# Miscellaneous functions
+
+
+@infer_global(np.ndenumerate)
+class NdEnumerate(AbstractTemplate):
+    def generic(self, args, kws):
+        assert not kws
+        (arr,) = args
+
+        if isinstance(arr, types.Array):
+            enumerate_type = types.NumpyNdEnumerateType(arr)
+            return signature(enumerate_type, *args)
+
+
+@infer_global(np.nditer)
+class NdIter(AbstractTemplate):
+    def generic(self, args, kws):
+        assert not kws
+        if len(args) != 1:
+            return
+        (arrays,) = args
+
+        if isinstance(arrays, types.BaseTuple):
+            if not arrays:
+                return
+            arrays = list(arrays)
+        else:
+            arrays = [arrays]
+        nditerty = types.NumpyNdIterType(arrays)
+        return signature(nditerty, *args)
+
+
+@infer_global(pndindex)
+@infer_global(np.ndindex)
+class NdIndex(AbstractTemplate):
+    def generic(self, args, kws):
+        assert not kws
+
+        # Either ndindex(shape) or ndindex(*shape)
+        if len(args) == 1 and isinstance(args[0], types.BaseTuple):
+            tup = args[0]
+            if tup.count > 0 and not isinstance(tup, types.UniTuple):
+                # Heterogeneous tuple
+                return
+            shape = list(tup)
+        else:
+            shape = args
+
+        if all(isinstance(x, types.Integer) for x in shape):
+            iterator_type = types.NumpyNdIndexType(len(shape))
+            return signature(iterator_type, *args)
+
+
+@infer_global(operator.eq)
+class DtypeEq(AbstractTemplate):
+    def generic(self, args, kws):
+        [lhs, rhs] = args
+        if isinstance(lhs, types.DType) and isinstance(rhs, types.DType):
+            return signature(types.boolean, lhs, rhs)


### PR DESCRIPTION
This PR vendors in few more classes (`typing.npydecl, typing.BaseContext, typing.Context`) from `numba.core.typing` for CUDA-specific customization. 
