### PR TITLE
Update thirdparty test locations

### DIFF
--- a/ci/test_thirdparty.sh
+++ b/ci/test_thirdparty.sh
@@ -45,7 +45,7 @@ rapids-logger "Run GroupBy UDF tests"
 python -m pytest python/cudf/cudf/tests/groupby/test_apply.py -k test_groupby_apply_jit -W ignore::UserWarning
 
 rapids-logger "Run NRT Stats Counting tests"
-python -m pytest python/cudf/cudf/tests/test_nrt_stats.py -W ignore::UserWarning
+python -m pytest python/cudf/cudf/tests/private_objects/test_nrt_stats.py  -W ignore::UserWarning
 
 
 popd


### PR DESCRIPTION
This PR updates the thirdparty tests to reflect the location of the tests in the latest cudf nightly. 