### PR TITLE
Vendor the annotations module for CUDA-specific refactoring

### DIFF
--- a/numba_cuda/numba/cuda/core/annotations/template.html
+++ b/numba_cuda/numba/cuda/core/annotations/template.html
@@ -1,0 +1,144 @@
+<html>
+
+<head>
+
+<style>
+
+.annotation_table {
+    color: #000000;
+    font-family: monospace;
+    margin: 5px;
+    width: 100%;
+}
+
+/* override JupyterLab style */
+.annotation_table td {
+    text-align: left;
+    background-color: transparent;
+    padding: 1px;
+}
+
+.annotation_table code
+{
+    background-color: transparent;
+    white-space: normal;
+}
+
+/* End override JupyterLab style */
+
+tr:hover {
+    background-color: rgba(92, 200, 249, 0.25);
+}
+
+td.object_tag summary ,
+td.lifted_tag summary{
+    font-weight: bold;
+    display: list-item;
+}
+
+span.lifted_tag {
+    color: #00cc33;
+}
+
+span.object_tag {
+    color: #cc3300;
+}
+
+
+td.lifted_tag {
+    background-color: #cdf7d8;
+}
+
+td.object_tag {
+    background-color: #ffd3d3;
+}
+
+code.ir_code {
+    color: grey;
+    font-style: italic;
+}
+
+.metadata {
+    border-bottom: medium solid black;
+    display: inline-block;
+    padding: 5px;
+    width: 100%;
+}
+
+.annotations {
+padding: 5px;
+}
+
+.hidden {
+display: none;
+}
+
+.buttons {
+padding: 10px;
+cursor: pointer;
+}
+
+</style>
+
+</head>
+
+<body>
+
+    {% for func_key in func_data.keys() %}
+
+        {% set loop1 = loop %}
+
+        <div class="metadata">
+        Function name: {{func_data[func_key]['funcname']}}<br />
+        in file: {{func_data[func_key]['filename']}}<br />
+        with signature: {{func_key[1]|e}}
+        </div>
+
+        <div class="annotations">
+
+        <table class="annotation_table tex2jax_ignore">
+            {%- for num, line in func_data[func_key]['python_lines'] -%}
+                {%- if func_data[func_key]['ir_lines'][num] %}
+                    <tr><td class="{{func_data[func_key]['python_tags'][num]}}">
+                        <details>
+                            <summary>
+                                <code>
+                                {{num}}:
+                                {{func_data[func_key]['python_indent'][num]}}{{line|e}}
+                                </code>
+                            </summary>
+                            <table class="annotation_table">
+                                <tbody>
+                                    {%- for ir_line, ir_line_type in func_data[func_key]['ir_lines'][num] %}
+                                        <tr class="ir_code func{{loop1.index0}}_ir">
+                                            <td><code>&nbsp;
+                                            {{- func_data[func_key]['python_indent'][num]}}
+                                            {{func_data[func_key]['ir_indent'][num][loop.index0]}}{{ir_line|e -}}
+                                            <span class="object_tag">{{ir_line_type}}</span>
+                                            </code>
+                                            </td>
+                                        </tr>
+                                    {%- endfor -%}
+                                </tbody>
+                            </table>
+                            </details>
+                    </td></tr>
+                {% else -%}
+                    <tr><td style=" padding-left: 22px;" class="{{func_data[func_key]['python_tags'][num]}}">
+                        <code>
+                            {{num}}:
+                            {{func_data[func_key]['python_indent'][num]}}{{line|e}}
+                        </code>
+                    </td></tr>
+                {%- endif -%}
+            {%- endfor -%}
+        </table>
+        </div>
+
+        <br /><br /><br />
+
+    {% endfor %}
+
+</body>
+
+</html>

--- a/numba_cuda/numba/cuda/core/annotations/type_annotations.py
+++ b/numba_cuda/numba/cuda/core/annotations/type_annotations.py
@@ -1,0 +1,304 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+from collections import defaultdict, OrderedDict
+from collections.abc import Mapping
+from contextlib import closing
+import copy
+import inspect
+import os
+import re
+import textwrap
+from io import StringIO
+
+import numba.core.dispatcher
+from numba.core import ir
+
+
+class SourceLines(Mapping):
+    def __init__(self, func):
+        try:
+            lines, startno = inspect.getsourcelines(func)
+        except OSError:
+            self.lines = ()
+            self.startno = 0
+        else:
+            self.lines = textwrap.dedent("".join(lines)).splitlines()
+            self.startno = startno
+
+    def __getitem__(self, lineno):
+        try:
+            return self.lines[lineno - self.startno].rstrip()
+        except IndexError:
+            return ""
+
+    def __iter__(self):
+        return iter((self.startno + i) for i in range(len(self.lines)))
+
+    def __len__(self):
+        return len(self.lines)
+
+    @property
+    def avail(self):
+        return bool(self.lines)
+
+
+class TypeAnnotation(object):
+    # func_data dict stores annotation data for all functions that are
+    # compiled. We store the data in the TypeAnnotation class since a new
+    # TypeAnnotation instance is created for each function that is compiled.
+    # For every function that is compiled, we add the type annotation data to
+    # this dict and write the html annotation file to disk (rewrite the html
+    # file for every function since we don't know if this is the last function
+    # to be compiled).
+    func_data = OrderedDict()
+
+    def __init__(
+        self,
+        func_ir,
+        typemap,
+        calltypes,
+        lifted,
+        lifted_from,
+        args,
+        return_type,
+        html_output=None,
+    ):
+        self.func_id = func_ir.func_id
+        self.blocks = func_ir.blocks
+        self.typemap = typemap
+        self.calltypes = calltypes
+        self.filename = func_ir.loc.filename
+        self.linenum = str(func_ir.loc.line)
+        self.signature = str(args) + " -> " + str(return_type)
+
+        # lifted loop information
+        self.lifted = lifted
+        self.num_lifted_loops = len(lifted)
+
+        # If this is a lifted loop function that is being compiled, lifted_from
+        # points to annotation data from function that this loop lifted function
+        # was lifted from. This is used to stick lifted loop annotations back
+        # into original function.
+        self.lifted_from = lifted_from
+
+    def prepare_annotations(self):
+        # Prepare annotations
+        groupedinst = defaultdict(list)
+        found_lifted_loop = False
+        # for blkid, blk in self.blocks.items():
+        for blkid in sorted(self.blocks.keys()):
+            blk = self.blocks[blkid]
+            groupedinst[blk.loc.line].append("label %s" % blkid)
+            for inst in blk.body:
+                lineno = inst.loc.line
+
+                if isinstance(inst, ir.Assign):
+                    if found_lifted_loop:
+                        atype = "XXX Lifted Loop XXX"
+                        found_lifted_loop = False
+                    elif (
+                        isinstance(inst.value, ir.Expr)
+                        and inst.value.op == "call"
+                    ):
+                        atype = self.calltypes[inst.value]
+                    elif isinstance(inst.value, ir.Const) and isinstance(
+                        inst.value.value, numba.core.dispatcher.LiftedLoop
+                    ):
+                        atype = "XXX Lifted Loop XXX"
+                        found_lifted_loop = True
+                    else:
+                        # TODO: fix parfor lowering so that typemap is valid.
+                        atype = self.typemap.get(inst.target.name, "<missing>")
+
+                    aline = "%s = %s  :: %s" % (inst.target, inst.value, atype)
+                elif isinstance(inst, ir.SetItem):
+                    atype = self.calltypes[inst]
+                    aline = "%s  :: %s" % (inst, atype)
+                else:
+                    aline = "%s" % inst
+                groupedinst[lineno].append("  %s" % aline)
+        return groupedinst
+
+    def annotate(self):
+        source = SourceLines(self.func_id.func)
+        # if not source.avail:
+        #     return "Source code unavailable"
+
+        groupedinst = self.prepare_annotations()
+
+        # Format annotations
+        io = StringIO()
+        with closing(io):
+            if source.avail:
+                print("# File: %s" % self.filename, file=io)
+                for num in source:
+                    srcline = source[num]
+                    ind = _getindent(srcline)
+                    print("%s# --- LINE %d --- " % (ind, num), file=io)
+                    for inst in groupedinst[num]:
+                        print("%s# %s" % (ind, inst), file=io)
+                    print(file=io)
+                    print(srcline, file=io)
+                    print(file=io)
+                if self.lifted:
+                    print("# The function contains lifted loops", file=io)
+                    for loop in self.lifted:
+                        print(
+                            "# Loop at line %d" % loop.get_source_location(),
+                            file=io,
+                        )
+                        print(
+                            "# Has %d overloads" % len(loop.overloads), file=io
+                        )
+                        for cres in loop.overloads.values():
+                            print(cres.type_annotation, file=io)
+            else:
+                print("# Source code unavailable", file=io)
+                for num in groupedinst:
+                    for inst in groupedinst[num]:
+                        print("%s" % (inst,), file=io)
+                    print(file=io)
+
+            return io.getvalue()
+
+    def html_annotate(self, outfile):
+        # ensure that annotation information is assembled
+        self.annotate_raw()
+        # make a deep copy ahead of the pending mutations
+        func_data = copy.deepcopy(self.func_data)
+
+        key = "python_indent"
+        for this_func in func_data.values():
+            if key in this_func:
+                idents = {}
+                for line, amount in this_func[key].items():
+                    idents[line] = "&nbsp;" * amount
+                this_func[key] = idents
+
+        key = "ir_indent"
+        for this_func in func_data.values():
+            if key in this_func:
+                idents = {}
+                for line, ir_id in this_func[key].items():
+                    idents[line] = ["&nbsp;" * amount for amount in ir_id]
+                this_func[key] = idents
+
+        try:
+            from jinja2 import Template
+        except ImportError:
+            raise ImportError("please install the 'jinja2' package")
+
+        root = os.path.join(os.path.dirname(__file__))
+        template_filename = os.path.join(root, "template.html")
+        with open(template_filename, "r") as template:
+            html = template.read()
+
+        template = Template(html)
+        rendered = template.render(func_data=func_data)
+        outfile.write(rendered)
+
+    def annotate_raw(self):
+        """
+        This returns "raw" annotation information i.e. it has no output format
+        specific markup included.
+        """
+        python_source = SourceLines(self.func_id.func)
+        ir_lines = self.prepare_annotations()
+        line_nums = [num for num in python_source]
+        lifted_lines = [l.get_source_location() for l in self.lifted]
+
+        def add_ir_line(func_data, line):
+            line_str = line.strip()
+            line_type = ""
+            if line_str.endswith("pyobject"):
+                line_str = line_str.replace("pyobject", "")
+                line_type = "pyobject"
+            func_data["ir_lines"][num].append((line_str, line_type))
+            indent_len = len(_getindent(line))
+            func_data["ir_indent"][num].append(indent_len)
+
+        func_key = (
+            self.func_id.filename + ":" + str(self.func_id.firstlineno + 1),
+            self.signature,
+        )
+        if (
+            self.lifted_from is not None
+            and self.lifted_from[1]["num_lifted_loops"] > 0
+        ):
+            # This is a lifted loop function that is being compiled. Get the
+            # numba ir for lines in loop function to use for annotating
+            # original python function that the loop was lifted from.
+            func_data = self.lifted_from[1]
+            for num in line_nums:
+                if num not in ir_lines.keys():
+                    continue
+                func_data["ir_lines"][num] = []
+                func_data["ir_indent"][num] = []
+                for line in ir_lines[num]:
+                    add_ir_line(func_data, line)
+                    if line.strip().endswith("pyobject"):
+                        func_data["python_tags"][num] = "object_tag"
+                        # If any pyobject line is found, make sure original python
+                        # line that was marked as a lifted loop start line is tagged
+                        # as an object line instead. Lifted loop start lines should
+                        # only be marked as lifted loop lines if the lifted loop
+                        # was successfully compiled in nopython mode.
+                        func_data["python_tags"][self.lifted_from[0]] = (
+                            "object_tag"
+                        )
+
+            # We're done with this lifted loop, so decrement lifted loop counter.
+            # When lifted loop counter hits zero, that means we're ready to write
+            # out annotations to html file.
+            self.lifted_from[1]["num_lifted_loops"] -= 1
+
+        elif func_key not in TypeAnnotation.func_data.keys():
+            TypeAnnotation.func_data[func_key] = {}
+            func_data = TypeAnnotation.func_data[func_key]
+
+            for i, loop in enumerate(self.lifted):
+                # Make sure that when we process each lifted loop function later,
+                # we'll know where it originally came from.
+                loop.lifted_from = (lifted_lines[i], func_data)
+            func_data["num_lifted_loops"] = self.num_lifted_loops
+
+            func_data["filename"] = self.filename
+            func_data["funcname"] = self.func_id.func_name
+            func_data["python_lines"] = []
+            func_data["python_indent"] = {}
+            func_data["python_tags"] = {}
+            func_data["ir_lines"] = {}
+            func_data["ir_indent"] = {}
+
+            for num in line_nums:
+                func_data["python_lines"].append(
+                    (num, python_source[num].strip())
+                )
+                indent_len = len(_getindent(python_source[num]))
+                func_data["python_indent"][num] = indent_len
+                func_data["python_tags"][num] = ""
+                func_data["ir_lines"][num] = []
+                func_data["ir_indent"][num] = []
+
+                for line in ir_lines[num]:
+                    add_ir_line(func_data, line)
+                    if num in lifted_lines:
+                        func_data["python_tags"][num] = "lifted_tag"
+                    elif line.strip().endswith("pyobject"):
+                        func_data["python_tags"][num] = "object_tag"
+        return self.func_data
+
+    def __str__(self):
+        return self.annotate()
+
+
+re_longest_white_prefix = re.compile(r"^\s*")
+
+
+def _getindent(text):
+    m = re_longest_white_prefix.match(text)
+    if not m:
+        return ""
+    else:
+        return " " * len(m.group(0))

--- a/numba_cuda/numba/cuda/core/typed_passes.py
+++ b/numba_cuda/numba/cuda/core/typed_passes.py
@@ -24,7 +24,7 @@ from numba.cuda.core.compiler_machinery import (
     AnalysisPass,
     register_pass,
 )
-from numba.core.annotations import type_annotations
+from numba.cuda.core.annotations import type_annotations
 from numba.cuda.core.ir_utils import (
     raise_on_unsupported_feature,
     warn_deprecated,

--- a/numba_cuda/numba/cuda/tests/cudapy/test_copy_propagate.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_copy_propagate.py
@@ -39,10 +39,6 @@ def _test_wont_propagate(b, z, w):
     return a < b
 
 
-def _null_func(a, b, c, d):
-    False
-
-
 def _in_list_var(list_var, var):
     for i in list_var:
         if i.name == var:

--- a/numba_cuda/numba/cuda/tests/cudapy/test_copy_propagate.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_copy_propagate.py
@@ -6,7 +6,6 @@
 
 from numba.core import types, ir, config
 from numba.cuda import compiler
-from numba.cuda.descriptor import cuda_target
 from numba.cuda.core.annotations import type_annotations
 from numba.cuda.core.ir_utils import (
     copy_propagate,
@@ -61,6 +60,8 @@ def _find_assign(func_ir, var):
 @skip_on_cudasim("cudasim doesn't support run_frontend")
 class TestCopyPropagate(CUDATestCase):
     def test1(self):
+        from numba.cuda.descriptor import cuda_target
+
         typingctx = cuda_target.typing_context
         targetctx = cuda_target.target_context
         test_ir = compiler.run_frontend(_test_will_propagate)
@@ -92,6 +93,8 @@ class TestCopyPropagate(CUDATestCase):
         self.assertFalse(_find_assign(test_ir, "x1"))
 
     def test2(self):
+        from numba.cuda.descriptor import cuda_target
+
         typingctx = cuda_target.typing_context
         targetctx = cuda_target.target_context
         test_ir = compiler.run_frontend(_test_wont_propagate)

--- a/numba_cuda/numba/cuda/tests/cudapy/test_copy_propagate.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_copy_propagate.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Copyright (c) 2017 Intel Corporation
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+from numba.core import types, ir, config
+from numba.cuda import compiler
+from numba.core.registry import cpu_target
+from numba.cuda.core.annotations import type_annotations
+from numba.cuda.core.ir_utils import (
+    copy_propagate,
+    apply_copy_propagate,
+    get_name_var_table,
+)
+from numba.cuda.core.typed_passes import type_inference_stage
+import unittest
+
+
+def _test_will_propagate(b, z, w):
+    x = 3
+    x1 = x
+    if b > 0:
+        y = z + w  # noqa: F821
+    else:
+        y = 0  # noqa: F841
+    a = 2 * x1
+    return a < b
+
+
+def _test_wont_propagate(b, z, w):
+    x = 3
+    if b > 0:
+        y = z + w  # noqa: F841
+        x = 1
+    else:
+        y = 0  # noqa: F841
+    a = 2 * x
+    return a < b
+
+
+def _null_func(a, b, c, d):
+    False
+
+
+def _in_list_var(list_var, var):
+    for i in list_var:
+        if i.name == var:
+            return True
+    return False
+
+
+def _find_assign(func_ir, var):
+    for label, block in func_ir.blocks.items():
+        for i, inst in enumerate(block.body):
+            if isinstance(inst, ir.Assign) and inst.target.name != var:
+                all_var = inst.list_vars()
+                if _in_list_var(all_var, var):
+                    return True
+
+    return False
+
+
+class TestCopyPropagate(unittest.TestCase):
+    def test1(self):
+        typingctx = cpu_target.typing_context
+        targetctx = cpu_target.target_context
+        test_ir = compiler.run_frontend(_test_will_propagate)
+        typingctx.refresh()
+        targetctx.refresh()
+        args = (types.int64, types.int64, types.int64)
+        typemap, return_type, calltypes, _ = type_inference_stage(
+            typingctx, targetctx, test_ir, args, None
+        )
+        _ = type_annotations.TypeAnnotation(
+            func_ir=test_ir,
+            typemap=typemap,
+            calltypes=calltypes,
+            lifted=(),
+            lifted_from=None,
+            args=args,
+            return_type=return_type,
+            html_output=config.HTML,
+        )
+        in_cps, out_cps = copy_propagate(test_ir.blocks, typemap)
+        _ = apply_copy_propagate(
+            test_ir.blocks,
+            in_cps,
+            get_name_var_table(test_ir.blocks),
+            typemap,
+            calltypes,
+        )
+
+        self.assertFalse(_find_assign(test_ir, "x1"))
+
+    def test2(self):
+        typingctx = cpu_target.typing_context
+        targetctx = cpu_target.target_context
+        test_ir = compiler.run_frontend(_test_wont_propagate)
+        typingctx.refresh()
+        targetctx.refresh()
+        args = (types.int64, types.int64, types.int64)
+        typemap, return_type, calltypes, _ = type_inference_stage(
+            typingctx, targetctx, test_ir, args, None
+        )
+        _ = type_annotations.TypeAnnotation(
+            func_ir=test_ir,
+            typemap=typemap,
+            calltypes=calltypes,
+            lifted=(),
+            lifted_from=None,
+            args=args,
+            return_type=return_type,
+            html_output=config.HTML,
+        )
+        in_cps, out_cps = copy_propagate(test_ir.blocks, typemap)
+        _ = apply_copy_propagate(
+            test_ir.blocks,
+            in_cps,
+            get_name_var_table(test_ir.blocks),
+            typemap,
+            calltypes,
+        )
+
+        self.assertTrue(_find_assign(test_ir, "x"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/numba_cuda/numba/cuda/tests/cudapy/test_copy_propagate.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_copy_propagate.py
@@ -14,6 +14,7 @@ from numba.cuda.core.ir_utils import (
     get_name_var_table,
 )
 from numba.cuda.core.typed_passes import type_inference_stage
+from numba.cuda.testing import CUDATestCase, skip_on_cudasim
 import unittest
 
 
@@ -57,7 +58,8 @@ def _find_assign(func_ir, var):
     return False
 
 
-class TestCopyPropagate(unittest.TestCase):
+@skip_on_cudasim("cudasim doesn't support run_frontend")
+class TestCopyPropagate(CUDATestCase):
     def test1(self):
         typingctx = cpu_target.typing_context
         targetctx = cpu_target.target_context

--- a/numba_cuda/numba/cuda/tests/cudapy/test_copy_propagate.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_copy_propagate.py
@@ -92,8 +92,8 @@ class TestCopyPropagate(CUDATestCase):
         self.assertFalse(_find_assign(test_ir, "x1"))
 
     def test2(self):
-        typingctx = cpu_target.typing_context
-        targetctx = cpu_target.target_context
+        typingctx = cuda_target.typing_context
+        targetctx = cuda_target.target_context
         test_ir = compiler.run_frontend(_test_wont_propagate)
         typingctx.refresh()
         targetctx.refresh()

--- a/numba_cuda/numba/cuda/tests/cudapy/test_copy_propagate.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_copy_propagate.py
@@ -61,8 +61,8 @@ def _find_assign(func_ir, var):
 @skip_on_cudasim("cudasim doesn't support run_frontend")
 class TestCopyPropagate(CUDATestCase):
     def test1(self):
-        typingctx = cpu_target.typing_context
-        targetctx = cpu_target.target_context
+        typingctx = cuda_target.typing_context
+        targetctx = cuda_target.target_context
         test_ir = compiler.run_frontend(_test_will_propagate)
         typingctx.refresh()
         targetctx.refresh()

--- a/numba_cuda/numba/cuda/tests/cudapy/test_copy_propagate.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_copy_propagate.py
@@ -6,7 +6,7 @@
 
 from numba.core import types, ir, config
 from numba.cuda import compiler
-from numba.core.registry import cpu_target
+from numba.cuda.descriptor import cuda_target
 from numba.cuda.core.annotations import type_annotations
 from numba.cuda.core.ir_utils import (
     copy_propagate,


### PR DESCRIPTION
I found no standalone tests, however a somewhat related test imports this module. Some test cases from the upstream version did not seem suitable to the CUDA target, so I brought in only a few test cases from upstream.