### PR TITLE
Compatibility fixes for Numba 0.62

### DIFF
--- a/numba_cuda/numba/cuda/core/typed_passes.py
+++ b/numba_cuda/numba/cuda/core/typed_passes.py
@@ -50,8 +50,13 @@ from numba.cuda.core.ir_utils import (
     replace_vars,
 )
 from numba.cuda.core import postproc
-from llvmlite import binding as llvm
 
+try:
+    # llvmlite < 0.45
+    from llvmlite.binding import passmanagers
+except ImportError:
+    # llvmlite >= 0.45
+    from llvmlite.binding import newpassmanagers as passmanagers
 
 # Outputs of type inference pass
 _TypingResults = namedtuple(
@@ -513,7 +518,7 @@ class BaseNativeLowering(abc.ABC, LoweringPass):
         calltypes = state.calltypes
         flags = state.flags
         metadata = state.metadata
-        pre_stats = llvm.passmanagers.dump_refprune_stats()
+        pre_stats = passmanagers.dump_refprune_stats()
 
         msg = "Function %s failed at nopython mode lowering" % (
             state.func_id.func_name,
@@ -576,7 +581,7 @@ class BaseNativeLowering(abc.ABC, LoweringPass):
                 )
 
             # capture pruning stats
-            post_stats = llvm.passmanagers.dump_refprune_stats()
+            post_stats = passmanagers.dump_refprune_stats()
             metadata["prune_stats"] = post_stats - pre_stats
 
             # Save the LLVM pass timings

--- a/numba_cuda/numba/cuda/memory_management/__init__.py
+++ b/numba_cuda/numba/cuda/memory_management/__init__.py
@@ -2,3 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from numba.cuda.memory_management.nrt import rtsys  # noqa: F401
+from numba.cuda.memory_management import arrayobj_extras  # noqa: F401
+
+
+__all__ = ["rtsys"]

--- a/numba_cuda/numba/cuda/memory_management/arrayobj_extras.py
+++ b/numba_cuda/numba/cuda/memory_management/arrayobj_extras.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+from numba import types
+from numba.core.extending import overload_classmethod
+from numba.np.arrayobj import intrin_alloc
+
+
+@overload_classmethod(types.Array, "_allocate", target="CUDA")
+def _ol_array_allocate(cls, allocsize, align):
+    """Implements a Numba-only default target (cpu) classmethod on the array
+    type.
+    """
+
+    def impl(cls, allocsize, align):
+        return intrin_alloc(allocsize, align)
+
+    return impl


### PR DESCRIPTION
- `newpassmanagers` need to be used with llvmlite >= 0.45 (the legacy pass manager is removed with the move to LLVM 20)
- The `Array._allocate()` overload was made CPU-only with https://github.com/numba/numba/pull/10185, so we need one for the CUDA target.