### PR TITLE
Bump thirdparty test version 

### DIFF
--- a/ci/test_thirdparty.sh
+++ b/ci/test_thirdparty.sh
@@ -41,6 +41,6 @@ rapids-logger "Run Scalar UDF tests"
 python -m pytest python/cudf/cudf/tests/test_udf_masked_ops.py -W ignore::UserWarning
 
 rapids-logger "Run GroupBy UDF tests"
-python -m pytest python/cudf/cudf/tests/test_groupby.py -k test_groupby_apply_jit -W ignore::UserWarning
+python -m pytest python/cudf/cudf/tests/groupby/test_apply.py -k test_groupby_apply_jit -W ignore::UserWarning
 
 popd


### PR DESCRIPTION
Because the issue fixed by https://github.com/rapidsai/cudf/pull/19604/commits/dde047faf73349453e123b921e1ead8285623b02 exists on cudf/25.08, bumping to the 25.08 stable release incurs the errors this commit addresses using our main branch today. To fix this, we’ll need to switch to nightlies for a RAPIDS release cycle. This situation should stabilize after the next rapids release assuming we don’t have a similar situation where changes in numba-cuda expose a latent bug that requires build time fixes in cuDF.

Normally I'd suggest just waiting until the next stable cuDF release, but the 25.08 release specifically added the most significant changes to extension usage in a long time and I think it's worth testing a cuDF version that includes those updates with the changes we make here sooner rather than later.