### PR TITLE
Remove costly but low-utility assertions

### DIFF
--- a/numba_cuda/numba/cuda/typing/templates.py
+++ b/numba_cuda/numba/cuda/typing/templates.py
@@ -1359,18 +1359,10 @@ class Registry(object):
         self.globals = []
 
     def register(self, item):
-        assert issubclass(
-            item,
-            (FunctionTemplate, numba.core.typing.templates.FunctionTemplate),
-        )
         self.functions.append(item)
         return item
 
     def register_attr(self, item):
-        assert issubclass(
-            item,
-            (AttributeTemplate, numba.core.typing.templates.AttributeTemplate),
-        )
         self.attributes.append(item)
         return item
 


### PR DESCRIPTION
I'm not aware of these assertions ever getting triggered by anyone making a mistake with registrations, but they do take a lot of time when the number of registrations is large - this commit thus removes them.