### PR TITLE
Improve debug value range coverage

### DIFF
--- a/numba_cuda/numba/cuda/lowering.py
+++ b/numba_cuda/numba/cuda/lowering.py
@@ -1833,33 +1833,67 @@ class CUDALower(Lower):
             self.context.enable_debuginfo
             # Conditions used to elide stores in parent method
             and self.store_var_needed(name)
-            # No emission of debuginfo for internal names
-            and not name.startswith("$")
         ):
-            # Emit debug value for user variable
             fetype = self.typeof(name)
             lltype = self.context.get_value_type(fetype)
             int_type = (llvm_ir.IntType,)
             real_type = llvm_ir.FloatType, llvm_ir.DoubleType
             if isinstance(lltype, int_type + real_type):
-                src_name = name.split(".")[0]
-                if src_name in self.poly_var_typ_map:
-                    # Do not emit debug value on polymorphic type var
-                    return
-                # Emit debug value for scalar variable
                 sizeof = self.context.get_abi_sizeof(lltype)
                 datamodel = self.context.data_model_manager[fetype]
                 line = self.loc.line if argidx is None else self.defn_loc.line
-                self.debuginfo.update_variable(
-                    self.builder,
-                    value,
-                    name,
-                    lltype,
-                    sizeof,
-                    line,
-                    datamodel,
-                    argidx,
-                )
+                if not name.startswith("$"):
+                    # Emit debug value for user variable
+                    src_name = name.split(".")[0]
+                    if src_name not in self.poly_var_typ_map:
+                        # Insert the llvm.dbg.value intrinsic call
+                        self.debuginfo.update_variable(
+                            self.builder,
+                            value,
+                            src_name,
+                            lltype,
+                            sizeof,
+                            line,
+                            datamodel,
+                            argidx,
+                        )
+                elif isinstance(value, llvm_ir.LoadInstr):
+                    # Emit debug value for user variable that falls out of the
+                    # coverage of dbg.value range per basic block
+                    ld_name = value.operands[0].name
+                    if not ld_name.startswith(("$", ".")):
+                        src_name = ld_name.split(".")[0]
+                        if (
+                            src_name not in self.poly_var_typ_map
+                            # Not yet covered by the dbg.value range
+                            and src_name not in self.dbg_val_names
+                        ):
+                            # Insert the llvm.dbg.value intrinsic call
+                            self.debuginfo.update_variable(
+                                self.builder,
+                                value,
+                                src_name,
+                                lltype,
+                                sizeof,
+                                line,
+                                datamodel,
+                                argidx,
+                            )
+
+    def pre_block(self, block):
+        super().pre_block(block)
+
+        # dbg.value range covered names
+        self.dbg_val_names = set()
+
+        if self.context.enable_debuginfo and self._disable_sroa_like_opt:
+            for x in block.find_insts(ir.Assign):
+                if x.target.name.startswith("$"):
+                    continue
+                ssa_name = x.target.name
+                src_name = ssa_name.split(".")[0]
+                if src_name not in self.dbg_val_names:
+                    self.dbg_val_names.add(src_name)
 
     def pre_lower(self):
         """

--- a/numba_cuda/numba/cuda/tests/cudapy/test_debuginfo.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_debuginfo.py
@@ -348,6 +348,33 @@ class TestCudaDebugInfo(CUDATestCase):
         match = re.compile(pat2).search(llvm_ir)
         self.assertIsNotNone(match, msg=llvm_ir)
 
+    def test_llvm_dbg_value_range(self):
+        sig = (types.int64,)
+
+        @cuda.jit("void(int64,)", debug=True, opt=False)
+        def foo(x):
+            """
+            CHECK-LABEL: define void @{{.+}}foo
+
+            CHECK: %[[VAL_0:.+]] = load i8*, i8** %"$bool32"
+            CHECK: store i8* null, i8** %"$bool32"
+            CHECK: %[[VAL_1:.+]] = load i1, i1* %"second.2"
+            CHECK: %[[VAL_2:.+]] = load i1, i1* %[[VAL_3:.+]]
+            CHECK: store i1 %[[VAL_1]], i1* %[[VAL_3]]
+            CHECK: call void @"llvm.dbg.value"(metadata i1 %[[VAL_1]], metadata ![[VAL_4:[0-9]+]]
+
+            CHECK: ![[VAL_4]] = !DILocalVariable{{.+}}name: "second"
+            """
+            if x > 0:
+                second = x > 10
+            else:
+                second = True
+            if second:
+                pass
+
+        ir = foo.inspect_llvm()[sig]
+        self.assertFileCheckMatches(ir, foo.__doc__)
+
     def test_no_user_var_alias(self):
         sig = (types.int32, types.int32)
 


### PR DESCRIPTION
The current kernel debug support tracks debug value of variables by inserting dbg.value immediate after a store instruction to a user variable. However, in some specific scenario the debug value info could be missing range, see details in nvbug#5321343, when a basic block has a load instruction loading from a user variable and saving to a temparary, then store the temporary to an internal variable without any other assignment instruction saving value to that user variable in the whole basic block. The back end libnvvm can not fully track the variable value in this scenario.

This PR adds the enhanced handling of debug value, detecting the not yet covered user variable and inserting the dbg.value for the missing range per basic block.

A test is also added to guard this change.

<!--

Thank you for contributing to numba-cuda :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
