### PR TITLE
Close `rtsys` singleton when `cuda.close()` is called

### DIFF
--- a/numba_cuda/numba/cuda/api.py
+++ b/numba_cuda/numba/cuda/api.py
@@ -11,7 +11,6 @@ import os
 import numpy as np
 
 from .cudadrv import devicearray, devices, driver
-
 from numba.core import config
 from numba.cuda.api_util import prepare_shape_strides_dtype
 

--- a/numba_cuda/numba/cuda/api.py
+++ b/numba_cuda/numba/cuda/api.py
@@ -11,6 +11,7 @@ import os
 import numpy as np
 
 from .cudadrv import devicearray, devices, driver
+
 from numba.core import config
 from numba.cuda.api_util import prepare_shape_strides_dtype
 
@@ -509,6 +510,9 @@ def close():
     contexts if the current thread is the main thread.
     """
     devices.reset()
+    from .memory_management import rtsys
+
+    rtsys.close()
 
 
 def _auto_device(ary, stream=0, copy=True):

--- a/numba_cuda/numba/cuda/memory_management/nrt.py
+++ b/numba_cuda/numba/cuda/memory_management/nrt.py
@@ -69,9 +69,17 @@ class _Runtime:
 
     def __init__(self):
         """Initialize memsys module and variable"""
+        self._reset()
+
+    def _reset(self):
+        """Reset to the uninitialized state"""
         self._memsys_module = None
         self._memsys = None
         self._initialized = False
+
+    def close(self):
+        """Close and reset"""
+        self._reset()
 
     def _compile_memsys_module(self):
         """


### PR DESCRIPTION
This PR fixes an issue where `cuda.close` invalidated the context containing the current memsys module without also invalidating the `_Runtime` instance that ostensibly owned that module. This caused reference errors later on when trying to use that module. 

Closes https://github.com/NVIDIA/numba-cuda/issues/453