### PR TITLE
Add CLA and third party Numba license

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -23,12 +23,12 @@ otherwise designated in writing by You as “Not a Submission.”
 “**Submission**” means the Code and any other copyrightable material Submitted by You, including any
 associated comments and documentation.
 
-## 2. Your Submission. 
+## 2. Your Submission.
 You must agree to the terms of this Agreement before making a Submission to any
 Project. This Agreement covers any and all Submissions that You, now or in the future (except as
 described in Section 4 below), Submit to any Project.
 
-## 3. Originality of Work. 
+## 3. Originality of Work.
 You represent that each of Your Submissions is entirely Your original work.
 Should You wish to Submit materials that are not Your original work, You may Submit them separately
 to the Project if You (a) retain all copyright and license information that was in the materials as You
@@ -37,7 +37,7 @@ containing materials of a third party:” followed by the names of the third par
 restrictions of which You are aware, and (c) follow any other instructions in the Project’s written
 guidelines concerning Submissions.
 
-## 4. Your Employer. 
+## 4. Your Employer.
 References to “employer” in this Agreement include Your employer or anyone else
 for whom You are acting in making Your Submission, e.g. as a contractor, vendor, or agent. If Your
 Submission is made in the course of Your work for an employer or Your employer has intellectual
@@ -66,7 +66,7 @@ import or otherwise dispose of the Submission alone or with the Project.
 No additional licenses or rights whatsoever (including, without limitation, any implied licenses) are
 granted by implication, exhaustion, estoppel or otherwise.
 
-## 6. Representations and Warranties. 
+## 6. Representations and Warranties.
 You represent that You are legally entitled to grant the above
 licenses. You represent that each of Your Submissions is entirely Your original work (except as You may
 have disclosed under Section 3). You represent that You have secured permission from Your employer to
@@ -80,20 +80,20 @@ EXPRESSLY STATED IN SECTIONS 3, 4, AND 6, THE SUBMISSION PROVIDED UNDER THIS AGR
 PROVIDED WITHOUT WARRANTY OF ANY KIND, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY OF
 NONINFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 
-## 7. Notice to NVIDIA. 
+## 7. Notice to NVIDIA.
 You agree to notify NVIDIA in writing of any facts or circumstances of which
 You later become aware that would make Your representations in this Agreement inaccurate in any
 respect.
 
-## 8. Information about Submissions. 
+## 8. Information about Submissions.
 You agree that contributions to Projects and information about
 contributions may be maintained indefinitely and disclosed publicly, including Your name and other
 information that You submit with Your Submission.
 
-## 9. Governing Law/Jurisdiction. 
+## 9. Governing Law/Jurisdiction.
 Claims arising under this Agreement shall be governed by the laws of Delaware, excluding its principles of conflict of laws and the United Nations Convention on Contracts for the Sale of Goods. The state and/or federal courts residing in Santa Clara County, California shall have exclusive jurisdiction over any dispute or claim arising out of this Agreement. You may not export the Software in violation of applicable export laws and regulations.
 
-## 10. Entire Agreement/Assignment. 
+## 10. Entire Agreement/Assignment.
 This Agreement is the entire agreement between the parties, and
 supersedes any and all prior agreements, understandings or communications, written or oral, between
 the parties relating to the subject matter hereof. This Agreement may be assigned by NVIDIA.

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,99 @@
+# Contribution License Agreement
+
+This Contribution License Agreement (“**Agreement**”) is agreed to by the party signing below (“**You**”),
+and conveys certain license rights to NVIDIA Corporation and its affiliates (“**NVIDIA**”) for Your
+contributions to NVIDIA open source projects. This Agreement is effective as of the latest signature
+date below.
+
+## 1. Definitions.
+
+“**Code**” means the computer software code, whether in human-readable or machine-executable form,
+that is delivered by You to NVIDIA under this Agreement.
+
+“**Project**” means any of the projects owned or managed by NVIDIA in which software is offered under
+a license approved by the Open Source Initiative (OSI) (www.opensource.org) and documentation
+offered under an OSI or a Creative Commons license (https://creativecommons.org/licenses).
+
+“**Submit**” is the act of uploading, submitting, transmitting, or distributing code or other content to any
+Project, including but not limited to communication on electronic mailing lists, source code control
+systems, and issue tracking systems that are managed by, or on behalf of, the Project for the purpose of
+discussing and improving that Project, but excluding communication that is conspicuously marked or
+otherwise designated in writing by You as “Not a Submission.”
+
+“**Submission**” means the Code and any other copyrightable material Submitted by You, including any
+associated comments and documentation.
+
+## 2. Your Submission. 
+You must agree to the terms of this Agreement before making a Submission to any
+Project. This Agreement covers any and all Submissions that You, now or in the future (except as
+described in Section 4 below), Submit to any Project.
+
+## 3. Originality of Work. 
+You represent that each of Your Submissions is entirely Your original work.
+Should You wish to Submit materials that are not Your original work, You may Submit them separately
+to the Project if You (a) retain all copyright and license information that was in the materials as You
+received them, (b) in the description accompanying Your Submission, include the phrase “Submission
+containing materials of a third party:” followed by the names of the third party and any licenses or other
+restrictions of which You are aware, and (c) follow any other instructions in the Project’s written
+guidelines concerning Submissions.
+
+## 4. Your Employer. 
+References to “employer” in this Agreement include Your employer or anyone else
+for whom You are acting in making Your Submission, e.g. as a contractor, vendor, or agent. If Your
+Submission is made in the course of Your work for an employer or Your employer has intellectual
+property rights in Your Submission by contract or applicable law, You must secure permission from Your
+employer to make the Submission before signing this Agreement. In that case, the term “You” in this
+Agreement will refer to You and the employer collectively. If You change employers in the future and
+desire to Submit additional Submissions for the new employer, then You agree to sign a new Agreement
+and secure permission from the new employer before Submitting those Submissions.
+
+
+## 5. Licenses.
+
+**a. Copyright License**. You grant NVIDIA, and those who receive the Submission directly or
+indirectly from NVIDIA, a perpetual, worldwide, non-exclusive, royalty-free, irrevocable license in the
+Submission to reproduce, prepare derivative works of, publicly display, publicly perform, and distribute
+the Submission and such derivative works, and to sublicense any or all of the foregoing rights to third
+parties.
+
+**b. Patent License**. You grant NVIDIA, and those who receive the Submission directly or
+indirectly from NVIDIA, a perpetual, worldwide, non-exclusive, royalty-free, irrevocable license under
+Your patent claims that are necessarily infringed by the Submission or the combination of the
+Submission with the Project to which it was Submitted to make, have made, use, offer to sell, sell and
+import or otherwise dispose of the Submission alone or with the Project.
+
+**c. Other Rights Reserved**. Each party reserves all rights not expressly granted in this Agreement.
+No additional licenses or rights whatsoever (including, without limitation, any implied licenses) are
+granted by implication, exhaustion, estoppel or otherwise.
+
+## 6. Representations and Warranties. 
+You represent that You are legally entitled to grant the above
+licenses. You represent that each of Your Submissions is entirely Your original work (except as You may
+have disclosed under Section 3). You represent that You have secured permission from Your employer to
+make the Submission in cases where Your Submission is made in the course of Your work for Your
+employer or Your employer has intellectual property rights in Your Submission by contract or applicable
+law. If You are signing this Agreement on behalf of Your employer, You represent and warrant that You
+have the necessary authority to bind the listed employer to the obligations contained in this Agreement.
+You are not expected to provide support for Your Submission, unless You choose to do so. UNLESS
+REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING, AND EXCEPT FOR THE WARRANTIES
+EXPRESSLY STATED IN SECTIONS 3, 4, AND 6, THE SUBMISSION PROVIDED UNDER THIS AGREEMENT IS
+PROVIDED WITHOUT WARRANTY OF ANY KIND, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY OF
+NONINFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+
+## 7. Notice to NVIDIA. 
+You agree to notify NVIDIA in writing of any facts or circumstances of which
+You later become aware that would make Your representations in this Agreement inaccurate in any
+respect.
+
+## 8. Information about Submissions. 
+You agree that contributions to Projects and information about
+contributions may be maintained indefinitely and disclosed publicly, including Your name and other
+information that You submit with Your Submission.
+
+## 9. Governing Law/Jurisdiction. 
+Claims arising under this Agreement shall be governed by the laws of Delaware, excluding its principles of conflict of laws and the United Nations Convention on Contracts for the Sale of Goods. The state and/or federal courts residing in Santa Clara County, California shall have exclusive jurisdiction over any dispute or claim arising out of this Agreement. You may not export the Software in violation of applicable export laws and regulations.
+
+## 10. Entire Agreement/Assignment. 
+This Agreement is the entire agreement between the parties, and
+supersedes any and all prior agreements, understandings or communications, written or oral, between
+the parties relating to the subject matter hereof. This Agreement may be assigned by NVIDIA.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,10 @@ into three categories:
 3. Comment on the issue saying you are going to work on it
 4. Code! Make sure to update unit tests!
 5. When done, [create your pull request](https://github.com/NVIDIA/numba-cuda/compare)
-6. Verify that CI passes all [status checks](https://help.github.com/articles/about-status-checks/). Fix if needed
-7. Wait for other developers to review your code and update code as needed
-8. Once reviewed and approved, a Numba-CUDA developer will merge your pull request
+6. Sign the [CLA](https://github.com/NVIDIA/numba-cuda/CLA.md)
+7. Verify that CI passes all [status checks](https://help.github.com/articles/about-status-checks/). Fix if needed
+8. Wait for other developers to review your code and update code as needed
+9. Once reviewed and approved, a Numba-CUDA developer will merge your pull request
 
 Remember, if you are unsure about anything, don't hesitate to comment on issues
 and ask for clarifications!

--- a/LICENSE.numba
+++ b/LICENSE.numba
@@ -1,5 +1,4 @@
 Copyright (c) 2012, Anaconda, Inc.
-Copyright (c) 2024, NVIDIA CORPORATION.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -12,7 +11,6 @@ this list of conditions and the following disclaimer.
 Redistributions in binary form must reproduce the above copyright
 notice, this list of conditions and the following disclaimer in the
 documentation and/or other materials provided with the distribution.
-
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR

--- a/conda/recipes/numba-cuda/meta.yaml
+++ b/conda/recipes/numba-cuda/meta.yaml
@@ -35,8 +35,10 @@ about:
   home: {{ project_urls["Homepage"] }}
   dev_url: {{ project_urls["Repository"] }}
   doc_url: {{ project_urls["Documentation"] }}
-  license: {{ project_data["license"]["text"] }}
+  license: {{ project_data["license"] }}
   license_family: BSD
-  license_file: LICENSE
+  license_file:
+    - LICENSE
+    - LICENSE.numba
   license_url: {{ project_urls["License"] }}
   summary: Numba CUDA target

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,6 @@ Issues = "https://github.com/NVIDIA/numba-cuda/issues"
 [tool.setuptools.dynamic]
 version = {attr = "numba_cuda.__version__"}
 
-[tool.setuptools]
-license-files = ["LICENSE"]
-
 [tool.setuptools.packages.find]
 include = ["numba_cuda*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
     { name = "Anaconda Inc." },
     { name = "NVIDIA Corporation" }
 ]
-license = { text = "BSD 2-clause" }
+license = "BSD-2-clause"
 license-files = ["LICENSE", "LICENSE.numba"]
 requires-python = ">=3.9"
 dependencies = ["numba>=0.60.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ authors = [
     { name = "NVIDIA Corporation" }
 ]
 license = { text = "BSD 2-clause" }
+license-files = ["LICENSE", "LICENSE.numba"]
 requires-python = ">=3.9"
 dependencies = ["numba>=0.60.0"]
 


### PR DESCRIPTION
Adds a `CLA.md` file as well as hooked up https://cla-assistant.io to handle CLA signing for contributors. Additionally adds a `LICENSE.numba` file and add relevant section to the `pyproject.toml` file to make sure we ship it as part of our package.
