### PR TITLE
Vendor in targetconfig, event, funcdesc, descriptors for CUDA-specific changes

### DIFF
--- a/numba_cuda/numba/cuda/compiler.py
+++ b/numba_cuda/numba/cuda/compiler.py
@@ -9,7 +9,6 @@ import copy
 from numba.core import ir as numba_ir
 from numba.core import (
     types,
-    funcdesc,
     config,
     bytecode,
     cpu,
@@ -17,12 +16,11 @@ from numba.core import (
 from numba.core.compiler_lock import global_compiler_lock
 from numba.core.errors import NumbaWarning, NumbaInvalidConfigWarning
 from numba.cuda.core.interpreter import Interpreter
-from numba.cuda.core import inline_closurecall
 
 from numba.cuda import cgutils, typing, lowering, nvvmutils, utils
 from numba.cuda.api import get_current_device
 from numba.cuda.codegen import ExternalCodeLibrary
-from numba.cuda.core import sigutils, postproc
+from numba.cuda.core import inline_closurecall, sigutils, postproc, funcdesc
 from numba.cuda.cudadrv import nvvm, nvrtc
 from numba.cuda.descriptor import cuda_target
 from numba.cuda.flags import CUDAFlags

--- a/numba_cuda/numba/cuda/core/compiler.py
+++ b/numba_cuda/numba/cuda/core/compiler.py
@@ -8,7 +8,7 @@ from numba.core import callconv, config, errors
 from numba.core.errors import CompilerError
 
 from numba.cuda.core.untyped_passes import ExtractByteCode, FixupArgs
-from numba.core.targetconfig import ConfigStack
+from numba.cuda.core.targetconfig import ConfigStack
 
 
 class _CompileStatus(object):

--- a/numba_cuda/numba/cuda/core/compiler.py
+++ b/numba_cuda/numba/cuda/core/compiler.py
@@ -8,7 +8,7 @@ from numba.core import callconv, config, errors
 from numba.core.errors import CompilerError
 
 from numba.cuda.core.untyped_passes import ExtractByteCode, FixupArgs
-from numba.cuda.core.targetconfig import ConfigStack
+from numba.core.targetconfig import ConfigStack
 
 
 class _CompileStatus(object):

--- a/numba_cuda/numba/cuda/core/compiler_machinery.py
+++ b/numba_cuda/numba/cuda/core/compiler_machinery.py
@@ -329,7 +329,7 @@ class PassManager(object):
             return_type=str(internal_state.return_type),
         )
         errctx = errors.new_error_context(f"Pass {pss.name()}")
-        with ev.trigger_event("numba-cuda:run_pass", data=ev_details), errctx:
+        with ev.trigger_event("numba:run_pass", data=ev_details), errctx:
             with SimpleTimer() as init_time:
                 mutated |= check(pss.run_initialization, internal_state)
             with SimpleTimer() as pass_time:

--- a/numba_cuda/numba/cuda/core/compiler_machinery.py
+++ b/numba_cuda/numba/cuda/core/compiler_machinery.py
@@ -329,7 +329,7 @@ class PassManager(object):
             return_type=str(internal_state.return_type),
         )
         errctx = errors.new_error_context(f"Pass {pss.name()}")
-        with ev.trigger_event("numba:run_pass", data=ev_details), errctx:
+        with ev.trigger_event("numba-cuda:run_pass", data=ev_details), errctx:
             with SimpleTimer() as init_time:
                 mutated |= check(pss.run_initialization, internal_state)
             with SimpleTimer() as pass_time:

--- a/numba_cuda/numba/cuda/core/compiler_machinery.py
+++ b/numba_cuda/numba/cuda/core/compiler_machinery.py
@@ -13,7 +13,7 @@ from numba.cuda import utils
 from numba.cuda.core.tracing import event
 from numba.cuda.core.postproc import PostProcessor
 from numba.cuda.core.ir_utils import enforce_no_dels, legalize_single_scope
-import numba.core.event as ev
+import numba.cuda.core.event as ev
 
 import numba.cuda.core.compiler_machinery as nccm
 

--- a/numba_cuda/numba/cuda/core/event.py
+++ b/numba_cuda/numba/cuda/core/event.py
@@ -7,7 +7,7 @@ to register callbacks to listen to specific compiler events.
 
 The following events are built in:
 
-- ``"numba:compile"`` is broadcast when a dispatcher is compiling. Events of
+- ``"numba-cuda:compile"`` is broadcast when a dispatcher is compiling. Events of
   this kind have ``data`` defined to be a ``dict`` with the following
   key-values:
 
@@ -15,14 +15,11 @@ The following events are built in:
   - ``"args"``: the argument types.
   - ``"return_type"``: the return type.
 
-- ``"numba:compiler_lock"`` is broadcast when the internal compiler-lock is
+- ``"numba-cuda:compiler_lock"`` is broadcast when the internal compiler-lock is
   acquired. This is mostly used internally to measure time spent with the lock
   acquired.
 
-- ``"numba:llvm_lock"`` is broadcast when the internal LLVM-lock is acquired.
-  This is used internally to measure time spent with the lock acquired.
-
-- ``"numba:run_pass"`` is broadcast when a compiler pass is running.
+- ``"numba-cuda:run_pass"`` is broadcast when a compiler pass is running.
 
     - ``"name"``: pass name.
     - ``"qualname"``: qualified name of the function being compiled.
@@ -36,9 +33,18 @@ Applications can register callbacks that are listening for specific events using
 of ``Listener`` that defines custom actions on occurrence of the specific event.
 """
 
+import os
+import json
+import atexit
+import abc
 import enum
+import time
+import threading
+from timeit import default_timer as timer
 from contextlib import contextmanager, ExitStack
 from collections import defaultdict
+from numba.core import config
+from numba.cuda import utils
 
 
 class EventStatus(enum.Enum):
@@ -51,10 +57,9 @@ class EventStatus(enum.Enum):
 # Builtin event kinds.
 _builtin_kinds = frozenset(
     [
-        "numba:compiler_lock",
-        "numba:compile",
-        "numba:llvm_lock",
-        "numba:run_pass",
+        "numba-cuda:compiler_lock",
+        "numba-cuda:compile",
+        "numba-cuda:run_pass",
     ]
 )
 
@@ -62,7 +67,7 @@ _builtin_kinds = frozenset(
 def _guard_kind(kind):
     """Guard to ensure that an event kind is valid.
 
-    All event kinds with a "numba:" prefix must be defined in the pre-defined
+    All event kinds with a "numba-cuda:" prefix must be defined in the pre-defined
     ``numba.cuda.core.event._builtin_kinds``.
     Custom event kinds are allowed by not using the above prefix.
 
@@ -74,10 +79,17 @@ def _guard_kind(kind):
     ------
     res : str
     """
-    if kind.startswith("numba:") and kind not in _builtin_kinds:
+    if kind.startswith("numba-cuda:") and kind not in _builtin_kinds:
         msg = (
             f"{kind} is not a valid event kind, "
-            "it starts with the reserved prefix 'numba:'"
+            "it starts with the reserved prefix 'numba-cuda:'"
+        )
+        raise ValueError(msg)
+    if kind.startswith("numba:"):
+        msg = (
+            f"{kind} is using invalid reserved prefix 'numba:' "
+            "it should either start with the reserved prefix 'numba-cuda:'"
+            ", or be a custom event kind"
         )
         raise ValueError(msg)
     return kind
@@ -183,6 +195,33 @@ class Event:
 _registered = defaultdict(list)
 
 
+def register(kind, listener):
+    """Register a listener for a given event kind.
+
+    Parameters
+    ----------
+    kind : str
+    listener : Listener
+    """
+    assert isinstance(listener, Listener)
+    kind = _guard_kind(kind)
+    _registered[kind].append(listener)
+
+
+def unregister(kind, listener):
+    """Unregister a listener for a given event kind.
+
+    Parameters
+    ----------
+    kind : str
+    listener : Listener
+    """
+    assert isinstance(listener, Listener)
+    kind = _guard_kind(kind)
+    lst = _registered[kind]
+    lst.remove(listener)
+
+
 def broadcast(event):
     """Broadcast an event to all registered listeners.
 
@@ -192,6 +231,178 @@ def broadcast(event):
     """
     for listener in _registered[event.kind]:
         listener.notify(event)
+
+
+class Listener(abc.ABC):
+    """Base class for all event listeners."""
+
+    @abc.abstractmethod
+    def on_start(self, event):
+        """Called when there is a *START* event.
+
+        Parameters
+        ----------
+        event : Event
+        """
+        pass
+
+    @abc.abstractmethod
+    def on_end(self, event):
+        """Called when there is a *END* event.
+
+        Parameters
+        ----------
+        event : Event
+        """
+        pass
+
+    def notify(self, event):
+        """Notify this Listener with the given Event.
+
+        Parameters
+        ----------
+        event : Event
+        """
+        if event.is_start:
+            self.on_start(event)
+        elif event.is_end:
+            self.on_end(event)
+        else:
+            raise AssertionError("unreachable")
+
+
+class TimingListener(Listener):
+    """A listener that measures the total time spent between *START* and
+    *END* events during the time this listener is active.
+    """
+
+    def __init__(self):
+        self._depth = 0
+
+    def on_start(self, event):
+        if self._depth == 0:
+            self._ts = timer()
+        self._depth += 1
+
+    def on_end(self, event):
+        self._depth -= 1
+        if self._depth == 0:
+            last = getattr(self, "_duration", 0)
+            self._duration = (timer() - self._ts) + last
+
+    @property
+    def done(self):
+        """Returns a ``bool`` indicating whether a measurement has been made.
+
+        When this returns ``False``, the matching event has never fired.
+        If and only if this returns ``True``, ``.duration`` can be read without
+        error.
+        """
+        return hasattr(self, "_duration")
+
+    @property
+    def duration(self):
+        """Returns the measured duration.
+
+        This may raise ``AttributeError``. Users can use ``.done`` to check
+        that a measurement has been made.
+        """
+        return self._duration
+
+
+class RecordingListener(Listener):
+    """A listener that records all events and stores them in the ``.buffer``
+    attribute as a list of 2-tuple ``(float, Event)``, where the first element
+    is the time the event occurred as returned by ``time.time()`` and the second
+    element is the event.
+    """
+
+    def __init__(self):
+        self.buffer = []
+
+    def on_start(self, event):
+        self.buffer.append((time.time(), event))
+
+    def on_end(self, event):
+        self.buffer.append((time.time(), event))
+
+
+@contextmanager
+def install_listener(kind, listener):
+    """Install a listener for event "kind" temporarily within the duration of
+    the context.
+
+    Returns
+    -------
+    res : Listener
+        The *listener* provided.
+
+    Examples
+    --------
+
+    >>> with install_listener("numba-cuda:compile", listener):
+    >>>     some_code()  # listener will be active here.
+    >>> other_code()  # listener will be unregistered by this point.
+
+    """
+    register(kind, listener)
+    try:
+        yield listener
+    finally:
+        unregister(kind, listener)
+
+
+@contextmanager
+def install_timer(kind, callback):
+    """Install a TimingListener temporarily to measure the duration of
+    an event.
+
+    If the context completes successfully, the *callback* function is executed.
+    The *callback* function is expected to take a float argument for the
+    duration in seconds.
+
+    Returns
+    -------
+    res : TimingListener
+
+    Examples
+    --------
+
+    This is equivalent to:
+
+    >>> with install_listener(kind, TimingListener()) as res:
+    >>>    ...
+    """
+    tl = TimingListener()
+    with install_listener(kind, tl):
+        yield tl
+
+    if tl.done:
+        callback(tl.duration)
+
+
+@contextmanager
+def install_recorder(kind):
+    """Install a RecordingListener temporarily to record all events.
+
+    Once the context is closed, users can use ``RecordingListener.buffer``
+    to access the recorded events.
+
+    Returns
+    -------
+    res : RecordingListener
+
+    Examples
+    --------
+
+    This is equivalent to:
+
+    >>> with install_listener(kind, RecordingListener()) as res:
+    >>>    ...
+    """
+    rl = RecordingListener()
+    with install_listener(kind, rl):
+        yield rl
 
 
 def start_event(kind, data=None):
@@ -250,3 +461,51 @@ def trigger_event(kind, data=None):
 
         start_event(kind, data=data)
         yield
+
+
+def _prepare_chrome_trace_data(listener: RecordingListener):
+    """Prepare events in `listener` for serializing as chrome trace data."""
+    # The spec for the trace event format can be found at:
+    # https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/edit   # noqa
+    # This code only uses the JSON Array Format for simplicity.
+    pid = os.getpid()
+    tid = threading.get_native_id()
+    evs = []
+    for ts, rec in listener.buffer:
+        data = rec.data
+        cat = str(rec.kind)
+        ts_scaled = ts * 1_000_000  # scale to microseconds
+        ph = "B" if rec.is_start else "E"
+        name = data["name"]
+        args = data
+        ev = dict(
+            cat=cat,
+            pid=pid,
+            tid=tid,
+            ts=ts_scaled,
+            ph=ph,
+            name=name,
+            args=args,
+        )
+        evs.append(ev)
+    return evs
+
+
+def _setup_chrome_trace_exit_handler():
+    """Setup a RecordingListener and an exit handler to write the captured
+    events to file.
+    """
+    listener = RecordingListener()
+    register("numba-cuda:run_pass", listener)
+    filename = config.CHROME_TRACE
+
+    @atexit.register
+    def _write_chrome_trace():
+        # The following output file is not multi-process safe.
+        evs = _prepare_chrome_trace_data(listener)
+        with open(filename, "w") as out:
+            json.dump(evs, out, cls=utils._LazyJSONEncoder)
+
+
+if config.CHROME_TRACE:
+    _setup_chrome_trace_exit_handler()

--- a/numba_cuda/numba/cuda/core/event.py
+++ b/numba_cuda/numba/cuda/core/event.py
@@ -7,7 +7,7 @@ to register callbacks to listen to specific compiler events.
 
 The following events are built in:
 
-- ``"numba-cuda:compile"`` is broadcast when a dispatcher is compiling. Events of
+- ``"numba:compile"`` is broadcast when a dispatcher is compiling. Events of
   this kind have ``data`` defined to be a ``dict`` with the following
   key-values:
 
@@ -15,11 +15,14 @@ The following events are built in:
   - ``"args"``: the argument types.
   - ``"return_type"``: the return type.
 
-- ``"numba-cuda:compiler_lock"`` is broadcast when the internal compiler-lock is
+- ``"numba:compiler_lock"`` is broadcast when the internal compiler-lock is
   acquired. This is mostly used internally to measure time spent with the lock
   acquired.
 
-- ``"numba-cuda:run_pass"`` is broadcast when a compiler pass is running.
+- ``"numba:llvm_lock"`` is broadcast when the internal LLVM-lock is acquired.
+  This is used internally to measure time spent with the lock acquired.
+
+- ``"numba:run_pass"`` is broadcast when a compiler pass is running.
 
     - ``"name"``: pass name.
     - ``"qualname"``: qualified name of the function being compiled.
@@ -33,18 +36,9 @@ Applications can register callbacks that are listening for specific events using
 of ``Listener`` that defines custom actions on occurrence of the specific event.
 """
 
-import os
-import json
-import atexit
-import abc
 import enum
-import time
-import threading
-from timeit import default_timer as timer
 from contextlib import contextmanager, ExitStack
 from collections import defaultdict
-from numba.core import config
-from numba.cuda import utils
 
 
 class EventStatus(enum.Enum):
@@ -57,9 +51,10 @@ class EventStatus(enum.Enum):
 # Builtin event kinds.
 _builtin_kinds = frozenset(
     [
-        "numba-cuda:compiler_lock",
-        "numba-cuda:compile",
-        "numba-cuda:run_pass",
+        "numba:compiler_lock",
+        "numba:compile",
+        "numba:llvm_lock",
+        "numba:run_pass",
     ]
 )
 
@@ -67,7 +62,7 @@ _builtin_kinds = frozenset(
 def _guard_kind(kind):
     """Guard to ensure that an event kind is valid.
 
-    All event kinds with a "numba-cuda:" prefix must be defined in the pre-defined
+    All event kinds with a "numba:" prefix must be defined in the pre-defined
     ``numba.cuda.core.event._builtin_kinds``.
     Custom event kinds are allowed by not using the above prefix.
 
@@ -79,17 +74,10 @@ def _guard_kind(kind):
     ------
     res : str
     """
-    if kind.startswith("numba-cuda:") and kind not in _builtin_kinds:
+    if kind.startswith("numba:") and kind not in _builtin_kinds:
         msg = (
             f"{kind} is not a valid event kind, "
-            "it starts with the reserved prefix 'numba-cuda:'"
-        )
-        raise ValueError(msg)
-    if kind.startswith("numba:"):
-        msg = (
-            f"{kind} is using invalid reserved prefix 'numba:' "
-            "it should either start with the reserved prefix 'numba-cuda:'"
-            ", or be a custom event kind"
+            "it starts with the reserved prefix 'numba:'"
         )
         raise ValueError(msg)
     return kind
@@ -195,33 +183,6 @@ class Event:
 _registered = defaultdict(list)
 
 
-def register(kind, listener):
-    """Register a listener for a given event kind.
-
-    Parameters
-    ----------
-    kind : str
-    listener : Listener
-    """
-    assert isinstance(listener, Listener)
-    kind = _guard_kind(kind)
-    _registered[kind].append(listener)
-
-
-def unregister(kind, listener):
-    """Unregister a listener for a given event kind.
-
-    Parameters
-    ----------
-    kind : str
-    listener : Listener
-    """
-    assert isinstance(listener, Listener)
-    kind = _guard_kind(kind)
-    lst = _registered[kind]
-    lst.remove(listener)
-
-
 def broadcast(event):
     """Broadcast an event to all registered listeners.
 
@@ -231,178 +192,6 @@ def broadcast(event):
     """
     for listener in _registered[event.kind]:
         listener.notify(event)
-
-
-class Listener(abc.ABC):
-    """Base class for all event listeners."""
-
-    @abc.abstractmethod
-    def on_start(self, event):
-        """Called when there is a *START* event.
-
-        Parameters
-        ----------
-        event : Event
-        """
-        pass
-
-    @abc.abstractmethod
-    def on_end(self, event):
-        """Called when there is a *END* event.
-
-        Parameters
-        ----------
-        event : Event
-        """
-        pass
-
-    def notify(self, event):
-        """Notify this Listener with the given Event.
-
-        Parameters
-        ----------
-        event : Event
-        """
-        if event.is_start:
-            self.on_start(event)
-        elif event.is_end:
-            self.on_end(event)
-        else:
-            raise AssertionError("unreachable")
-
-
-class TimingListener(Listener):
-    """A listener that measures the total time spent between *START* and
-    *END* events during the time this listener is active.
-    """
-
-    def __init__(self):
-        self._depth = 0
-
-    def on_start(self, event):
-        if self._depth == 0:
-            self._ts = timer()
-        self._depth += 1
-
-    def on_end(self, event):
-        self._depth -= 1
-        if self._depth == 0:
-            last = getattr(self, "_duration", 0)
-            self._duration = (timer() - self._ts) + last
-
-    @property
-    def done(self):
-        """Returns a ``bool`` indicating whether a measurement has been made.
-
-        When this returns ``False``, the matching event has never fired.
-        If and only if this returns ``True``, ``.duration`` can be read without
-        error.
-        """
-        return hasattr(self, "_duration")
-
-    @property
-    def duration(self):
-        """Returns the measured duration.
-
-        This may raise ``AttributeError``. Users can use ``.done`` to check
-        that a measurement has been made.
-        """
-        return self._duration
-
-
-class RecordingListener(Listener):
-    """A listener that records all events and stores them in the ``.buffer``
-    attribute as a list of 2-tuple ``(float, Event)``, where the first element
-    is the time the event occurred as returned by ``time.time()`` and the second
-    element is the event.
-    """
-
-    def __init__(self):
-        self.buffer = []
-
-    def on_start(self, event):
-        self.buffer.append((time.time(), event))
-
-    def on_end(self, event):
-        self.buffer.append((time.time(), event))
-
-
-@contextmanager
-def install_listener(kind, listener):
-    """Install a listener for event "kind" temporarily within the duration of
-    the context.
-
-    Returns
-    -------
-    res : Listener
-        The *listener* provided.
-
-    Examples
-    --------
-
-    >>> with install_listener("numba-cuda:compile", listener):
-    >>>     some_code()  # listener will be active here.
-    >>> other_code()  # listener will be unregistered by this point.
-
-    """
-    register(kind, listener)
-    try:
-        yield listener
-    finally:
-        unregister(kind, listener)
-
-
-@contextmanager
-def install_timer(kind, callback):
-    """Install a TimingListener temporarily to measure the duration of
-    an event.
-
-    If the context completes successfully, the *callback* function is executed.
-    The *callback* function is expected to take a float argument for the
-    duration in seconds.
-
-    Returns
-    -------
-    res : TimingListener
-
-    Examples
-    --------
-
-    This is equivalent to:
-
-    >>> with install_listener(kind, TimingListener()) as res:
-    >>>    ...
-    """
-    tl = TimingListener()
-    with install_listener(kind, tl):
-        yield tl
-
-    if tl.done:
-        callback(tl.duration)
-
-
-@contextmanager
-def install_recorder(kind):
-    """Install a RecordingListener temporarily to record all events.
-
-    Once the context is closed, users can use ``RecordingListener.buffer``
-    to access the recorded events.
-
-    Returns
-    -------
-    res : RecordingListener
-
-    Examples
-    --------
-
-    This is equivalent to:
-
-    >>> with install_listener(kind, RecordingListener()) as res:
-    >>>    ...
-    """
-    rl = RecordingListener()
-    with install_listener(kind, rl):
-        yield rl
 
 
 def start_event(kind, data=None):
@@ -461,51 +250,3 @@ def trigger_event(kind, data=None):
 
         start_event(kind, data=data)
         yield
-
-
-def _prepare_chrome_trace_data(listener: RecordingListener):
-    """Prepare events in `listener` for serializing as chrome trace data."""
-    # The spec for the trace event format can be found at:
-    # https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/edit   # noqa
-    # This code only uses the JSON Array Format for simplicity.
-    pid = os.getpid()
-    tid = threading.get_native_id()
-    evs = []
-    for ts, rec in listener.buffer:
-        data = rec.data
-        cat = str(rec.kind)
-        ts_scaled = ts * 1_000_000  # scale to microseconds
-        ph = "B" if rec.is_start else "E"
-        name = data["name"]
-        args = data
-        ev = dict(
-            cat=cat,
-            pid=pid,
-            tid=tid,
-            ts=ts_scaled,
-            ph=ph,
-            name=name,
-            args=args,
-        )
-        evs.append(ev)
-    return evs
-
-
-def _setup_chrome_trace_exit_handler():
-    """Setup a RecordingListener and an exit handler to write the captured
-    events to file.
-    """
-    listener = RecordingListener()
-    register("numba-cuda:run_pass", listener)
-    filename = config.CHROME_TRACE
-
-    @atexit.register
-    def _write_chrome_trace():
-        # The following output file is not multi-process safe.
-        evs = _prepare_chrome_trace_data(listener)
-        with open(filename, "w") as out:
-            json.dump(evs, out, cls=utils._LazyJSONEncoder)
-
-
-if config.CHROME_TRACE:
-    _setup_chrome_trace_exit_handler()

--- a/numba_cuda/numba/cuda/core/event.py
+++ b/numba_cuda/numba/cuda/core/event.py
@@ -1,0 +1,252 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+The ``numba.cuda.core.event`` module provides a simple event system for applications
+to register callbacks to listen to specific compiler events.
+
+The following events are built in:
+
+- ``"numba:compile"`` is broadcast when a dispatcher is compiling. Events of
+  this kind have ``data`` defined to be a ``dict`` with the following
+  key-values:
+
+  - ``"dispatcher"``: the dispatcher object that is compiling.
+  - ``"args"``: the argument types.
+  - ``"return_type"``: the return type.
+
+- ``"numba:compiler_lock"`` is broadcast when the internal compiler-lock is
+  acquired. This is mostly used internally to measure time spent with the lock
+  acquired.
+
+- ``"numba:llvm_lock"`` is broadcast when the internal LLVM-lock is acquired.
+  This is used internally to measure time spent with the lock acquired.
+
+- ``"numba:run_pass"`` is broadcast when a compiler pass is running.
+
+    - ``"name"``: pass name.
+    - ``"qualname"``: qualified name of the function being compiled.
+    - ``"module"``: module name of the function being compiled.
+    - ``"flags"``: compilation flags.
+    - ``"args"``: argument types.
+    - ``"return_type"`` return type.
+
+Applications can register callbacks that are listening for specific events using
+``register(kind: str, listener: Listener)``, where ``listener`` is an instance
+of ``Listener`` that defines custom actions on occurrence of the specific event.
+"""
+
+import enum
+from contextlib import contextmanager, ExitStack
+from collections import defaultdict
+
+
+class EventStatus(enum.Enum):
+    """Status of an event."""
+
+    START = enum.auto()
+    END = enum.auto()
+
+
+# Builtin event kinds.
+_builtin_kinds = frozenset(
+    [
+        "numba:compiler_lock",
+        "numba:compile",
+        "numba:llvm_lock",
+        "numba:run_pass",
+    ]
+)
+
+
+def _guard_kind(kind):
+    """Guard to ensure that an event kind is valid.
+
+    All event kinds with a "numba:" prefix must be defined in the pre-defined
+    ``numba.cuda.core.event._builtin_kinds``.
+    Custom event kinds are allowed by not using the above prefix.
+
+    Parameters
+    ----------
+    kind : str
+
+    Return
+    ------
+    res : str
+    """
+    if kind.startswith("numba:") and kind not in _builtin_kinds:
+        msg = (
+            f"{kind} is not a valid event kind, "
+            "it starts with the reserved prefix 'numba:'"
+        )
+        raise ValueError(msg)
+    return kind
+
+
+class Event:
+    """An event.
+
+    Parameters
+    ----------
+    kind : str
+    status : EventStatus
+    data : any; optional
+        Additional data for the event.
+    exc_details : 3-tuple; optional
+        Same 3-tuple for ``__exit__``.
+    """
+
+    def __init__(self, kind, status, data=None, exc_details=None):
+        self._kind = _guard_kind(kind)
+        self._status = status
+        self._data = data
+        self._exc_details = (
+            None
+            if exc_details is None or exc_details[0] is None
+            else exc_details
+        )
+
+    @property
+    def kind(self):
+        """Event kind
+
+        Returns
+        -------
+        res : str
+        """
+        return self._kind
+
+    @property
+    def status(self):
+        """Event status
+
+        Returns
+        -------
+        res : EventStatus
+        """
+        return self._status
+
+    @property
+    def data(self):
+        """Event data
+
+        Returns
+        -------
+        res : object
+        """
+        return self._data
+
+    @property
+    def is_start(self):
+        """Is it a *START* event?
+
+        Returns
+        -------
+        res : bool
+        """
+        return self._status == EventStatus.START
+
+    @property
+    def is_end(self):
+        """Is it an *END* event?
+
+        Returns
+        -------
+        res : bool
+        """
+        return self._status == EventStatus.END
+
+    @property
+    def is_failed(self):
+        """Is the event carrying an exception?
+
+        This is used for *END* event. This method will never return ``True``
+        in a *START* event.
+
+        Returns
+        -------
+        res : bool
+        """
+        return self._exc_details is None
+
+    def __str__(self):
+        data = (
+            f"{type(self.data).__qualname__}"
+            if self.data is not None
+            else "None"
+        )
+        return f"Event({self._kind}, {self._status}, data: {data})"
+
+    __repr__ = __str__
+
+
+_registered = defaultdict(list)
+
+
+def broadcast(event):
+    """Broadcast an event to all registered listeners.
+
+    Parameters
+    ----------
+    event : Event
+    """
+    for listener in _registered[event.kind]:
+        listener.notify(event)
+
+
+def start_event(kind, data=None):
+    """Trigger the start of an event of *kind* with *data*.
+
+    Parameters
+    ----------
+    kind : str
+        Event kind.
+    data : any; optional
+        Extra event data.
+    """
+    evt = Event(kind=kind, status=EventStatus.START, data=data)
+    broadcast(evt)
+
+
+def end_event(kind, data=None, exc_details=None):
+    """Trigger the end of an event of *kind*, *exc_details*.
+
+    Parameters
+    ----------
+    kind : str
+        Event kind.
+    data : any; optional
+        Extra event data.
+    exc_details : 3-tuple; optional
+        Same 3-tuple for ``__exit__``. Or, ``None`` if no error.
+    """
+    evt = Event(
+        kind=kind,
+        status=EventStatus.END,
+        data=data,
+        exc_details=exc_details,
+    )
+    broadcast(evt)
+
+
+@contextmanager
+def trigger_event(kind, data=None):
+    """A context manager to trigger the start and end events of *kind* with
+    *data*. The start event is triggered when entering the context.
+    The end event is triggered when exiting the context.
+
+    Parameters
+    ----------
+    kind : str
+        Event kind.
+    data : any; optional
+        Extra event data.
+    """
+    with ExitStack() as scope:
+
+        @scope.push
+        def on_exit(*exc_details):
+            end_event(kind, data=data, exc_details=exc_details)
+
+        start_event(kind, data=data)
+        yield

--- a/numba_cuda/numba/cuda/core/funcdesc.py
+++ b/numba_cuda/numba/cuda/core/funcdesc.py
@@ -1,0 +1,332 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Function descriptors.
+"""
+
+from collections import defaultdict
+import importlib
+
+from numba.core import types
+from numba.cuda import itanium_mangler
+from numba.cuda.utils import _dynamic_modname, _dynamic_module
+
+
+def default_mangler(name, argtypes, *, abi_tags=(), uid=None):
+    return itanium_mangler.mangle(name, argtypes, abi_tags=abi_tags, uid=uid)
+
+
+def qualifying_prefix(modname, qualname):
+    """
+    Returns a new string that is used for the first half of the mangled name.
+    """
+    # XXX choose a different convention for object mode
+    return "{}.{}".format(modname, qualname) if modname else qualname
+
+
+class FunctionDescriptor(object):
+    """
+    Base class for function descriptors: an object used to carry
+    useful metadata about a natively callable function.
+
+    Note that while `FunctionIdentity` denotes a Python function
+    which is being concretely compiled by Numba, `FunctionDescriptor`
+    may be more "abstract".
+    """
+
+    __slots__ = (
+        "native",
+        "modname",
+        "qualname",
+        "doc",
+        "typemap",
+        "calltypes",
+        "args",
+        "kws",
+        "restype",
+        "argtypes",
+        "mangled_name",
+        "unique_name",
+        "env_name",
+        "global_dict",
+        "inline",
+        "noalias",
+        "abi_tags",
+        "uid",
+    )
+
+    def __init__(
+        self,
+        native,
+        modname,
+        qualname,
+        unique_name,
+        doc,
+        typemap,
+        restype,
+        calltypes,
+        args,
+        kws,
+        mangler=None,
+        argtypes=None,
+        inline=False,
+        noalias=False,
+        env_name=None,
+        global_dict=None,
+        abi_tags=(),
+        uid=None,
+    ):
+        self.native = native
+        self.modname = modname
+        self.global_dict = global_dict
+        self.qualname = qualname
+        self.unique_name = unique_name
+        self.doc = doc
+        # XXX typemap and calltypes should be on the compile result,
+        # not the FunctionDescriptor
+        self.typemap = typemap
+        self.calltypes = calltypes
+        self.args = args
+        self.kws = kws
+        self.restype = restype
+        # Argument types
+        if argtypes is not None:
+            assert isinstance(argtypes, tuple), argtypes
+            self.argtypes = argtypes
+        else:
+            # Get argument types from the type inference result
+            # (note the "arg.FOO" convention as used in typeinfer
+            self.argtypes = tuple(self.typemap["arg." + a] for a in args)
+        mangler = default_mangler if mangler is None else mangler
+        # The mangled name *must* be unique, else the wrong function can
+        # be chosen at link time.
+        qualprefix = qualifying_prefix(self.modname, self.qualname)
+        self.uid = uid
+        self.mangled_name = mangler(
+            qualprefix,
+            self.argtypes,
+            abi_tags=abi_tags,
+            uid=uid,
+        )
+        if env_name is None:
+            env_name = mangler(
+                ".NumbaEnv.{}".format(qualprefix),
+                self.argtypes,
+                abi_tags=abi_tags,
+                uid=uid,
+            )
+        self.env_name = env_name
+        self.inline = inline
+        self.noalias = noalias
+        self.abi_tags = abi_tags
+
+    def lookup_globals(self):
+        """
+        Return the global dictionary of the function.
+        It may not match the Module's globals if the function is created
+        dynamically (i.e. exec)
+        """
+        return self.global_dict or self.lookup_module().__dict__
+
+    def lookup_module(self):
+        """
+        Return the module in which this function is supposed to exist.
+        This may be a dummy module if the function was dynamically
+        generated or the module can't be found.
+        """
+        if self.modname == _dynamic_modname:
+            return _dynamic_module
+        else:
+            try:
+                # ensure module exist
+                return importlib.import_module(self.modname)
+            except ImportError:
+                return _dynamic_module
+
+    def lookup_function(self):
+        """
+        Return the original function object described by this object.
+        """
+        return getattr(self.lookup_module(), self.qualname)
+
+    @property
+    def llvm_func_name(self):
+        """
+        The LLVM-registered name for the raw function.
+        """
+        return self.mangled_name
+
+    # XXX refactor this
+
+    @property
+    def llvm_cpython_wrapper_name(self):
+        """
+        The LLVM-registered name for a CPython-compatible wrapper of the
+        raw function (i.e. a PyCFunctionWithKeywords).
+        """
+        return itanium_mangler.prepend_namespace(
+            self.mangled_name, ns="cpython"
+        )
+
+    @property
+    def llvm_cfunc_wrapper_name(self):
+        """
+        The LLVM-registered name for a C-compatible wrapper of the
+        raw function.
+        """
+        return "cfunc." + self.mangled_name
+
+    def __repr__(self):
+        return "<function descriptor %r>" % (self.unique_name)
+
+    @classmethod
+    def _get_function_info(cls, func_ir):
+        """
+        Returns
+        -------
+        qualname, unique_name, modname, doc, args, kws, globals
+
+        ``unique_name`` must be a unique name.
+        """
+        func = func_ir.func_id.func
+        qualname = func_ir.func_id.func_qualname
+        # XXX to func_id
+        modname = func.__module__
+        doc = func.__doc__ or ""
+        args = tuple(func_ir.arg_names)
+        kws = ()  # TODO
+        global_dict = None
+
+        if modname is None:
+            # Dynamically generated function.
+            modname = _dynamic_modname
+            # Retain a reference to the dictionary of the function.
+            # This disables caching, serialization and pickling.
+            global_dict = func_ir.func_id.func.__globals__
+
+        unique_name = func_ir.func_id.unique_name
+
+        return qualname, unique_name, modname, doc, args, kws, global_dict
+
+    @classmethod
+    def _from_python_function(
+        cls,
+        func_ir,
+        typemap,
+        restype,
+        calltypes,
+        native,
+        mangler=None,
+        inline=False,
+        noalias=False,
+        abi_tags=(),
+    ):
+        (
+            qualname,
+            unique_name,
+            modname,
+            doc,
+            args,
+            kws,
+            global_dict,
+        ) = cls._get_function_info(func_ir)
+
+        self = cls(
+            native,
+            modname,
+            qualname,
+            unique_name,
+            doc,
+            typemap,
+            restype,
+            calltypes,
+            args,
+            kws,
+            mangler=mangler,
+            inline=inline,
+            noalias=noalias,
+            global_dict=global_dict,
+            abi_tags=abi_tags,
+            uid=func_ir.func_id.unique_id,
+        )
+        return self
+
+
+class PythonFunctionDescriptor(FunctionDescriptor):
+    """
+    A FunctionDescriptor subclass for Numba-compiled functions.
+    """
+
+    __slots__ = ()
+
+    @classmethod
+    def from_specialized_function(
+        cls,
+        func_ir,
+        typemap,
+        restype,
+        calltypes,
+        mangler,
+        inline,
+        noalias,
+        abi_tags,
+    ):
+        """
+        Build a FunctionDescriptor for a given specialization of a Python
+        function (in nopython mode).
+        """
+        return cls._from_python_function(
+            func_ir,
+            typemap,
+            restype,
+            calltypes,
+            native=True,
+            mangler=mangler,
+            inline=inline,
+            noalias=noalias,
+            abi_tags=abi_tags,
+        )
+
+    @classmethod
+    def from_object_mode_function(cls, func_ir):
+        """
+        Build a FunctionDescriptor for an object mode variant of a Python
+        function.
+        """
+        typemap = defaultdict(lambda: types.pyobject)
+        calltypes = typemap.copy()
+        restype = types.pyobject
+        return cls._from_python_function(
+            func_ir, typemap, restype, calltypes, native=False
+        )
+
+
+class ExternalFunctionDescriptor(FunctionDescriptor):
+    """
+    A FunctionDescriptor subclass for opaque external functions
+    (e.g. raw C functions).
+    """
+
+    __slots__ = ()
+
+    def __init__(self, name, restype, argtypes):
+        args = ["arg%d" % i for i in range(len(argtypes))]
+
+        def mangler(a, x, abi_tags, uid=None):
+            return a
+
+        super(ExternalFunctionDescriptor, self).__init__(
+            native=True,
+            modname=None,
+            qualname=name,
+            unique_name=name,
+            doc="",
+            typemap=None,
+            restype=restype,
+            calltypes=None,
+            args=args,
+            kws=None,
+            mangler=mangler,
+            argtypes=argtypes,
+        )

--- a/numba_cuda/numba/cuda/core/funcdesc.py
+++ b/numba_cuda/numba/cuda/core/funcdesc.py
@@ -157,8 +157,6 @@ class FunctionDescriptor(object):
         """
         return self.mangled_name
 
-    # XXX refactor this
-
     @property
     def llvm_cpython_wrapper_name(self):
         """

--- a/numba_cuda/numba/cuda/core/options.py
+++ b/numba_cuda/numba/cuda/core/options.py
@@ -8,6 +8,68 @@ Defines CUDA Options for use in the CUDA target
 from abc import ABCMeta, abstractmethod
 
 
+class TargetOptions:
+    """Target options maps user options from decorators to the
+    ``numba.cuda.core.compiler.Flags`` used by lowering and target context.
+    """
+
+    class Mapping:
+        def __init__(self, flag_name, apply=lambda x: x):
+            self.flag_name = flag_name
+            self.apply = apply
+
+    def finalize(self, flags, options):
+        """Subclasses can override this method to make target specific
+        customizations of default flags.
+
+        Parameters
+        ----------
+        flags : Flags
+        options : dict
+        """
+        pass
+
+    @classmethod
+    def parse_as_flags(cls, flags, options):
+        """Parse target options defined in ``options`` and set ``flags``
+        accordingly.
+
+        Parameters
+        ----------
+        flags : Flags
+        options : dict
+        """
+        opt = cls()
+        opt._apply(flags, options)
+        opt.finalize(flags, options)
+        return flags
+
+    def _apply(self, flags, options):
+        # Find all Mapping instances in the class
+        mappings = {}
+        cls = type(self)
+        for k in dir(cls):
+            v = getattr(cls, k)
+            if isinstance(v, cls.Mapping):
+                mappings[k] = v
+
+        used = set()
+        for k, mapping in mappings.items():
+            if k in options:
+                v = mapping.apply(options[k])
+                setattr(flags, mapping.flag_name, v)
+                used.add(k)
+
+        unused = set(options) - used
+        if unused:
+            # Unread options?
+            m = (
+                f"Unrecognized options: {unused}. "
+                f"Known options are {mappings.keys()}"
+            )
+            raise KeyError(m)
+
+
 class AbstractOptionValue(metaclass=ABCMeta):
     """Abstract base class for custom option values."""
 

--- a/numba_cuda/numba/cuda/core/targetconfig.py
+++ b/numba_cuda/numba/cuda/core/targetconfig.py
@@ -11,7 +11,7 @@ import zlib
 import base64
 
 from types import MappingProxyType
-from numba.core.targetconfig import ConfigStack
+from numba.cuda import utils
 
 
 class Option:
@@ -46,6 +46,47 @@ class Option:
     @property
     def doc(self):
         return self._doc
+
+
+try:
+    from numba.core.targetconfig import ConfigStack, _FlagsStack
+except ImportError:
+
+    class _FlagsStack(utils.ThreadLocalStack, stack_name="flags"):
+        pass
+
+    class ConfigStack:
+        """A stack for tracking target configurations in the compiler.
+
+        It stores the stack in a thread-local class attribute. All instances in the
+        same thread will see the same stack.
+        """
+
+        @classmethod
+        def top_or_none(cls):
+            """Get the TOS or return None if no config is set."""
+            self = cls()
+            if self:
+                flags = self.top()
+            else:
+                # Note: should this be the default flag for the target instead?
+                flags = None
+            return flags
+
+        def __init__(self):
+            self._stk = _FlagsStack()
+
+        def top(self):
+            return self._stk.top()
+
+        def __len__(self):
+            return len(self._stk)
+
+        def enter(self, flags):
+            """Returns a contextmanager that performs ``push(flags)`` on enter and
+            ``pop()`` on exit.
+            """
+            return self._stk.enter(flags)
 
 
 class _MetaTargetConfig(type):

--- a/numba_cuda/numba/cuda/core/targetconfig.py
+++ b/numba_cuda/numba/cuda/core/targetconfig.py
@@ -11,7 +11,7 @@ import zlib
 import base64
 
 from types import MappingProxyType
-from numba.cuda import utils
+from numba.core.targetconfig import ConfigStack
 
 
 class Option:
@@ -46,44 +46,6 @@ class Option:
     @property
     def doc(self):
         return self._doc
-
-
-class _FlagsStack(utils.ThreadLocalStack, stack_name="flags"):
-    pass
-
-
-class ConfigStack:
-    """A stack for tracking target configurations in the compiler.
-
-    It stores the stack in a thread-local class attribute. All instances in the
-    same thread will see the same stack.
-    """
-
-    @classmethod
-    def top_or_none(cls):
-        """Get the TOS or return None if no config is set."""
-        self = cls()
-        if self:
-            flags = self.top()
-        else:
-            # Note: should this be the default flag for the target instead?
-            flags = None
-        return flags
-
-    def __init__(self):
-        self._stk = _FlagsStack()
-
-    def top(self):
-        return self._stk.top()
-
-    def __len__(self):
-        return len(self._stk)
-
-    def enter(self, flags):
-        """Returns a contextmanager that performs ``push(flags)`` on enter and
-        ``pop()`` on exit.
-        """
-        return self._stk.enter(flags)
 
 
 class _MetaTargetConfig(type):

--- a/numba_cuda/numba/cuda/core/targetconfig.py
+++ b/numba_cuda/numba/cuda/core/targetconfig.py
@@ -1,0 +1,326 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+This module contains utils for manipulating target configurations such as
+compiler flags.
+"""
+
+import re
+import zlib
+import base64
+
+from types import MappingProxyType
+from numba.cuda import utils
+
+
+class Option:
+    """An option to be used in ``TargetConfig``."""
+
+    __slots__ = "_type", "_default", "_doc"
+
+    def __init__(self, type, *, default, doc):
+        """
+        Parameters
+        ----------
+        type :
+            Type of the option value. It can be a callable.
+            The setter always calls ``self._type(value)``.
+        default :
+            The default value for the option.
+        doc : str
+            Docstring for the option.
+        """
+        self._type = type
+        self._default = default
+        self._doc = doc
+
+    @property
+    def type(self):
+        return self._type
+
+    @property
+    def default(self):
+        return self._default
+
+    @property
+    def doc(self):
+        return self._doc
+
+
+class _FlagsStack(utils.ThreadLocalStack, stack_name="flags"):
+    pass
+
+
+class ConfigStack:
+    """A stack for tracking target configurations in the compiler.
+
+    It stores the stack in a thread-local class attribute. All instances in the
+    same thread will see the same stack.
+    """
+
+    @classmethod
+    def top_or_none(cls):
+        """Get the TOS or return None if no config is set."""
+        self = cls()
+        if self:
+            flags = self.top()
+        else:
+            # Note: should this be the default flag for the target instead?
+            flags = None
+        return flags
+
+    def __init__(self):
+        self._stk = _FlagsStack()
+
+    def top(self):
+        return self._stk.top()
+
+    def __len__(self):
+        return len(self._stk)
+
+    def enter(self, flags):
+        """Returns a contextmanager that performs ``push(flags)`` on enter and
+        ``pop()`` on exit.
+        """
+        return self._stk.enter(flags)
+
+
+class _MetaTargetConfig(type):
+    """Metaclass for ``TargetConfig``.
+
+    When a subclass of ``TargetConfig`` is created, all ``Option`` defined
+    as class members will be parsed and corresponding getters, setters, and
+    delters will be inserted.
+    """
+
+    def __init__(cls, name, bases, dct):
+        """Invoked when subclass is created.
+
+        Insert properties for each ``Option`` that are class members.
+        All the options will be grouped inside the ``.options`` class
+        attribute.
+        """
+        # Gather options from base classes and class dict
+        opts = {}
+        # Reversed scan into the base classes to follow MRO ordering such that
+        # the closest base class is overriding
+        for base_cls in reversed(bases):
+            opts.update(base_cls.options)
+        opts.update(cls.find_options(dct))
+        # Store the options into class attribute as a ready-only mapping.
+        cls.options = MappingProxyType(opts)
+
+        # Make properties for each of the options
+        def make_prop(name, option):
+            def getter(self):
+                return self._values.get(name, option.default)
+
+            def setter(self, val):
+                self._values[name] = option.type(val)
+
+            def delter(self):
+                del self._values[name]
+
+            return property(getter, setter, delter, option.doc)
+
+        for name, option in cls.options.items():
+            setattr(cls, name, make_prop(name, option))
+
+    def find_options(cls, dct):
+        """Returns a new dict with all the items that are a mapping to an
+        ``Option``.
+        """
+        return {k: v for k, v in dct.items() if isinstance(v, Option)}
+
+
+class _NotSetType:
+    def __repr__(self):
+        return "<NotSet>"
+
+
+_NotSet = _NotSetType()
+
+
+class TargetConfig(metaclass=_MetaTargetConfig):
+    """Base class for ``TargetConfig``.
+
+    Subclass should fill class members with ``Option``. For example:
+
+    >>> class MyTargetConfig(TargetConfig):
+    >>>     a_bool_option = Option(type=bool, default=False, doc="a bool")
+    >>>     an_int_option = Option(type=int, default=0, doc="an int")
+
+    The metaclass will insert properties for each ``Option``. For example:
+
+    >>> tc = MyTargetConfig()
+    >>> tc.a_bool_option = True  # invokes the setter
+    >>> print(tc.an_int_option)  # print the default
+    """
+
+    __slots__ = ["_values"]
+
+    # Used for compression in mangling.
+    # Set to -15 to disable the header and checksum for smallest output.
+    _ZLIB_CONFIG = {"wbits": -15}
+
+    def __init__(self, copy_from=None):
+        """
+        Parameters
+        ----------
+        copy_from : TargetConfig or None
+            if None, creates an empty ``TargetConfig``.
+            Otherwise, creates a copy.
+        """
+        self._values = {}
+        if copy_from is not None:
+            assert isinstance(copy_from, TargetConfig)
+            self._values.update(copy_from._values)
+
+    def __repr__(self):
+        # NOTE: default options will be placed at the end and grouped inside
+        #       a square bracket; i.e. [optname=optval, ...]
+        args = []
+        defs = []
+        for k in self.options:
+            msg = f"{k}={getattr(self, k)}"
+            if not self.is_set(k):
+                defs.append(msg)
+            else:
+                args.append(msg)
+        clsname = self.__class__.__name__
+        return f"{clsname}({', '.join(args)}, [{', '.join(defs)}])"
+
+    def __hash__(self):
+        return hash(tuple(sorted(self.values())))
+
+    def __eq__(self, other):
+        if isinstance(other, TargetConfig):
+            return self.values() == other.values()
+        else:
+            return NotImplemented
+
+    def values(self):
+        """Returns a dict of all the values"""
+        return {k: getattr(self, k) for k in self.options}
+
+    def is_set(self, name):
+        """Is the option set?"""
+        self._guard_option(name)
+        return name in self._values
+
+    def discard(self, name):
+        """Remove the option by name if it is defined.
+
+        After this, the value for the option will be set to its default value.
+        """
+        self._guard_option(name)
+        self._values.pop(name, None)
+
+    def inherit_if_not_set(self, name, default=_NotSet):
+        """Inherit flag from ``ConfigStack``.
+
+        Parameters
+        ----------
+        name : str
+            Option name.
+        default : optional
+            When given, it overrides the default value.
+            It is only used when the flag is not defined locally and there is
+            no entry in the ``ConfigStack``.
+        """
+        self._guard_option(name)
+        if not self.is_set(name):
+            cstk = ConfigStack()
+            if cstk:
+                # inherit
+                top = cstk.top()
+                setattr(self, name, getattr(top, name))
+            elif default is not _NotSet:
+                setattr(self, name, default)
+
+    def copy(self):
+        """Clone this instance."""
+        return type(self)(self)
+
+    def summary(self) -> str:
+        """Returns a ``str`` that summarizes this instance.
+
+        In contrast to ``__repr__``, only options that are explicitly set will
+        be shown.
+        """
+        args = [f"{k}={v}" for k, v in self._summary_args()]
+        clsname = self.__class__.__name__
+        return f"{clsname}({', '.join(args)})"
+
+    def _guard_option(self, name):
+        if name not in self.options:
+            msg = f"{name!r} is not a valid option for {type(self)}"
+            raise ValueError(msg)
+
+    def _summary_args(self):
+        """returns a sorted sequence of 2-tuple containing the
+        ``(flag_name, flag_value)`` for flag that are set with a non-default
+        value.
+        """
+        args = []
+        for k in sorted(self.options):
+            opt = self.options[k]
+            if self.is_set(k):
+                flagval = getattr(self, k)
+                if opt.default != flagval:
+                    v = (k, flagval)
+                    args.append(v)
+        return args
+
+    @classmethod
+    def _make_compression_dictionary(cls) -> bytes:
+        """Returns a ``bytes`` object suitable for use as a dictionary for
+        compression.
+        """
+        buf = []
+        # include package name
+        buf.append("numba")
+        # include class name
+        buf.append(cls.__class__.__name__)
+        # include common values
+        buf.extend(["True", "False"])
+        # include all options name and their default value
+        for k, opt in cls.options.items():
+            buf.append(k)
+            buf.append(str(opt.default))
+        return "".join(buf).encode()
+
+    def get_mangle_string(self) -> str:
+        """Return a string suitable for symbol mangling."""
+        zdict = self._make_compression_dictionary()
+
+        comp = zlib.compressobj(
+            zdict=zdict, level=zlib.Z_BEST_COMPRESSION, **self._ZLIB_CONFIG
+        )
+        # The mangled string is a compressed and base64 encoded version of the
+        # summary
+        buf = [comp.compress(self.summary().encode())]
+        buf.append(comp.flush())
+        return base64.b64encode(b"".join(buf)).decode()
+
+    @classmethod
+    def demangle(cls, mangled: str) -> str:
+        """Returns the demangled result from ``.get_mangle_string()``"""
+
+        # unescape _XX sequence
+        def repl(x):
+            return chr(int("0x" + x.group(0)[1:], 16))
+
+        unescaped = re.sub(r"_[a-zA-Z0-9][a-zA-Z0-9]", repl, mangled)
+        # decode base64
+        raw = base64.b64decode(unescaped)
+        # decompress
+        zdict = cls._make_compression_dictionary()
+        dc = zlib.decompressobj(zdict=zdict, **cls._ZLIB_CONFIG)
+        buf = []
+        while raw:
+            buf.append(dc.decompress(raw))
+            raw = dc.unconsumed_tail
+        buf.append(dc.flush())
+        return b"".join(buf).decode()

--- a/numba_cuda/numba/cuda/core/typed_passes.py
+++ b/numba_cuda/numba/cuda/core/typed_passes.py
@@ -12,7 +12,6 @@ from numba.core import (
     types,
     typing,
     ir,
-    funcdesc,
     typeinfer,
     config,
     lowering,
@@ -36,7 +35,7 @@ from numba.cuda.core.ir_utils import (
     compute_cfg_from_blocks,
     is_operator_or_getitem,
 )
-from numba.cuda.core import postproc, rewrites
+from numba.cuda.core import postproc, rewrites, funcdesc
 from llvmlite import binding as llvm
 
 

--- a/numba_cuda/numba/cuda/descriptor.py
+++ b/numba_cuda/numba/cuda/descriptor.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+from abc import ABCMeta
 from numba.cuda.core.options import TargetOptions
 from .target import CUDATargetContext, CUDATypingContext
 
@@ -9,7 +10,7 @@ class CUDATargetOptions(TargetOptions):
     pass
 
 
-class CUDATarget:
+class CUDATarget(metaclass=ABCMeta):
     def __init__(self, name):
         self.options = CUDATargetOptions
         # The typing and target contexts are initialized only when needed -

--- a/numba_cuda/numba/cuda/descriptor.py
+++ b/numba_cuda/numba/cuda/descriptor.py
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-from numba.core.descriptors import TargetDescriptor
-from numba.core.options import TargetOptions
+from abc import ABCMeta
+from numba.cuda.core.options import TargetOptions
 from .target import CUDATargetContext, CUDATypingContext
 
 
@@ -10,7 +10,7 @@ class CUDATargetOptions(TargetOptions):
     pass
 
 
-class CUDATarget(TargetDescriptor):
+class CUDATarget(metaclass=ABCMeta):
     def __init__(self, name):
         self.options = CUDATargetOptions
         # The typing and target contexts are initialized only when needed -
@@ -18,7 +18,7 @@ class CUDATarget(TargetDescriptor):
         # systems that might not have them present.
         self._typingctx = None
         self._targetctx = None
-        super().__init__(name)
+        self._target_name = name
 
     @property
     def typing_context(self):

--- a/numba_cuda/numba/cuda/descriptor.py
+++ b/numba_cuda/numba/cuda/descriptor.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-from abc import ABCMeta
 from numba.cuda.core.options import TargetOptions
 from .target import CUDATargetContext, CUDATypingContext
 
@@ -10,7 +9,7 @@ class CUDATargetOptions(TargetOptions):
     pass
 
 
-class CUDATarget(metaclass=ABCMeta):
+class CUDATarget:
     def __init__(self, name):
         self.options = CUDATargetOptions
         # The typing and target contexts are initialized only when needed -

--- a/numba_cuda/numba/cuda/flags.py
+++ b/numba_cuda/numba/cuda/flags.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-from numba.core.targetconfig import TargetConfig, Option
+from numba.cuda.core.targetconfig import TargetConfig, Option
 
 from numba.core import cpu
 

--- a/numba_cuda/numba/cuda/lowering.py
+++ b/numba_cuda/numba/cuda/lowering.py
@@ -11,13 +11,14 @@ from llvmlite import ir as llvm_ir
 from numba.core import (
     typing,
     types,
+    targetconfig,
     ir,
     generators,
     config,
     removerefctpass,
 )
 from numba.cuda import debuginfo, cgutils, utils
-from numba.cuda.core import ir_utils, targetconfig, funcdesc
+from numba.cuda.core import ir_utils, funcdesc
 from numba.core.errors import (
     LoweringError,
     new_error_context,

--- a/numba_cuda/numba/cuda/lowering.py
+++ b/numba_cuda/numba/cuda/lowering.py
@@ -11,14 +11,13 @@ from llvmlite import ir as llvm_ir
 from numba.core import (
     typing,
     types,
-    targetconfig,
     ir,
     generators,
     config,
     removerefctpass,
 )
 from numba.cuda import debuginfo, cgutils, utils
-from numba.cuda.core import ir_utils, funcdesc
+from numba.cuda.core import ir_utils, targetconfig, funcdesc
 from numba.core.errors import (
     LoweringError,
     new_error_context,

--- a/numba_cuda/numba/cuda/lowering.py
+++ b/numba_cuda/numba/cuda/lowering.py
@@ -12,14 +12,12 @@ from numba.core import (
     typing,
     types,
     ir,
-    funcdesc,
     generators,
     config,
     removerefctpass,
-    targetconfig,
 )
 from numba.cuda import debuginfo, cgutils, utils
-from numba.cuda.core import ir_utils
+from numba.cuda.core import ir_utils, targetconfig, funcdesc
 from numba.core.errors import (
     LoweringError,
     new_error_context,
@@ -28,7 +26,7 @@ from numba.core.errors import (
     UnsupportedError,
     NumbaDebugInfoWarning,
 )
-from numba.core.funcdesc import default_mangler
+from numba.cuda.core.funcdesc import default_mangler
 from numba.cuda.core.environment import Environment
 from numba.core.analysis import compute_use_defs, must_use_alloca
 from numba.misc.firstlinefinder import get_func_body_first_lineno

--- a/numba_cuda/numba/cuda/mathimpl.py
+++ b/numba_cuda/numba/cuda/mathimpl.py
@@ -4,12 +4,11 @@
 import math
 import operator
 from llvmlite import ir
-from numba.core import types, typing
+from numba.core import types, typing, targetconfig
 from numba.cuda import cgutils
 from numba.core.imputils import Registry
 from numba.types import float32, float64, int64, uint64
 from numba.cuda import libdevice
-from numba.cuda.core import targetconfig
 
 registry = Registry()
 lower = registry.lower

--- a/numba_cuda/numba/cuda/mathimpl.py
+++ b/numba_cuda/numba/cuda/mathimpl.py
@@ -4,11 +4,12 @@
 import math
 import operator
 from llvmlite import ir
-from numba.core import types, typing, targetconfig
+from numba.core import types, typing
 from numba.cuda import cgutils
 from numba.core.imputils import Registry
 from numba.types import float32, float64, int64, uint64
 from numba.cuda import libdevice
+from numba.cuda.core import targetconfig
 
 registry = Registry()
 lower = registry.lower

--- a/numba_cuda/numba/cuda/nvvmutils.py
+++ b/numba_cuda/numba/cuda/nvvmutils.py
@@ -3,7 +3,7 @@
 
 import itertools
 from llvmlite import ir
-from numba.cuda.core import targetconfig
+from numba.core import targetconfig
 from numba.cuda import cgutils
 from .cudadrv import nvvm
 

--- a/numba_cuda/numba/cuda/nvvmutils.py
+++ b/numba_cuda/numba/cuda/nvvmutils.py
@@ -3,7 +3,7 @@
 
 import itertools
 from llvmlite import ir
-from numba.core import targetconfig
+from numba.cuda.core import targetconfig
 from numba.cuda import cgutils
 from .cudadrv import nvvm
 

--- a/numba_cuda/numba/cuda/target.py
+++ b/numba_cuda/numba/cuda/target.py
@@ -9,7 +9,6 @@ import warnings
 
 from numba.core import (
     config,
-    targetconfig,
     types,
 )
 from numba.core.compiler_lock import global_compiler_lock
@@ -32,6 +31,7 @@ from numba.cuda.debuginfo import CUDADIBuilder
 from numba.cuda.flags import CUDAFlags
 from numba.cuda.models import cuda_data_manager
 from numba.cuda.core.callconv import BaseCallConv, MinimalCallConv
+from numba.cuda.core import targetconfig
 
 # -----------------------------------------------------------------------------
 # Typing

--- a/numba_cuda/numba/cuda/target.py
+++ b/numba_cuda/numba/cuda/target.py
@@ -10,6 +10,7 @@ import warnings
 from numba.core import (
     config,
     types,
+    targetconfig,
 )
 from numba.core.compiler_lock import global_compiler_lock
 from numba.core.dispatcher import Dispatcher
@@ -31,7 +32,6 @@ from numba.cuda.debuginfo import CUDADIBuilder
 from numba.cuda.flags import CUDAFlags
 from numba.cuda.models import cuda_data_manager
 from numba.cuda.core.callconv import BaseCallConv, MinimalCallConv
-from numba.cuda.core import targetconfig
 
 # -----------------------------------------------------------------------------
 # Typing

--- a/numba_cuda/numba/cuda/target.py
+++ b/numba_cuda/numba/cuda/target.py
@@ -10,7 +10,6 @@ import warnings
 from numba.core import (
     config,
     types,
-    targetconfig,
 )
 from numba.core.compiler_lock import global_compiler_lock
 from numba.core.dispatcher import Dispatcher
@@ -32,6 +31,7 @@ from numba.cuda.debuginfo import CUDADIBuilder
 from numba.cuda.flags import CUDAFlags
 from numba.cuda.models import cuda_data_manager
 from numba.cuda.core.callconv import BaseCallConv, MinimalCallConv
+from numba.cuda.core import targetconfig
 
 # -----------------------------------------------------------------------------
 # Typing

--- a/numba_cuda/numba/cuda/typing/templates.py
+++ b/numba_cuda/numba/cuda/typing/templates.py
@@ -15,7 +15,7 @@ from collections.abc import Sequence
 from types import MethodType, FunctionType, MappingProxyType
 
 import numba
-from numba.core import types
+from numba.core import types, targetconfig
 from numba.core.errors import (
     TypingError,
     InternalError,
@@ -23,7 +23,7 @@ from numba.core.errors import (
 from numba.cuda.core.options import InlineOptions
 from numba.core.typing.templates import Signature as CoreSignature
 from numba.cuda import utils
-from numba.cuda.core import ir_utils, targetconfig
+from numba.cuda.core import ir_utils
 
 # info store for inliner callback functions e.g. cost model
 _inline_info = namedtuple("inline_info", "func_ir typemap calltypes signature")

--- a/numba_cuda/numba/cuda/typing/templates.py
+++ b/numba_cuda/numba/cuda/typing/templates.py
@@ -15,7 +15,7 @@ from collections.abc import Sequence
 from types import MethodType, FunctionType, MappingProxyType
 
 import numba
-from numba.core import types, targetconfig
+from numba.core import types
 from numba.core.errors import (
     TypingError,
     InternalError,
@@ -23,7 +23,7 @@ from numba.core.errors import (
 from numba.cuda.core.options import InlineOptions
 from numba.core.typing.templates import Signature as CoreSignature
 from numba.cuda import utils
-from numba.cuda.core import ir_utils
+from numba.cuda.core import ir_utils, targetconfig
 
 # info store for inliner callback functions e.g. cost model
 _inline_info = namedtuple("inline_info", "func_ir typemap calltypes signature")


### PR DESCRIPTION
This PR vendors in `targetconfig`, `event`, `funcdesc`, `descriptors` from `numba.core` for CUDA-Specific customization.