### PR TITLE
[Refactor][NFC] Vendor-in numba.extending for future CUDA-specific changes

### DIFF
--- a/numba_cuda/numba/cuda/_internal/cuda_bf16.py
+++ b/numba_cuda/numba/cuda/_internal/cuda_bf16.py
@@ -20,7 +20,7 @@ import numba
 from llvmlite import ir
 from numba import types
 from numba.core.datamodel import PrimitiveModel, StructModel
-from numba.core.extending import (
+from numba.cuda.extending import (
     lower_cast,
     make_attribute_wrapper,
     register_model,
@@ -40,7 +40,7 @@ from numba.cuda.typing.templates import AttributeTemplate, ConcreteTemplate
 from numba.cuda.typing.templates import Registry as TypingRegistry
 from numba.cuda import CUSource, declare_device
 from numba.cuda.vector_types import vector_types
-from numba.extending import as_numba_type
+from numba.cuda.extending import as_numba_type
 from numba.types import (
     CPointer,
     Function,

--- a/numba_cuda/numba/cuda/_internal/cuda_fp16.py
+++ b/numba_cuda/numba/cuda/_internal/cuda_fp16.py
@@ -22,7 +22,7 @@ from numba import types
 from numba.cuda.cudadrv.driver import _have_nvjitlink
 from numba.core.datamodel import PrimitiveModel, StructModel
 from numba.core.errors import NumbaPerformanceWarning
-from numba.core.extending import (
+from numba.cuda.extending import (
     lower_cast,
     make_attribute_wrapper,
     register_model,
@@ -39,7 +39,7 @@ from numba.cuda.typing.templates import (
 )
 from numba.cuda.typing.templates import Registry as TypingRegistry
 from numba.cuda.vector_types import vector_types
-from numba.extending import as_numba_type
+from numba.cuda.extending import as_numba_type
 from numba.types import (
     CPointer,
     Function,

--- a/numba_cuda/numba/cuda/bf16.py
+++ b/numba_cuda/numba/cuda/bf16.py
@@ -130,7 +130,7 @@ from numba.cuda._internal.cuda_bf16 import (
     htanh,
     htanh_approx,
 )
-from numba.extending import overload
+from numba.cuda.extending import overload
 
 import math
 

--- a/numba_cuda/numba/cuda/cg.py
+++ b/numba_cuda/numba/cuda/cg.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from numba.core import types
-from numba.core.extending import overload, overload_method
+from numba.cuda.extending import overload, overload_method
 from numba.core.typing import signature
 from numba.cuda import nvvmutils
 from numba.cuda.extending import intrinsic

--- a/numba_cuda/numba/cuda/core/inline_closurecall.py
+++ b/numba_cuda/numba/cuda/core/inline_closurecall.py
@@ -35,7 +35,7 @@ from numba.core.analysis import (
     compute_live_variables,
 )
 from numba.core.imputils import impl_ret_untracked
-from numba.core.extending import intrinsic
+from numba.cuda.extending import intrinsic
 from numba.core.typing import signature
 
 from numba.cuda.core import postproc, rewrites

--- a/numba_cuda/numba/cuda/core/ir_utils.py
+++ b/numba_cuda/numba/cuda/core/ir_utils.py
@@ -10,7 +10,7 @@ import collections
 import warnings
 
 import numba
-from numba.core.extending import _Intrinsic
+from numba.cuda.extending import _Intrinsic
 from numba.core import types, ir, analysis, config
 from numba.cuda import typing
 from numba.cuda.core import postproc, rewrites
@@ -1788,7 +1788,7 @@ def find_callname(
             def_val = callee_def.value
             # get the underlying definition of Intrinsic object to be able to
             # find the module effectively.
-            # Otherwise, it will return numba.extending
+            # Otherwise, it will return numba.cuda.extending
             if isinstance(def_val, _Intrinsic):
                 def_val = def_val._defn
             if hasattr(def_val, "__module__"):

--- a/numba_cuda/numba/cuda/core/typed_passes.py
+++ b/numba_cuda/numba/cuda/core/typed_passes.py
@@ -474,7 +474,7 @@ class NoPythonBackend(LoweringPass):
 @register_pass(mutates_CFG=True, analysis_only=False)
 class InlineOverloads(FunctionPass):
     """
-    This pass will inline a function wrapped by the numba.extending.overload
+    This pass will inline a function wrapped by the numba.cuda.extending.overload
     decorator directly into the site of its call depending on the value set in
     the 'inline' kwarg to the decorator.
 

--- a/numba_cuda/numba/cuda/cpython/cmathimpl.py
+++ b/numba_cuda/numba/cuda/cpython/cmathimpl.py
@@ -12,7 +12,7 @@ from numba.core.imputils import impl_ret_untracked, Registry
 from numba.core import types
 from numba.core.typing import signature
 from numba.cuda.cpython import mathimpl
-from numba.core.extending import overload
+from numba.cuda.extending import overload
 
 
 registry = Registry("cmathimpl")

--- a/numba_cuda/numba/cuda/cpython/mathimpl.py
+++ b/numba_cuda/numba/cuda/cpython/mathimpl.py
@@ -15,7 +15,7 @@ from llvmlite.ir import Constant
 
 from numba.core.imputils import impl_ret_untracked, Registry
 from numba.core import types, config
-from numba.core.extending import overload
+from numba.cuda.extending import overload
 from numba.core.typing import signature
 from numba.cpython.unsafe.numbers import trailing_zeros
 from numba.cuda import cgutils

--- a/numba_cuda/numba/cuda/cpython/numbers.py
+++ b/numba_cuda/numba/cuda/cpython/numbers.py
@@ -12,7 +12,7 @@ from llvmlite.ir import Constant
 
 from numba.core.imputils import impl_ret_untracked, Registry
 from numba.core import typing, types, errors
-from numba.core.extending import overload_method
+from numba.cuda.extending import overload_method
 from numba.cpython.unsafe.numbers import viewer
 from numba.cuda import cgutils
 

--- a/numba_cuda/numba/cuda/extending.py
+++ b/numba_cuda/numba/cuda/extending.py
@@ -5,11 +5,36 @@
 Added for symmetry with the core API
 """
 
-from numba.core.extending import intrinsic as _intrinsic
+import os
+import uuid
+import weakref
+import collections
+import functools
+
+import numba
+from numba.core import types, errors, utils, config
+
+# # Exported symbols
+from numba.core.typing.typeof import typeof_impl  # noqa: F401
+from numba.core.typing.asnumbatype import as_numba_type  # noqa: F401
+from numba.core.typing.templates import infer, infer_getattr  # noqa: F401
+
+from numba.core.imputils import (  # noqa: F401
+    lower_builtin,
+    lower_getattr,
+    lower_getattr_generic,  # noqa: F401
+    lower_setattr,
+    lower_setattr_generic,
+    lower_cast,
+)  # noqa: F401
+from numba.cuda.core.pythonapi import box, unbox, reflect, NativeValue  # noqa: F401
+from numba._helperlib import _import_cython_function  # noqa: F401
+from numba.cuda.serialize import ReduceMixin
+from numba.core.datamodel import models as core_models  # noqa: F401
+
+
 from numba.cuda.models import register_model  # noqa: F401
 from numba.cuda import models  # noqa: F401
-
-intrinsic = _intrinsic(target="cuda")
 
 
 def make_attribute_wrapper(typeclass, struct_attr, python_attr):
@@ -18,7 +43,7 @@ def make_attribute_wrapper(typeclass, struct_attr, python_attr):
     as a read-only attribute named *python_attr*.
     The given *typeclass*'s model must be a StructModel subclass.
 
-    Vendored from numba.core.extending with a change to consider the CUDA data
+    Vendored from numba.cuda.extending with a change to consider the CUDA data
     model manager.
     """
     from numba.cuda.typing.templates import AttributeTemplate
@@ -63,3 +88,562 @@ def make_attribute_wrapper(typeclass, struct_attr, python_attr):
         attrty = get_attr_fe_type(typ)
         attrval = getattr(val, struct_attr)
         return impl_ret_borrowed(context, builder, attrty, attrval)
+
+
+def type_callable(func):
+    """
+    Decorate a function as implementing typing for the callable *func*.
+    *func* can be a callable object (probably a global) or a string
+    denoting a built-in operation (such 'getitem' or '__array_wrap__')
+    """
+    from numba.core.typing.templates import (
+        CallableTemplate,
+        infer,
+        infer_global,
+    )
+
+    if not callable(func) and not isinstance(func, str):
+        raise TypeError("`func` should be a function or string")
+    try:
+        func_name = func.__name__
+    except AttributeError:
+        func_name = str(func)
+
+    def decorate(typing_func):
+        def generic(self):
+            return typing_func(self.context)
+
+        name = "%s_CallableTemplate" % (func_name,)
+        bases = (CallableTemplate,)
+        class_dict = dict(key=func, generic=generic)
+        template = type(name, bases, class_dict)
+        infer(template)
+        if callable(func):
+            infer_global(func, types.Function(template))
+        return typing_func
+
+    return decorate
+
+
+# By default, an *overload* does not have a cpython wrapper because it is not
+# callable from python. It also has `nopython=True`, this has been default since
+# its inception!
+_overload_default_jit_options = {"no_cpython_wrapper": True, "nopython": True}
+
+
+def overload(
+    func,
+    jit_options={},
+    strict=True,
+    inline="never",
+    prefer_literal=False,
+    **kwargs,
+):
+    """
+    A decorator marking the decorated function as typing and implementing
+    *func* in nopython mode.
+
+    The decorated function will have the same formal parameters as *func*
+    and be passed the Numba types of those parameters.  It should return
+    a function implementing *func* for the given types.
+
+    Here is an example implementing len() for tuple types::
+
+        @overload(len)
+        def tuple_len(seq):
+            if isinstance(seq, types.BaseTuple):
+                n = len(seq)
+
+                def len_impl(seq):
+                    return n
+
+                return len_impl
+
+    Compiler options can be passed as an dictionary using the **jit_options**
+    argument.
+
+    Overloading strictness (that the typing and implementing signatures match)
+    is enforced by the **strict** keyword argument, it is recommended that this
+    is set to True (default).
+
+    To handle a function that accepts imprecise types, an overload
+    definition can return 2-tuple of ``(signature, impl_function)``, where
+    the ``signature`` is a ``typing.Signature`` specifying the precise
+    signature to be used; and ``impl_function`` is the same implementation
+    function as in the simple case.
+
+    If the kwarg inline determines whether the overload is inlined in the
+    calling function and can be one of three values:
+    * 'never' (default) - the overload is never inlined.
+    * 'always' - the overload is always inlined.
+    * a function that takes two arguments, both of which are instances of a
+      namedtuple with fields:
+        * func_ir
+        * typemap
+        * calltypes
+        * signature
+      The first argument holds the information from the caller, the second
+      holds the information from the callee. The function should return Truthy
+      to determine whether to inline, this essentially permitting custom
+      inlining rules (typical use might be cost models).
+
+    The *prefer_literal* option allows users to control if literal types should
+    be tried first or last. The default (`False`) is to use non-literal types.
+    Implementations that can specialize based on literal values should set the
+    option to `True`. Note, this option maybe expanded in the near future to
+    allow for more control (e.g. disabling non-literal types).
+
+    **kwargs prescribes additional arguments passed through to the overload
+    template. The only accepted key at present is 'target' which is a string
+    corresponding to the target that this overload should be bound against.
+    """
+    from numba.core.typing.templates import make_overload_template, infer_global
+
+    # set default options
+    opts = _overload_default_jit_options.copy()
+    opts.update(jit_options)  # let user options override
+
+    # TODO: abort now if the kwarg 'target' relates to an unregistered target,
+    # this requires sorting out the circular imports first.
+
+    def decorate(overload_func):
+        template = make_overload_template(
+            func, overload_func, opts, strict, inline, prefer_literal, **kwargs
+        )
+        infer(template)
+        if callable(func):
+            infer_global(func, types.Function(template))
+        return overload_func
+
+    return decorate
+
+
+def register_jitable(*args, **kwargs):
+    """
+    Register a regular python function that can be executed by the python
+    interpreter and can be compiled into a nopython function when referenced
+    by other jit'ed functions.  Can be used as::
+
+        @register_jitable
+        def foo(x, y):
+            return x + y
+
+    Or, with compiler options::
+
+        @register_jitable(_nrt=False)  # disable runtime allocation
+        def foo(x, y):
+            return x + y
+
+    """
+
+    def wrap(fn):
+        # It is just a wrapper for @overload
+        inline = kwargs.pop("inline", "never")
+
+        @overload(fn, jit_options=kwargs, inline=inline, strict=False)
+        def ov_wrap(*args, **kwargs):
+            return fn
+
+        return fn
+
+    if kwargs:
+        return wrap
+    else:
+        return wrap(*args)
+
+
+def overload_attribute(typ, attr, **kwargs):
+    """
+    A decorator marking the decorated function as typing and implementing
+    attribute *attr* for the given Numba type in nopython mode.
+
+    *kwargs* are passed to the underlying `@overload` call.
+
+    Here is an example implementing .nbytes for array types::
+
+        @overload_attribute(types.Array, "nbytes")
+        def array_nbytes(arr):
+            def get(arr):
+                return arr.size * arr.itemsize
+
+            return get
+    """
+    # TODO implement setters
+    from numba.core.typing.templates import make_overload_attribute_template
+
+    def decorate(overload_func):
+        template = make_overload_attribute_template(
+            typ, attr, overload_func, **kwargs
+        )
+        infer_getattr(template)
+        overload(overload_func, **kwargs)(overload_func)
+        return overload_func
+
+    return decorate
+
+
+def _overload_method_common(typ, attr, **kwargs):
+    """Common code for overload_method and overload_classmethod"""
+    from numba.core.typing.templates import make_overload_method_template
+
+    def decorate(overload_func):
+        copied_kwargs = kwargs.copy()  # avoid mutating parent dict
+        template = make_overload_method_template(
+            typ,
+            attr,
+            overload_func,
+            inline=copied_kwargs.pop("inline", "never"),
+            prefer_literal=copied_kwargs.pop("prefer_literal", False),
+            **copied_kwargs,
+        )
+        infer_getattr(template)
+        overload(overload_func, **kwargs)(overload_func)
+        return overload_func
+
+    return decorate
+
+
+def overload_method(typ, attr, **kwargs):
+    """
+    A decorator marking the decorated function as typing and implementing
+    method *attr* for the given Numba type in nopython mode.
+
+    *kwargs* are passed to the underlying `@overload` call.
+
+    Here is an example implementing .take() for array types::
+
+        @overload_method(types.Array, "take")
+        def array_take(arr, indices):
+            if isinstance(indices, types.Array):
+
+                def take_impl(arr, indices):
+                    n = indices.shape[0]
+                    res = np.empty(n, arr.dtype)
+                    for i in range(n):
+                        res[i] = arr[indices[i]]
+                    return res
+
+                return take_impl
+    """
+    return _overload_method_common(typ, attr, **kwargs)
+
+
+def overload_classmethod(typ, attr, **kwargs):
+    """
+    A decorator marking the decorated function as typing and implementing
+    classmethod *attr* for the given Numba type in nopython mode.
+
+
+    Similar to ``overload_method``.
+
+
+    Here is an example implementing a classmethod on the Array type to call
+    ``np.arange()``::
+
+        @overload_classmethod(types.Array, "make")
+        def ov_make(cls, nitems):
+            def impl(cls, nitems):
+                return np.arange(nitems)
+
+            return impl
+
+    The above code will allow the following to work in jit-compiled code::
+
+        @njit
+        def foo(n):
+            return types.Array.make(n)
+    """
+    return _overload_method_common(types.TypeRef(typ), attr, **kwargs)
+
+
+class _Intrinsic(ReduceMixin):
+    """
+    Dummy callable for intrinsic
+    """
+
+    _memo = weakref.WeakValueDictionary()
+    # hold refs to last N functions deserialized, retaining them in _memo
+    # regardless of whether there is another reference
+    _recent = collections.deque(maxlen=config.FUNCTION_CACHE_SIZE)
+
+    __uuid = None
+
+    def __init__(self, name, defn, prefer_literal=False, **kwargs):
+        self._ctor_kwargs = kwargs
+        self._name = name
+        self._defn = defn
+        self._prefer_literal = prefer_literal
+        functools.update_wrapper(self, defn)
+
+    @property
+    def _uuid(self):
+        """
+        An instance-specific UUID, to avoid multiple deserializations of
+        a given instance.
+
+        Note this is lazily-generated, for performance reasons.
+        """
+        u = self.__uuid
+        if u is None:
+            u = str(uuid.uuid1())
+            self._set_uuid(u)
+        return u
+
+    def _set_uuid(self, u):
+        assert self.__uuid is None
+        self.__uuid = u
+        self._memo[u] = self
+        self._recent.append(self)
+
+    def _register(self):
+        # _ctor_kwargs
+        from numba.core.typing.templates import (
+            make_intrinsic_template,
+            infer_global,
+        )
+
+        template = make_intrinsic_template(
+            self,
+            self._defn,
+            self._name,
+            prefer_literal=self._prefer_literal,
+            kwargs=self._ctor_kwargs,
+        )
+        infer(template)
+        infer_global(self, types.Function(template))
+
+    def __call__(self, *args, **kwargs):
+        """
+        This is only defined to pretend to be a callable from CPython.
+        """
+        msg = "{0} is not usable in pure-python".format(self)
+        raise NotImplementedError(msg)
+
+    def __repr__(self):
+        return "<intrinsic {0}>".format(self._name)
+
+    def __deepcopy__(self, memo):
+        # NOTE: Intrinsic are immutable and we don't need to copy.
+        #       This is triggered from deepcopy of statements.
+        return self
+
+    def _reduce_states(self):
+        """
+        NOTE: part of ReduceMixin protocol
+        """
+        return dict(uuid=self._uuid, name=self._name, defn=self._defn)
+
+    @classmethod
+    def _rebuild(cls, uuid, name, defn):
+        """
+        NOTE: part of ReduceMixin protocol
+        """
+        try:
+            return cls._memo[uuid]
+        except KeyError:
+            llc = cls(name=name, defn=defn)
+            llc._register()
+            llc._set_uuid(uuid)
+            return llc
+
+
+def _intrinsic(*args, **kwargs):
+    """
+    A decorator marking the decorated function as typing and implementing
+    *func* in nopython mode using the llvmlite IRBuilder API.  This is an escape
+    hatch for expert users to build custom LLVM IR that will be inlined to
+    the caller.
+
+    The first argument to *func* is the typing context.  The rest of the
+    arguments corresponds to the type of arguments of the decorated function.
+    These arguments are also used as the formal argument of the decorated
+    function.  If *func* has the signature ``foo(typing_context, arg0, arg1)``,
+    the decorated function will have the signature ``foo(arg0, arg1)``.
+
+    The return values of *func* should be a 2-tuple of expected type signature,
+    and a code-generation function that will passed to ``lower_builtin``.
+    For unsupported operation, return None.
+
+    Here is an example implementing a ``cast_int_to_byte_ptr`` that cast
+    any integer to a byte pointer::
+
+        @intrinsic
+        def cast_int_to_byte_ptr(typingctx, src):
+            # check for accepted types
+            if isinstance(src, types.Integer):
+                # create the expected type signature
+                result_type = types.CPointer(types.uint8)
+                sig = result_type(types.uintp)
+
+                # defines the custom code generation
+                def codegen(context, builder, signature, args):
+                    # llvm IRBuilder code here
+                    [src] = args
+                    rtype = signature.return_type
+                    llrtype = context.get_value_type(rtype)
+                    return builder.inttoptr(src, llrtype)
+
+                return sig, codegen
+    """
+
+    # Make inner function for the actual work
+    def _intrinsic(func):
+        name = getattr(func, "__name__", str(func))
+        llc = _Intrinsic(name, func, **kwargs)
+        llc._register()
+        return llc
+
+    if not kwargs:
+        # No option is given
+        return _intrinsic(*args)
+    else:
+        # options are given, create a new callable to recv the
+        # definition function
+        def wrapper(func):
+            return _intrinsic(func)
+
+        return wrapper
+
+
+intrinsic = _intrinsic(target="cuda")
+
+
+def get_cython_function_address(module_name, function_name):
+    """
+    Get the address of a Cython function.
+
+    Args
+    ----
+    module_name:
+        Name of the Cython module
+    function_name:
+        Name of the Cython function
+
+    Returns
+    -------
+    A Python int containing the address of the function
+
+    """
+    return _import_cython_function(module_name, function_name)
+
+
+def include_path():
+    """Returns the C include directory path."""
+    include_dir = os.path.dirname(os.path.dirname(numba.__file__))
+    path = os.path.abspath(include_dir)
+    return path
+
+
+def sentry_literal_args(pysig, literal_args, args, kwargs):
+    """Ensures that the given argument types (in *args* and *kwargs*) are
+    literally typed for a function with the python signature *pysig* and the
+    list of literal argument names in *literal_args*.
+
+    Alternatively, this is the same as::
+
+        SentryLiteralArgs(literal_args).for_pysig(pysig).bind(*args, **kwargs)
+    """
+    boundargs = pysig.bind(*args, **kwargs)
+
+    # Find literal argument positions and whether it is satisfied.
+    request_pos = set()
+    missing = False
+    for i, (k, v) in enumerate(boundargs.arguments.items()):
+        if k in literal_args:
+            request_pos.add(i)
+            if not isinstance(v, types.Literal):
+                missing = True
+    if missing:
+        # Yes, there are missing required literal arguments
+        e = errors.ForceLiteralArg(request_pos)
+
+        # A helper function to fold arguments
+        def folded(args, kwargs):
+            out = pysig.bind(*args, **kwargs).arguments.values()
+            return tuple(out)
+
+        raise e.bind_fold_arguments(folded)
+
+
+class SentryLiteralArgs(
+    collections.namedtuple("_SentryLiteralArgs", ["literal_args"])
+):
+    """
+    Parameters
+    ----------
+    literal_args : Sequence[str]
+        A sequence of names for literal arguments
+
+    Examples
+    --------
+
+    The following line:
+
+    >>> SentryLiteralArgs(literal_args).for_pysig(pysig).bind(*args, **kwargs)
+
+    is equivalent to:
+
+    >>> sentry_literal_args(pysig, literal_args, args, kwargs)
+    """
+
+    def for_function(self, func):
+        """Bind the sentry to the signature of *func*.
+
+        Parameters
+        ----------
+        func : Function
+            A python function.
+
+        Returns
+        -------
+        obj : BoundLiteralArgs
+        """
+        return self.for_pysig(utils.pysignature(func))
+
+    def for_pysig(self, pysig):
+        """Bind the sentry to the given signature *pysig*.
+
+        Parameters
+        ----------
+        pysig : inspect.Signature
+
+
+        Returns
+        -------
+        obj : BoundLiteralArgs
+        """
+        return BoundLiteralArgs(
+            pysig=pysig,
+            literal_args=self.literal_args,
+        )
+
+
+class BoundLiteralArgs(
+    collections.namedtuple("BoundLiteralArgs", ["pysig", "literal_args"])
+):
+    """
+    This class is usually created by SentryLiteralArgs.
+    """
+
+    def bind(self, *args, **kwargs):
+        """Bind to argument types."""
+        return sentry_literal_args(
+            self.pysig,
+            self.literal_args,
+            args,
+            kwargs,
+        )
+
+
+def is_jitted(function):
+    """Returns True if a function is wrapped by one of the Numba @jit
+    decorators, for example: numba.jit, numba.njit
+
+    The purpose of this function is to provide a means to check if a function is
+    already JIT decorated.
+    """
+
+    # don't want to export this so import locally
+    from numba.core.dispatcher import Dispatcher
+
+    return isinstance(function, Dispatcher)

--- a/numba_cuda/numba/cuda/extending.py
+++ b/numba_cuda/numba/cuda/extending.py
@@ -12,7 +12,8 @@ import collections
 import functools
 
 import numba
-from numba.core import types, errors, utils, config
+from numba.core import types, errors, config
+from numba.cuda import utils
 
 # # Exported symbols
 from numba.core.typing.typeof import typeof_impl  # noqa: F401
@@ -506,25 +507,6 @@ def _intrinsic(*args, **kwargs):
 
 
 intrinsic = _intrinsic(target="cuda")
-
-
-def get_cython_function_address(module_name, function_name):
-    """
-    Get the address of a Cython function.
-
-    Args
-    ----
-    module_name:
-        Name of the Cython module
-    function_name:
-        Name of the Cython function
-
-    Returns
-    -------
-    A Python int containing the address of the function
-
-    """
-    return _import_cython_function(module_name, function_name)
 
 
 def include_path():

--- a/numba_cuda/numba/cuda/fp16.py
+++ b/numba_cuda/numba/cuda/fp16.py
@@ -135,7 +135,7 @@ from numba.cuda._internal.cuda_fp16 import (
     htrunc,
 )
 
-from numba.extending import overload
+from numba.cuda.extending import overload
 import math
 
 

--- a/numba_cuda/numba/cuda/intrinsics.py
+++ b/numba_cuda/numba/cuda/intrinsics.py
@@ -7,7 +7,7 @@ from numba import cuda, types
 from numba.cuda import cgutils
 from numba.core.errors import RequireLiteralValue, TypingError
 from numba.core.typing import signature
-from numba.core.extending import overload_attribute, overload_method
+from numba.cuda.extending import overload_attribute, overload_method
 from numba.cuda import nvvmutils
 from numba.cuda.extending import intrinsic
 

--- a/numba_cuda/numba/cuda/models.py
+++ b/numba_cuda/numba/cuda/models.py
@@ -7,7 +7,7 @@ from llvmlite import ir
 
 from numba.core.datamodel.registry import DataModelManager, register
 from numba.core.datamodel import PrimitiveModel
-from numba.core.extending import models
+from numba.cuda.extending import core_models
 from numba.core import types
 from numba.cuda.types import Dim3, GridGroup, CUDADispatcher, Bfloat16
 
@@ -18,21 +18,21 @@ register_model = functools.partial(register, cuda_data_manager)
 
 
 @register_model(Dim3)
-class Dim3Model(models.StructModel):
+class Dim3Model(core_models.StructModel):
     def __init__(self, dmm, fe_type):
         members = [("x", types.int32), ("y", types.int32), ("z", types.int32)]
         super().__init__(dmm, fe_type, members)
 
 
 @register_model(GridGroup)
-class GridGroupModel(models.PrimitiveModel):
+class GridGroupModel(core_models.PrimitiveModel):
     def __init__(self, dmm, fe_type):
         be_type = ir.IntType(64)
         super().__init__(dmm, fe_type, be_type)
 
 
 @register_model(types.Float)
-class FloatModel(models.PrimitiveModel):
+class FloatModel(core_models.PrimitiveModel):
     def __init__(self, dmm, fe_type):
         if fe_type == types.float16:
             be_type = ir.IntType(16)
@@ -45,7 +45,7 @@ class FloatModel(models.PrimitiveModel):
         super(FloatModel, self).__init__(dmm, fe_type, be_type)
 
 
-register_model(CUDADispatcher)(models.OpaqueModel)
+register_model(CUDADispatcher)(core_models.OpaqueModel)
 
 
 @register_model(Bfloat16)

--- a/numba_cuda/numba/cuda/np/npyfuncs.py
+++ b/numba_cuda/numba/cuda/np/npyfuncs.py
@@ -12,11 +12,11 @@ import math
 import llvmlite.ir
 import numpy as np
 
-from numba.core.extending import overload
+from numba.cuda.extending import overload
 from numba.core.imputils import impl_ret_untracked
 from numba.core import typing, types, errors
 from numba.cuda import cgutils
-from numba.core.extending import register_jitable
+from numba.cuda.extending import register_jitable
 from numba.np import npdatetime
 from numba.np.math import cmathimpl, mathimpl, numbers
 from numba.np.numpy_support import numpy_version

--- a/numba_cuda/numba/cuda/tests/cudapy/extensions_usecases.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/extensions_usecases.py
@@ -21,8 +21,8 @@ test_struct_model_type = TestStructModelType()
 
 if not config.ENABLE_CUDASIM:
     from numba import int32
-    from numba.core.extending import (
-        models,
+    from numba.cuda.extending import (
+        core_models,
         typeof_impl,
         type_callable,
     )
@@ -38,7 +38,7 @@ if not config.ENABLE_CUDASIM:
         return test_struct_model_type
 
     @register_model(TestStructModelType)
-    class TestStructModel(models.StructModel):
+    class TestStructModel(core_models.StructModel):
         def __init__(self, dmm, fe_type):
             members = [("x", int32), ("y", int32)]
             super().__init__(dmm, fe_type, members)

--- a/numba_cuda/numba/cuda/tests/cudapy/test_extending.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_extending.py
@@ -8,7 +8,7 @@ from llvmlite import ir
 import numpy as np
 import os
 from numba import config, cuda, njit, types
-from numba.extending import overload
+from numba.cuda.extending import overload
 
 
 class Interval:
@@ -40,9 +40,9 @@ def sum_intervals(i, j):
 
 if not config.ENABLE_CUDASIM:
     from numba.cuda import cgutils
-    from numba.core.extending import (
+    from numba.cuda.extending import (
         lower_builtin,
-        models,
+        core_models,
         type_callable,
         typeof_impl,
     )
@@ -73,13 +73,13 @@ if not config.ENABLE_CUDASIM:
         return typer
 
     @register_model(IntervalType)
-    class IntervalModel(models.StructModel):
+    class IntervalModel(core_models.StructModel):
         def __init__(self, dmm, fe_type):
             members = [
                 ("lo", types.float64),
                 ("hi", types.float64),
             ]
-            models.StructModel.__init__(self, dmm, fe_type, members)
+            core_models.StructModel.__init__(self, dmm, fe_type, members)
 
     make_attribute_wrapper(IntervalType, "lo", "lo")
     make_attribute_wrapper(IntervalType, "hi", "hi")

--- a/numba_cuda/numba/cuda/tests/cudapy/test_overload.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_overload.py
@@ -3,7 +3,7 @@
 
 from numba import cuda, njit, types, version_info
 from numba.core.errors import TypingError
-from numba.core.extending import overload, overload_attribute
+from numba.cuda.extending import overload, overload_attribute
 from numba.core.typing.typeof import typeof
 from numba.cuda.testing import CUDATestCase, skip_on_cudasim, unittest
 import numpy as np

--- a/numba_cuda/numba/cuda/tests/cudapy/test_ssa.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_ssa.py
@@ -14,7 +14,7 @@ from numba import types, cuda
 from numba.cuda import jit
 from numba.core import errors
 
-from numba.extending import overload
+from numba.cuda.extending import overload
 from numba.cuda.tests.support import override_config
 from numba.cuda.testing import CUDATestCase, skip_on_cudasim
 

--- a/numba_cuda/numba/cuda/tests/overload_usecases.py
+++ b/numba_cuda/numba/cuda/tests/overload_usecases.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Python 3 syntax only use cases, used in test_extending.py
+
+# arg name is different, and there's no arg name to match before *args
+
+
+def impl4(z, *args, kw=None):
+    if z > 10:
+        return 1
+    else:
+        return -1
+
+
+# arg name is different but at a detectable location, with *args
+
+
+def impl5(z, b, *args, kw=None):
+    if z > 10:
+        return 1
+    else:
+        return -1
+
+
+def var_positional_impl(a, *star_args_token, kw=None, kw1=12):
+    def impl(a, b, f, kw=None, kw1=12):
+        if a > 10:
+            return 1
+        else:
+            return -1
+
+    return impl

--- a/numba_cuda/numba/cuda/tests/pdlike_usecase.py
+++ b/numba_cuda/numba/cuda/tests/pdlike_usecase.py
@@ -1,0 +1,347 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Implementation of a minimal Pandas-like API.
+"""
+
+import numpy as np
+
+from numba.core import types, cgutils
+from numba.core.datamodel import models
+from numba.core.extending import (
+    typeof_impl,
+    type_callable,
+    register_model,
+    lower_builtin,
+    box,
+    unbox,
+    NativeValue,
+    overload,
+    overload_attribute,
+    overload_method,
+    make_attribute_wrapper,
+)
+from numba.core.imputils import impl_ret_borrowed
+
+
+class Index(object):
+    """
+    A minimal pandas.Index-like object.
+    """
+
+    def __init__(self, data):
+        assert isinstance(data, np.ndarray)
+        assert data.ndim == 1
+        self._data = data
+
+    def __iter__(self):
+        return iter(self._data)
+
+    @property
+    def dtype(self):
+        return self._data.dtype
+
+    @property
+    def flags(self):
+        return self._data.flags
+
+
+class IndexType(types.Buffer):
+    """
+    The type class for Index objects.
+    """
+
+    array_priority = 1000
+
+    def __init__(self, dtype, layout, pyclass):
+        self.pyclass = pyclass
+        super(IndexType, self).__init__(dtype, 1, layout)
+
+    @property
+    def key(self):
+        return self.pyclass, self.dtype, self.layout
+
+    @property
+    def as_array(self):
+        return types.Array(self.dtype, 1, self.layout)
+
+    def copy(self, dtype=None, ndim=1, layout=None):
+        assert ndim == 1
+        if dtype is None:
+            dtype = self.dtype
+        layout = layout or self.layout
+        return type(self)(dtype, layout, self.pyclass)
+
+
+class Series(object):
+    """
+    A minimal pandas.Series-like object.
+    """
+
+    def __init__(self, data, index):
+        assert isinstance(data, np.ndarray)
+        assert isinstance(index, Index)
+        assert data.ndim == 1
+        self._values = data
+        self._index = index
+
+    def __iter__(self):
+        return iter(self._values)
+
+    @property
+    def dtype(self):
+        return self._values.dtype
+
+    @property
+    def flags(self):
+        return self._values.flags
+
+
+class SeriesType(types.ArrayCompatible):
+    """
+    The type class for Series objects.
+    """
+
+    array_priority = 1000
+
+    def __init__(self, dtype, index):
+        assert isinstance(index, IndexType)
+        self.dtype = dtype
+        self.index = index
+        self.values = types.Array(self.dtype, 1, "C")
+        name = "series(%s, %s)" % (dtype, index)
+        super(SeriesType, self).__init__(name)
+
+    @property
+    def key(self):
+        return self.dtype, self.index
+
+    @property
+    def as_array(self):
+        return self.values
+
+    def copy(self, dtype=None, ndim=1, layout="C"):
+        assert ndim == 1
+        assert layout == "C"
+        if dtype is None:
+            dtype = self.dtype
+        return type(self)(dtype, self.index)
+
+
+@typeof_impl.register(Index)
+def typeof_index(val, c):
+    arrty = typeof_impl(val._data, c)
+    assert arrty.ndim == 1
+    return IndexType(arrty.dtype, arrty.layout, type(val))
+
+
+@typeof_impl.register(Series)
+def typeof_series(val, c):
+    index = typeof_impl(val._index, c)
+    arrty = typeof_impl(val._values, c)
+    assert arrty.ndim == 1
+    assert arrty.layout == "C"
+    return SeriesType(arrty.dtype, index)
+
+
+@type_callable("__array_wrap__")
+def type_array_wrap(context):
+    def typer(input_type, result):
+        if isinstance(input_type, (IndexType, SeriesType)):
+            return input_type.copy(
+                dtype=result.dtype, ndim=result.ndim, layout=result.layout
+            )
+
+    return typer
+
+
+@type_callable(Series)
+def type_series_constructor(context):
+    def typer(data, index):
+        if isinstance(index, IndexType) and isinstance(data, types.Array):
+            assert data.layout == "C"
+            assert data.ndim == 1
+            return SeriesType(data.dtype, index)
+
+    return typer
+
+
+# Backend extensions for Index and Series
+
+
+@register_model(IndexType)
+class IndexModel(models.StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [("data", fe_type.as_array)]
+        models.StructModel.__init__(self, dmm, fe_type, members)
+
+
+@register_model(SeriesType)
+class SeriesModel(models.StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [
+            ("index", fe_type.index),
+            ("values", fe_type.as_array),
+        ]
+        models.StructModel.__init__(self, dmm, fe_type, members)
+
+
+make_attribute_wrapper(IndexType, "data", "_data")
+make_attribute_wrapper(SeriesType, "index", "_index")
+make_attribute_wrapper(SeriesType, "values", "_values")
+
+
+def make_index(context, builder, typ, **kwargs):
+    return cgutils.create_struct_proxy(typ)(context, builder, **kwargs)
+
+
+def make_series(context, builder, typ, **kwargs):
+    return cgutils.create_struct_proxy(typ)(context, builder, **kwargs)
+
+
+@lower_builtin("__array__", IndexType)
+def index_as_array(context, builder, sig, args):
+    val = make_index(context, builder, sig.args[0], ref=args[0])
+    return val._get_ptr_by_name("data")
+
+
+@lower_builtin("__array__", SeriesType)
+def series_as_array(context, builder, sig, args):
+    val = make_series(context, builder, sig.args[0], ref=args[0])
+    return val._get_ptr_by_name("values")
+
+
+@lower_builtin("__array_wrap__", IndexType, types.Array)
+def index_wrap_array(context, builder, sig, args):
+    dest = make_index(context, builder, sig.return_type)
+    dest.data = args[1]
+    return impl_ret_borrowed(
+        context, builder, sig.return_type, dest._getvalue()
+    )
+
+
+@lower_builtin("__array_wrap__", SeriesType, types.Array)
+def series_wrap_array(context, builder, sig, args):
+    src = make_series(context, builder, sig.args[0], value=args[0])
+    dest = make_series(context, builder, sig.return_type)
+    dest.values = args[1]
+    dest.index = src.index
+    return impl_ret_borrowed(
+        context, builder, sig.return_type, dest._getvalue()
+    )
+
+
+@lower_builtin(Series, types.Array, IndexType)
+def pdseries_constructor(context, builder, sig, args):
+    data, index = args
+    series = make_series(context, builder, sig.return_type)
+    series.index = index
+    series.values = data
+    return impl_ret_borrowed(
+        context, builder, sig.return_type, series._getvalue()
+    )
+
+
+@unbox(IndexType)
+def unbox_index(typ, obj, c):
+    """
+    Convert a Index object to a native structure.
+    """
+    data = c.pyapi.object_getattr_string(obj, "_data")
+    index = make_index(c.context, c.builder, typ)
+    index.data = c.unbox(typ.as_array, data).value
+
+    return NativeValue(index._getvalue())
+
+
+@unbox(SeriesType)
+def unbox_series(typ, obj, c):
+    """
+    Convert a Series object to a native structure.
+    """
+    index = c.pyapi.object_getattr_string(obj, "_index")
+    values = c.pyapi.object_getattr_string(obj, "_values")
+    series = make_series(c.context, c.builder, typ)
+    series.index = c.unbox(typ.index, index).value
+    series.values = c.unbox(typ.values, values).value
+
+    return NativeValue(series._getvalue())
+
+
+@box(IndexType)
+def box_index(typ, val, c):
+    """
+    Convert a native index structure to a Index object.
+    """
+    # First build a Numpy array object, then wrap it in a Index
+    index = make_index(c.context, c.builder, typ, value=val)
+    classobj = c.pyapi.unserialize(c.pyapi.serialize_object(typ.pyclass))
+    arrayobj = c.box(typ.as_array, index.data)
+    indexobj = c.pyapi.call_function_objargs(classobj, (arrayobj,))
+    return indexobj
+
+
+@box(SeriesType)
+def box_series(typ, val, c):
+    """
+    Convert a native series structure to a Series object.
+    """
+    series = make_series(c.context, c.builder, typ, value=val)
+    classobj = c.pyapi.unserialize(c.pyapi.serialize_object(Series))
+    indexobj = c.box(typ.index, series.index)
+    arrayobj = c.box(typ.as_array, series.values)
+    seriesobj = c.pyapi.call_function_objargs(classobj, (arrayobj, indexobj))
+    return seriesobj
+
+
+@overload_attribute(IndexType, "is_monotonic_increasing")
+def index_is_monotonic_increasing(index):
+    """
+    Index.is_monotonic_increasing
+    """
+
+    def getter(index):
+        data = index._data
+        if len(data) == 0:
+            return True
+        u = data[0]
+        for v in data:
+            if v < u:
+                return False
+            v = u
+        return True
+
+    return getter
+
+
+@overload(len)
+def series_len(series):
+    """
+    len(Series)
+    """
+    if isinstance(series, SeriesType):
+
+        def len_impl(series):
+            return len(series._values)
+
+        return len_impl
+
+
+@overload_method(SeriesType, "clip")
+def series_clip(series, lower, upper):
+    """
+    Series.clip(...)
+    """
+
+    def clip_impl(series, lower, upper):
+        data = series._values.copy()
+        for i in range(len(data)):
+            v = data[i]
+            if v < lower:
+                data[i] = lower
+            elif v > upper:
+                data[i] = upper
+        return Series(data, series._index)
+
+    return clip_impl

--- a/numba_cuda/numba/cuda/tests/pdlike_usecase.py
+++ b/numba_cuda/numba/cuda/tests/pdlike_usecase.py
@@ -7,9 +7,10 @@ Implementation of a minimal Pandas-like API.
 
 import numpy as np
 
-from numba.core import types, cgutils
-from numba.core.datamodel import models
-from numba.core.extending import (
+from numba.core import types
+from numba.cuda import cgutils
+from numba.cuda.models import core_models
+from numba.cuda.extending import (
     typeof_impl,
     type_callable,
     register_model,
@@ -171,20 +172,20 @@ def type_series_constructor(context):
 
 
 @register_model(IndexType)
-class IndexModel(models.StructModel):
+class IndexModel(core_models.StructModel):
     def __init__(self, dmm, fe_type):
         members = [("data", fe_type.as_array)]
-        models.StructModel.__init__(self, dmm, fe_type, members)
+        core_models.StructModel.__init__(self, dmm, fe_type, members)
 
 
 @register_model(SeriesType)
-class SeriesModel(models.StructModel):
+class SeriesModel(core_models.StructModel):
     def __init__(self, dmm, fe_type):
         members = [
             ("index", fe_type.index),
             ("values", fe_type.as_array),
         ]
-        models.StructModel.__init__(self, dmm, fe_type, members)
+        core_models.StructModel.__init__(self, dmm, fe_type, members)
 
 
 make_attribute_wrapper(IndexType, "data", "_data")

--- a/numba_cuda/numba/cuda/tests/support.py
+++ b/numba_cuda/numba/cuda/tests/support.py
@@ -24,7 +24,7 @@ from numba import types
 from numba.core import errors, config
 from numba.cuda.typing import cffi_utils
 from numba.cuda.memory_management.nrt import rtsys
-from numba.core.extending import (
+from numba.cuda.extending import (
     typeof_impl,
     register_model,
     unbox,

--- a/numba_cuda/numba/cuda/tests/support.py
+++ b/numba_cuda/numba/cuda/tests/support.py
@@ -17,6 +17,8 @@ import tempfile
 import time
 import types as pytypes
 from functools import cached_property
+import multiprocessing as mp
+import traceback
 
 import numpy as np
 
@@ -54,6 +56,19 @@ windows_only = unittest.skipIf(not sys.platform.startswith("win"), _win_reason)
 
 IS_NUMPY_2 = numpy_support.numpy_version >= (2, 0)
 skip_if_numpy_2 = unittest.skipIf(IS_NUMPY_2, "Not supported on numpy 2.0+")
+
+# Typeguard
+has_typeguard = bool(os.environ.get("NUMBA_USE_TYPEGUARD", 0))
+
+skip_unless_typeguard = unittest.skipUnless(
+    has_typeguard,
+    "Typeguard is not enabled",
+)
+
+skip_if_typeguard = unittest.skipIf(
+    has_typeguard,
+    "Broken if Typeguard is enabled",
+)
 
 _trashcan_dir = "numba-cuda-tests"
 
@@ -817,3 +832,81 @@ class CheckWarningsMixin(object):
                     self.assertEqual(w.category, category)
                     found += 1
         self.assertEqual(found, len(messages))
+
+
+@contextlib.contextmanager
+def override_env_config(name, value):
+    """
+    Return a context manager that temporarily sets an Numba config environment
+    *name* to *value*.
+    """
+    old = os.environ.get(name)
+    os.environ[name] = value
+    config.reload_config()
+
+    try:
+        yield
+    finally:
+        if old is None:
+            # If it wasn't set originally, delete the environ var
+            del os.environ[name]
+        else:
+            # Otherwise, restore to the old value
+            os.environ[name] = old
+        # Always reload config
+        config.reload_config()
+
+
+def run_in_new_process_in_cache_dir(func, cache_dir, verbose=True):
+    """Spawn a new process to run `func` with a temporary cache directory.
+
+    The childprocess's stdout and stderr will be captured and redirected to
+    the current process's stdout and stderr.
+
+    Similar to ``run_in_new_process_caching()`` but the ``cache_dir`` is a
+    directory path instead of a name prefix for the directory path.
+
+    Returns
+    -------
+    ret : dict
+        exitcode: 0 for success. 1 for exception-raised.
+        stdout: str
+        stderr: str
+    """
+    ctx = mp.get_context("spawn")
+    qout = ctx.Queue()
+    with override_env_config("NUMBA_CACHE_DIR", cache_dir):
+        proc = ctx.Process(target=_remote_runner, args=[func, qout])
+        proc.start()
+        proc.join()
+        stdout = qout.get_nowait()
+        stderr = qout.get_nowait()
+        if verbose and stdout.strip():
+            print()
+            print("STDOUT".center(80, "-"))
+            print(stdout)
+        if verbose and stderr.strip():
+            print(file=sys.stderr)
+            print("STDERR".center(80, "-"), file=sys.stderr)
+            print(stderr, file=sys.stderr)
+    return {
+        "exitcode": proc.exitcode,
+        "stdout": stdout,
+        "stderr": stderr,
+    }
+
+
+def _remote_runner(fn, qout):
+    """Used by `run_in_new_process_caching()`"""
+    with captured_stderr() as stderr:
+        with captured_stdout() as stdout:
+            try:
+                fn()
+            except Exception:
+                traceback.print_exc()
+                exitcode = 1
+            else:
+                exitcode = 0
+        qout.put(stdout.getvalue())
+    qout.put(stderr.getvalue())
+    sys.exit(exitcode)

--- a/numba_cuda/numba/cuda/tests/test_extending.py
+++ b/numba_cuda/numba/cuda/tests/test_extending.py
@@ -1,0 +1,2185 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import inspect
+import math
+import operator
+import sys
+import pickle
+import multiprocessing
+import ctypes
+import warnings
+import re
+
+import numpy as np
+from llvmlite import ir
+
+import numba
+from numba import njit, jit, vectorize, guvectorize, objmode
+from numba.core import types, errors, typing
+from numba.cuda import cgutils
+from numba.cuda.tests.support import (
+    TestCase,
+    captured_stdout,
+    temp_directory,
+    override_config,
+    run_in_new_process_in_cache_dir,
+    skip_if_typeguard,
+)
+from numba.core.errors import LoweringError
+import unittest
+
+from numba.extending import (
+    typeof_impl,
+    type_callable,
+    lower_builtin,
+    lower_cast,
+    overload,
+    overload_attribute,
+    overload_method,
+    models,
+    register_model,
+    box,
+    unbox,
+    NativeValue,
+    intrinsic,
+    _Intrinsic,
+    register_jitable,
+    get_cython_function_address,
+    is_jitted,
+    overload_classmethod,
+)
+from numba.cuda.typing.templates import (
+    ConcreteTemplate,
+    signature,
+    Registry,
+    AbstractTemplate,
+)
+
+# Pandas-like API implementation
+from .pdlike_usecase import Index, Series
+
+registry = Registry()
+infer = registry.register
+infer_global = registry.register_global
+infer_getattr = registry.register_attr
+
+
+try:
+    import scipy.special.cython_special as sc
+except ImportError:
+    sc = None
+
+
+# -----------------------------------------------------------------------
+# Define a custom type and an implicit cast on it
+
+
+class MyDummy(object):
+    pass
+
+
+class MyDummyType(types.Opaque):
+    def can_convert_to(self, context, toty):
+        if isinstance(toty, types.Number):
+            from numba.core.typeconv import Conversion
+
+            return Conversion.safe
+
+
+mydummy_type = MyDummyType("mydummy")
+mydummy = MyDummy()
+
+
+@typeof_impl.register(MyDummy)
+def typeof_mydummy(val, c):
+    return mydummy_type
+
+
+@lower_cast(MyDummyType, types.Number)
+def mydummy_to_number(context, builder, fromty, toty, val):
+    """
+    Implicit conversion from MyDummy to int.
+    """
+    return context.get_constant(toty, 42)
+
+
+def get_dummy():
+    return mydummy
+
+
+register_model(MyDummyType)(models.OpaqueModel)
+
+
+@unbox(MyDummyType)
+def unbox_index(typ, obj, c):
+    return NativeValue(c.context.get_dummy_value())
+
+
+# -----------------------------------------------------------------------
+# Define a second custom type but w/o implicit cast to Number
+
+
+def base_dummy_type_factory(name):
+    class DynType(object):
+        pass
+
+    class DynTypeType(types.Opaque):
+        pass
+
+    dyn_type_type = DynTypeType(name)
+
+    @typeof_impl.register(DynType)
+    def typeof_mydummy(val, c):
+        return dyn_type_type
+
+    register_model(DynTypeType)(models.OpaqueModel)
+    return DynTypeType, DynType, dyn_type_type
+
+
+MyDummyType2, MyDummy2, mydummy_type_2 = base_dummy_type_factory("mydummy2")
+
+
+@unbox(MyDummyType2)
+def unbox_index2(typ, obj, c):
+    return NativeValue(c.context.get_dummy_value())
+
+
+# -----------------------------------------------------------------------
+# Define a function's typing and implementation using the classical
+# two-step API
+
+
+def func1(x=None):
+    raise NotImplementedError
+
+
+def type_func1_(context):
+    def typer(x=None):
+        if x in (None, types.none):
+            # 0-arg or 1-arg with None
+            return types.int32
+        elif isinstance(x, types.Float):
+            # 1-arg with float
+            return x
+
+    return typer
+
+
+type_func1 = type_callable(func1)(type_func1_)
+
+
+@lower_builtin(func1)
+@lower_builtin(func1, types.none)
+def func1_nullary(context, builder, sig, args):
+    return context.get_constant(sig.return_type, 42)
+
+
+@lower_builtin(func1, types.Float)
+def func1_unary(context, builder, sig, args):
+    def func1_impl(x):
+        return math.sqrt(2 * x)
+
+    return context.compile_internal(builder, func1_impl, sig, args)
+
+
+# We can do the same for a known internal operation, here "print_item"
+# which we extend to support MyDummyType.
+
+
+@infer
+class PrintDummy(ConcreteTemplate):
+    key = "print_item"
+    cases = [signature(types.none, mydummy_type)]
+
+
+@lower_builtin("print_item", MyDummyType)
+def print_dummy(context, builder, sig, args):
+    [x] = args
+    pyapi = context.get_python_api(builder)
+    strobj = pyapi.unserialize(pyapi.serialize_object("hello!"))
+    pyapi.print_object(strobj)
+    pyapi.decref(strobj)
+    return context.get_dummy_value()
+
+
+# -----------------------------------------------------------------------
+# Define an overloaded function (combined API)
+
+
+def where(cond, x, y):
+    raise NotImplementedError
+
+
+def np_where(cond, x, y):
+    """
+    Wrap np.where() to allow for keyword arguments
+    """
+    return np.where(cond, x, y)
+
+
+def call_where(cond, x, y):
+    return where(cond, y=y, x=x)
+
+
+@overload(where)
+def overload_where_arrays(cond, x, y):
+    """
+    Implement where() for arrays.
+    """
+    # Choose implementation based on argument types.
+    if isinstance(cond, types.Array):
+        if x.dtype != y.dtype:
+            raise errors.TypingError("x and y should have the same dtype")
+
+        # Array where() => return an array of the same shape
+        if all(ty.layout == "C" for ty in (cond, x, y)):
+
+            def where_impl(cond, x, y):
+                """
+                Fast implementation for C-contiguous arrays
+                """
+                shape = cond.shape
+                if x.shape != shape or y.shape != shape:
+                    raise ValueError("all inputs should have the same shape")
+                res = np.empty_like(x)
+                cf = cond.flat
+                xf = x.flat
+                yf = y.flat
+                rf = res.flat
+                for i in range(cond.size):
+                    rf[i] = xf[i] if cf[i] else yf[i]
+                return res
+
+        else:
+
+            def where_impl(cond, x, y):
+                """
+                Generic implementation for other arrays
+                """
+                shape = cond.shape
+                if x.shape != shape or y.shape != shape:
+                    raise ValueError("all inputs should have the same shape")
+                res = np.empty_like(x)
+                for idx, c in np.ndenumerate(cond):
+                    res[idx] = x[idx] if c else y[idx]
+                return res
+
+        return where_impl
+
+
+# We can define another overload function for the same function, they
+# will be tried in turn until one succeeds.
+
+
+@overload(where)
+def overload_where_scalars(cond, x, y):
+    """
+    Implement where() for scalars.
+    """
+    if not isinstance(cond, types.Array):
+        if x != y:
+            raise errors.TypingError("x and y should have the same type")
+
+        def where_impl(cond, x, y):
+            """
+            Scalar where() => return a 0-dim array
+            """
+            scal = x if cond else y
+            # Can't use full_like() on Numpy < 1.8
+            arr = np.empty_like(scal)
+            arr[()] = scal
+            return arr
+
+        return where_impl
+
+
+# -----------------------------------------------------------------------
+# Overload an already defined built-in function, extending it for new types.
+
+
+@overload(len)
+def overload_len_dummy(arg):
+    if isinstance(arg, MyDummyType):
+
+        def len_impl(arg):
+            return 13
+
+        return len_impl
+
+
+@overload(operator.add)
+def overload_add_dummy(arg1, arg2):
+    if isinstance(arg1, (MyDummyType, MyDummyType2)) and isinstance(
+        arg2, (MyDummyType, MyDummyType2)
+    ):
+
+        def dummy_add_impl(arg1, arg2):
+            return 42
+
+        return dummy_add_impl
+
+
+@overload(operator.delitem)
+def overload_dummy_delitem(obj, idx):
+    if isinstance(obj, MyDummyType) and isinstance(idx, types.Integer):
+
+        def dummy_delitem_impl(obj, idx):
+            print("del", obj, idx)
+
+        return dummy_delitem_impl
+
+
+@overload(operator.getitem)
+def overload_dummy_getitem(obj, idx):
+    if isinstance(obj, MyDummyType) and isinstance(idx, types.Integer):
+
+        def dummy_getitem_impl(obj, idx):
+            return idx + 123
+
+        return dummy_getitem_impl
+
+
+@overload(operator.setitem)
+def overload_dummy_setitem(obj, idx, val):
+    if all(
+        [
+            isinstance(obj, MyDummyType),
+            isinstance(idx, types.Integer),
+            isinstance(val, types.Integer),
+        ]
+    ):
+
+        def dummy_setitem_impl(obj, idx, val):
+            print(idx, val)
+
+        return dummy_setitem_impl
+
+
+def call_add_operator(arg1, arg2):
+    return operator.add(arg1, arg2)
+
+
+def call_add_binop(arg1, arg2):
+    return arg1 + arg2
+
+
+@overload(operator.iadd)
+def overload_iadd_dummy(arg1, arg2):
+    if isinstance(arg1, (MyDummyType, MyDummyType2)) and isinstance(
+        arg2, (MyDummyType, MyDummyType2)
+    ):
+
+        def dummy_iadd_impl(arg1, arg2):
+            return 42
+
+        return dummy_iadd_impl
+
+
+def call_iadd_operator(arg1, arg2):
+    return operator.add(arg1, arg2)
+
+
+def call_iadd_binop(arg1, arg2):
+    arg1 += arg2
+
+    return arg1
+
+
+def call_delitem(obj, idx):
+    del obj[idx]
+
+
+def call_getitem(obj, idx):
+    return obj[idx]
+
+
+def call_setitem(obj, idx, val):
+    obj[idx] = val
+
+
+@overload_method(MyDummyType, "length")
+def overload_method_length(arg):
+    def imp(arg):
+        return len(arg)
+
+    return imp
+
+
+def cache_overload_method_usecase(x):
+    return x.length()
+
+
+def call_func1_nullary():
+    return func1()
+
+
+def call_func1_unary(x):
+    return func1(x)
+
+
+def len_usecase(x):
+    return len(x)
+
+
+def print_usecase(x):
+    print(x)
+
+
+def getitem_usecase(x, key):
+    return x[key]
+
+
+def npyufunc_usecase(x):
+    return np.cos(np.sin(x))
+
+
+def get_data_usecase(x):
+    return x._data
+
+
+def get_index_usecase(x):
+    return x._index
+
+
+def is_monotonic_usecase(x):
+    return x.is_monotonic_increasing
+
+
+def make_series_usecase(data, index):
+    return Series(data, index)
+
+
+def clip_usecase(x, lo, hi):
+    return x.clip(lo, hi)
+
+
+# -----------------------------------------------------------------------
+
+
+def return_non_boxable():
+    return np
+
+
+@overload(return_non_boxable)
+def overload_return_non_boxable():
+    def imp():
+        return np
+
+    return imp
+
+
+def non_boxable_ok_usecase(sz):
+    mod = return_non_boxable()
+    return mod.arange(sz)
+
+
+def non_boxable_bad_usecase():
+    return return_non_boxable()
+
+
+def mk_func_input(f):
+    pass
+
+
+@infer_global(mk_func_input)
+class MkFuncTyping(AbstractTemplate):
+    def generic(self, args, kws):
+        assert isinstance(args[0], types.MakeFunctionLiteral)
+        return signature(types.none, *args)
+
+
+def mk_func_test_impl():
+    mk_func_input(lambda a: a)
+
+
+# -----------------------------------------------------------------------
+
+
+@overload(np.exp)
+def overload_np_exp(obj):
+    if isinstance(obj, MyDummyType):
+
+        def imp(obj):
+            # Returns a constant if a MyDummyType is seen
+            return 0xDEADBEEF
+
+        return imp
+
+
+class TestLowLevelExtending(TestCase):
+    """
+    Test the low-level two-tier extension API.
+    """
+
+    # Check with `@jit` from within the test process and also in a new test
+    # process so as to check the registration mechanism.
+
+    def test_func1(self):
+        pyfunc = call_func1_nullary
+        cfunc = jit(nopython=True)(pyfunc)
+        self.assertPreciseEqual(cfunc(), 42)
+        pyfunc = call_func1_unary
+        cfunc = jit(nopython=True)(pyfunc)
+        self.assertPreciseEqual(cfunc(None), 42)
+        self.assertPreciseEqual(cfunc(18.0), 6.0)
+
+    @TestCase.run_test_in_subprocess
+    def test_func1_isolated(self):
+        self.test_func1()
+
+    def test_type_callable_keeps_function(self):
+        self.assertIs(type_func1, type_func1_)
+        self.assertIsNotNone(type_func1)
+
+    @TestCase.run_test_in_subprocess
+    def test_cast_mydummy(self):
+        pyfunc = get_dummy
+        cfunc = njit(
+            types.float64(),
+        )(pyfunc)
+        self.assertPreciseEqual(cfunc(), 42.0)
+
+
+class TestPandasLike(TestCase):
+    """
+    Test implementing a pandas-like Index object.
+    Also stresses most of the high-level API.
+    """
+
+    def test_index_len(self):
+        i = Index(np.arange(3))
+        cfunc = jit(nopython=True)(len_usecase)
+        self.assertPreciseEqual(cfunc(i), 3)
+
+    def test_index_getitem(self):
+        i = Index(np.int32([42, 8, -5]))
+        cfunc = jit(nopython=True)(getitem_usecase)
+        self.assertPreciseEqual(cfunc(i, 1), 8)
+        ii = cfunc(i, slice(1, None))
+        self.assertIsInstance(ii, Index)
+        self.assertEqual(list(ii), [8, -5])
+
+    def test_index_ufunc(self):
+        """
+        Check Numpy ufunc on an Index object.
+        """
+        i = Index(np.int32([42, 8, -5]))
+        cfunc = jit(nopython=True)(npyufunc_usecase)
+        ii = cfunc(i)
+        self.assertIsInstance(ii, Index)
+        self.assertPreciseEqual(ii._data, np.cos(np.sin(i._data)))
+
+    def test_index_get_data(self):
+        # The _data attribute is exposed with make_attribute_wrapper()
+        i = Index(np.int32([42, 8, -5]))
+        cfunc = jit(nopython=True)(get_data_usecase)
+        data = cfunc(i)
+        self.assertIs(data, i._data)
+
+    def test_index_is_monotonic(self):
+        # The is_monotonic_increasing attribute is exposed with
+        # overload_attribute()
+        cfunc = jit(nopython=True)(is_monotonic_usecase)
+        for values, expected in [
+            ([8, 42, 5], False),
+            ([5, 8, 42], True),
+            ([], True),
+        ]:
+            i = Index(np.int32(values))
+            got = cfunc(i)
+            self.assertEqual(got, expected)
+
+    def test_series_len(self):
+        i = Index(np.int32([2, 4, 3]))
+        s = Series(np.float64([1.5, 4.0, 2.5]), i)
+        cfunc = jit(nopython=True)(len_usecase)
+        self.assertPreciseEqual(cfunc(s), 3)
+
+    def test_series_get_index(self):
+        i = Index(np.int32([2, 4, 3]))
+        s = Series(np.float64([1.5, 4.0, 2.5]), i)
+        cfunc = jit(nopython=True)(get_index_usecase)
+        got = cfunc(s)
+        self.assertIsInstance(got, Index)
+        self.assertIs(got._data, i._data)
+
+    def test_series_ufunc(self):
+        """
+        Check Numpy ufunc on an Series object.
+        """
+        i = Index(np.int32([42, 8, -5]))
+        s = Series(np.int64([1, 2, 3]), i)
+        cfunc = jit(nopython=True)(npyufunc_usecase)
+        ss = cfunc(s)
+        self.assertIsInstance(ss, Series)
+        self.assertIsInstance(ss._index, Index)
+        self.assertIs(ss._index._data, i._data)
+        self.assertPreciseEqual(ss._values, np.cos(np.sin(s._values)))
+
+    def test_series_constructor(self):
+        i = Index(np.int32([42, 8, -5]))
+        d = np.float64([1.5, 4.0, 2.5])
+        cfunc = jit(nopython=True)(make_series_usecase)
+        got = cfunc(d, i)
+        self.assertIsInstance(got, Series)
+        self.assertIsInstance(got._index, Index)
+        self.assertIs(got._index._data, i._data)
+        self.assertIs(got._values, d)
+
+    def test_series_clip(self):
+        i = Index(np.int32([42, 8, -5]))
+        s = Series(np.float64([1.5, 4.0, 2.5]), i)
+        cfunc = jit(nopython=True)(clip_usecase)
+        ss = cfunc(s, 1.6, 3.0)
+        self.assertIsInstance(ss, Series)
+        self.assertIsInstance(ss._index, Index)
+        self.assertIs(ss._index._data, i._data)
+        self.assertPreciseEqual(ss._values, np.float64([1.6, 3.0, 2.5]))
+
+
+class TestHighLevelExtending(TestCase):
+    """
+    Test the high-level combined API.
+    """
+
+    def test_where(self):
+        """
+        Test implementing a function with @overload.
+        """
+        pyfunc = call_where
+        cfunc = jit(nopython=True)(pyfunc)
+
+        def check(*args, **kwargs):
+            expected = np_where(*args, **kwargs)
+            got = cfunc(*args, **kwargs)
+            self.assertPreciseEqual(expected, got)
+
+        check(x=3, cond=True, y=8)
+        check(True, 3, 8)
+        check(
+            np.bool_([True, False, True]),
+            np.int32([1, 2, 3]),
+            np.int32([4, 5, 5]),
+        )
+
+        # The typing error is propagated
+        with self.assertRaises(errors.TypingError) as raises:
+            cfunc(np.bool_([]), np.int32([]), np.int64([]))
+        self.assertIn(
+            "x and y should have the same dtype", str(raises.exception)
+        )
+
+    def test_len(self):
+        """
+        Test re-implementing len() for a custom type with @overload.
+        """
+        cfunc = jit(nopython=True)(len_usecase)
+        self.assertPreciseEqual(cfunc(MyDummy()), 13)
+        self.assertPreciseEqual(cfunc([4, 5]), 2)
+
+    def test_print(self):
+        """
+        Test re-implementing print() for a custom type with @overload.
+        """
+        cfunc = jit(nopython=True)(print_usecase)
+        with captured_stdout():
+            cfunc(MyDummy())
+            self.assertEqual(sys.stdout.getvalue(), "hello!\n")
+
+    def test_add_operator(self):
+        """
+        Test re-implementing operator.add() for a custom type with @overload.
+        """
+        pyfunc = call_add_operator
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self.assertPreciseEqual(cfunc(1, 2), 3)
+        self.assertPreciseEqual(cfunc(MyDummy2(), MyDummy2()), 42)
+
+        # this will call add(Number, Number) as MyDummy implicitly casts to
+        # Number
+        self.assertPreciseEqual(cfunc(MyDummy(), MyDummy()), 84)
+
+    def test_add_binop(self):
+        """
+        Test re-implementing '+' for a custom type via @overload(operator.add).
+        """
+        pyfunc = call_add_binop
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self.assertPreciseEqual(cfunc(1, 2), 3)
+        self.assertPreciseEqual(cfunc(MyDummy2(), MyDummy2()), 42)
+
+        # this will call add(Number, Number) as MyDummy implicitly casts to
+        # Number
+        self.assertPreciseEqual(cfunc(MyDummy(), MyDummy()), 84)
+
+    def test_iadd_operator(self):
+        """
+        Test re-implementing operator.add() for a custom type with @overload.
+        """
+        pyfunc = call_iadd_operator
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self.assertPreciseEqual(cfunc(1, 2), 3)
+        self.assertPreciseEqual(cfunc(MyDummy2(), MyDummy2()), 42)
+
+        # this will call add(Number, Number) as MyDummy implicitly casts to
+        # Number
+        self.assertPreciseEqual(cfunc(MyDummy(), MyDummy()), 84)
+
+    def test_iadd_binop(self):
+        """
+        Test re-implementing '+' for a custom type via @overload(operator.add).
+        """
+        pyfunc = call_iadd_binop
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self.assertPreciseEqual(cfunc(1, 2), 3)
+        self.assertPreciseEqual(cfunc(MyDummy2(), MyDummy2()), 42)
+
+        # this will call add(Number, Number) as MyDummy implicitly casts to
+        # Number
+        self.assertPreciseEqual(cfunc(MyDummy(), MyDummy()), 84)
+
+    def test_delitem(self):
+        pyfunc = call_delitem
+        cfunc = jit(nopython=True)(pyfunc)
+        obj = MyDummy()
+        e = None
+
+        with captured_stdout() as out:
+            try:
+                cfunc(obj, 321)
+            except Exception as exc:
+                e = exc
+
+        if e is not None:
+            raise e
+        self.assertEqual(out.getvalue(), "del hello! 321\n")
+
+    def test_getitem(self):
+        pyfunc = call_getitem
+        cfunc = jit(nopython=True)(pyfunc)
+        self.assertPreciseEqual(cfunc(MyDummy(), 321), 321 + 123)
+
+    def test_setitem(self):
+        pyfunc = call_setitem
+        cfunc = jit(nopython=True)(pyfunc)
+        obj = MyDummy()
+        e = None
+
+        with captured_stdout() as out:
+            try:
+                cfunc(obj, 321, 123)
+            except Exception as exc:
+                e = exc
+
+        if e is not None:
+            raise e
+        self.assertEqual(out.getvalue(), "321 123\n")
+
+    def test_no_cpython_wrapper(self):
+        """
+        Test overloading whose return value cannot be represented in CPython.
+        """
+        # Test passing Module type from a @overload implementation to ensure
+        # that the *no_cpython_wrapper* flag works
+        ok_cfunc = jit(nopython=True)(non_boxable_ok_usecase)
+        n = 10
+        got = ok_cfunc(n)
+        expect = non_boxable_ok_usecase(n)
+        np.testing.assert_equal(expect, got)
+        # Verify that the Module type cannot be returned to CPython
+        bad_cfunc = jit(nopython=True)(non_boxable_bad_usecase)
+        with self.assertRaises(TypeError) as raises:
+            bad_cfunc()
+        errmsg = str(raises.exception)
+        expectmsg = "cannot convert native Module"
+        self.assertIn(expectmsg, errmsg)
+
+    def test_typing_vs_impl_signature_mismatch_handling(self):
+        """
+        Tests that an overload which has a differing typing and implementing
+        signature raises an exception.
+        """
+
+        def gen_ol(impl=None):
+            def myoverload(a, b, c, kw=None):
+                pass
+
+            @overload(myoverload)
+            def _myoverload_impl(a, b, c, kw=None):
+                return impl
+
+            @jit(nopython=True)
+            def foo(a, b, c, d):
+                myoverload(a, b, c, kw=d)
+
+            return foo
+
+        sentinel = "Typing and implementation arguments differ in"
+
+        # kwarg value is different
+        def impl1(a, b, c, kw=12):
+            if a > 10:
+                return 1
+            else:
+                return -1
+
+        with self.assertRaises(errors.TypingError) as e:
+            gen_ol(impl1)(1, 2, 3, 4)
+        msg = str(e.exception)
+        self.assertIn(sentinel, msg)
+        self.assertIn("keyword argument default values", msg)
+        self.assertIn('<Parameter "kw=12">', msg)
+        self.assertIn('<Parameter "kw=None">', msg)
+
+        # kwarg name is different
+        def impl2(a, b, c, kwarg=None):
+            if a > 10:
+                return 1
+            else:
+                return -1
+
+        with self.assertRaises(errors.TypingError) as e:
+            gen_ol(impl2)(1, 2, 3, 4)
+        msg = str(e.exception)
+        self.assertIn(sentinel, msg)
+        self.assertIn("keyword argument names", msg)
+        self.assertIn('<Parameter "kwarg=None">', msg)
+        self.assertIn('<Parameter "kw=None">', msg)
+
+        # arg name is different
+        def impl3(z, b, c, kw=None):
+            if a > 10:  # noqa: F821
+                return 1
+            else:
+                return -1
+
+        with self.assertRaises(errors.TypingError) as e:
+            gen_ol(impl3)(1, 2, 3, 4)
+        msg = str(e.exception)
+        self.assertIn(sentinel, msg)
+        self.assertIn("argument names", msg)
+        self.assertFalse("keyword" in msg)
+        self.assertIn('<Parameter "a">', msg)
+        self.assertIn('<Parameter "z">', msg)
+
+        from .overload_usecases import impl4, impl5
+
+        with self.assertRaises(errors.TypingError) as e:
+            gen_ol(impl4)(1, 2, 3, 4)
+        msg = str(e.exception)
+        self.assertIn(sentinel, msg)
+        self.assertIn("argument names", msg)
+        self.assertFalse("keyword" in msg)
+        self.assertIn("First difference: 'z'", msg)
+
+        with self.assertRaises(errors.TypingError) as e:
+            gen_ol(impl5)(1, 2, 3, 4)
+        msg = str(e.exception)
+        self.assertIn(sentinel, msg)
+        self.assertIn("argument names", msg)
+        self.assertFalse("keyword" in msg)
+        self.assertIn('<Parameter "a">', msg)
+        self.assertIn('<Parameter "z">', msg)
+
+        # too many args
+        def impl6(a, b, c, d, e, kw=None):
+            if a > 10:
+                return 1
+            else:
+                return -1
+
+        with self.assertRaises(errors.TypingError) as e:
+            gen_ol(impl6)(1, 2, 3, 4)
+        msg = str(e.exception)
+        self.assertIn(sentinel, msg)
+        self.assertIn("argument names", msg)
+        self.assertFalse("keyword" in msg)
+        self.assertIn('<Parameter "d">', msg)
+        self.assertIn('<Parameter "e">', msg)
+
+        # too few args
+        def impl7(a, b, kw=None):
+            if a > 10:
+                return 1
+            else:
+                return -1
+
+        with self.assertRaises(errors.TypingError) as e:
+            gen_ol(impl7)(1, 2, 3, 4)
+        msg = str(e.exception)
+        self.assertIn(sentinel, msg)
+        self.assertIn("argument names", msg)
+        self.assertFalse("keyword" in msg)
+        self.assertIn('<Parameter "c">', msg)
+
+        # too many kwargs
+        def impl8(a, b, c, kw=None, extra_kwarg=None):
+            if a > 10:
+                return 1
+            else:
+                return -1
+
+        with self.assertRaises(errors.TypingError) as e:
+            gen_ol(impl8)(1, 2, 3, 4)
+        msg = str(e.exception)
+        self.assertIn(sentinel, msg)
+        self.assertIn("keyword argument names", msg)
+        self.assertIn('<Parameter "extra_kwarg=None">', msg)
+
+        # too few kwargs
+        def impl9(a, b, c):
+            if a > 10:
+                return 1
+            else:
+                return -1
+
+        with self.assertRaises(errors.TypingError) as e:
+            gen_ol(impl9)(1, 2, 3, 4)
+        msg = str(e.exception)
+        self.assertIn(sentinel, msg)
+        self.assertIn("keyword argument names", msg)
+        self.assertIn('<Parameter "kw=None">', msg)
+
+    def test_typing_vs_impl_signature_mismatch_handling_var_positional(self):
+        """
+        Tests that an overload which has a differing typing and implementing
+        signature raises an exception and uses VAR_POSITIONAL (*args) in typing
+        """
+
+        def myoverload(a, kw=None):
+            pass
+
+        from .overload_usecases import var_positional_impl
+
+        overload(myoverload)(var_positional_impl)
+
+        @jit(nopython=True)
+        def foo(a, b):
+            return myoverload(a, b, 9, kw=11)
+
+        with self.assertRaises(errors.TypingError) as e:
+            foo(1, 5)
+        msg = str(e.exception)
+        self.assertIn("VAR_POSITIONAL (e.g. *args) argument kind", msg)
+        self.assertIn("offending argument name is '*star_args_token'", msg)
+
+    def test_typing_vs_impl_signature_mismatch_handling_var_keyword(self):
+        """
+        Tests that an overload which uses **kwargs (VAR_KEYWORD)
+        """
+
+        def gen_ol(impl, strict=True):
+            def myoverload(a, kw=None):
+                pass
+
+            overload(myoverload, strict=strict)(impl)
+
+            @jit(nopython=True)
+            def foo(a, b):
+                return myoverload(a, kw=11)
+
+            return foo
+
+        # **kwargs in typing
+        def ol1(a, **kws):
+            def impl(a, kw=10):
+                return a
+
+            return impl
+
+        gen_ol(ol1, False)(1, 2)  # no error if strictness not enforced
+        with self.assertRaises(errors.TypingError) as e:
+            gen_ol(ol1)(1, 2)
+        msg = str(e.exception)
+        self.assertIn("use of VAR_KEYWORD (e.g. **kwargs) is unsupported", msg)
+        self.assertIn("offending argument name is '**kws'", msg)
+
+        # **kwargs in implementation
+        def ol2(a, kw=0):
+            def impl(a, **kws):
+                return a
+
+            return impl
+
+        with self.assertRaises(errors.TypingError) as e:
+            gen_ol(ol2)(1, 2)
+        msg = str(e.exception)
+        self.assertIn("use of VAR_KEYWORD (e.g. **kwargs) is unsupported", msg)
+        self.assertIn("offending argument name is '**kws'", msg)
+
+    def test_overload_method_kwargs(self):
+        # Issue #3489
+        @overload_method(types.Array, "foo")
+        def fooimpl(arr, a_kwarg=10):
+            def impl(arr, a_kwarg=10):
+                return a_kwarg
+
+            return impl
+
+        @njit
+        def bar(A):
+            return A.foo(), A.foo(20), A.foo(a_kwarg=30)
+
+        Z = np.arange(5)
+
+        self.assertEqual(bar(Z), (10, 20, 30))
+
+    def test_overload_method_literal_unpack(self):
+        # Issue #3683
+        @overload_method(types.Array, "litfoo")
+        def litfoo(arr, val):
+            # Must be an integer
+            if isinstance(val, types.Integer):
+                # Must not be literal
+                if not isinstance(val, types.Literal):
+
+                    def impl(arr, val):
+                        return val
+
+                    return impl
+
+        @njit
+        def bar(A):
+            return A.litfoo(0xCAFE)
+
+        A = np.zeros(1)
+        bar(A)
+        self.assertEqual(bar(A), 0xCAFE)
+
+    def test_overload_ufunc(self):
+        # Issue #4133.
+        # Use an extended type (MyDummyType) to use with a customized
+        # ufunc (np.exp).
+        @njit
+        def test():
+            return np.exp(mydummy)
+
+        self.assertEqual(test(), 0xDEADBEEF)
+
+    def test_overload_method_stararg(self):
+        @overload_method(MyDummyType, "method_stararg")
+        def _ov_method_stararg(obj, val, val2, *args):
+            def get(obj, val, val2, *args):
+                return (val, val2, args)
+
+            return get
+
+        @njit
+        def foo(obj, *args):
+            # Test with expanding stararg
+            return obj.method_stararg(*args)
+
+        obj = MyDummy()
+        self.assertEqual(foo(obj, 1, 2), (1, 2, ()))
+        self.assertEqual(foo(obj, 1, 2, 3), (1, 2, (3,)))
+        self.assertEqual(foo(obj, 1, 2, 3, 4), (1, 2, (3, 4)))
+
+        @njit
+        def bar(obj):
+            # Test with explicit argument
+            return (
+                obj.method_stararg(1, 2),
+                obj.method_stararg(1, 2, 3),
+                obj.method_stararg(1, 2, 3, 4),
+            )
+
+        self.assertEqual(
+            bar(obj),
+            ((1, 2, ()), (1, 2, (3,)), (1, 2, (3, 4))),
+        )
+
+        # Check cases that put tuple type into stararg
+        # NOTE: the expected result has an extra tuple because of stararg.
+        self.assertEqual(
+            foo(obj, 1, 2, (3,)),
+            (1, 2, ((3,),)),
+        )
+        self.assertEqual(
+            foo(obj, 1, 2, (3, 4)),
+            (1, 2, ((3, 4),)),
+        )
+        self.assertEqual(
+            foo(obj, 1, 2, (3, (4, 5))),
+            (1, 2, ((3, (4, 5)),)),
+        )
+
+    def test_overload_classmethod(self):
+        # Add classmethod to a subclass of Array
+        class MyArray(types.Array):
+            pass
+
+        @overload_classmethod(MyArray, "array_alloc")
+        def ol_array_alloc(cls, nitems):
+            def impl(cls, nitems):
+                arr = np.arange(nitems)
+                return arr
+
+            return impl
+
+        @njit
+        def foo(nitems):
+            return MyArray.array_alloc(nitems)
+
+        nitems = 13
+        self.assertPreciseEqual(foo(nitems), np.arange(nitems))
+
+        # Check that the base type doesn't get the classmethod
+
+        @njit
+        def no_classmethod_in_base(nitems):
+            return types.Array.array_alloc(nitems)
+
+        with self.assertRaises(errors.TypingError) as raises:
+            no_classmethod_in_base(nitems)
+        self.assertIn(
+            "Unknown attribute 'array_alloc' of",
+            str(raises.exception),
+        )
+
+
+def _assert_cache_stats(cfunc, expect_hit, expect_misses):
+    hit = cfunc._cache_hits[cfunc.signatures[0]]
+    if hit != expect_hit:
+        raise AssertionError("cache not used")
+    miss = cfunc._cache_misses[cfunc.signatures[0]]
+    if miss != expect_misses:
+        raise AssertionError("cache not used")
+
+
+@skip_if_typeguard
+class TestOverloadMethodCaching(TestCase):
+    # Nested multiprocessing.Pool raises AssertionError:
+    # "daemonic processes are not allowed to have children"
+    _numba_parallel_test_ = False
+
+    def test_caching_overload_method(self):
+        self._cache_dir = temp_directory(self.__class__.__name__)
+        with override_config("CACHE_DIR", self._cache_dir):
+            self.run_caching_overload_method()
+
+    def run_caching_overload_method(self):
+        cfunc = jit(nopython=True, cache=True)(cache_overload_method_usecase)
+        self.assertPreciseEqual(cfunc(MyDummy()), 13)
+        _assert_cache_stats(cfunc, 0, 1)
+        llvmir = cfunc.inspect_llvm((mydummy_type,))
+        # Ensure the inner method is not a declaration
+        decls = [
+            ln
+            for ln in llvmir.splitlines()
+            if ln.startswith("declare") and "overload_method_length" in ln
+        ]
+        self.assertEqual(len(decls), 0)
+        # Test in a separate process
+        try:
+            ctx = multiprocessing.get_context("spawn")
+        except AttributeError:
+            ctx = multiprocessing
+        q = ctx.Queue()
+        p = ctx.Process(
+            target=run_caching_overload_method, args=(q, self._cache_dir)
+        )
+        p.start()
+        q.put(MyDummy())
+        p.join()
+        # Ensure subprocess exited normally
+        self.assertEqual(p.exitcode, 0)
+        res = q.get(timeout=1)
+        self.assertEqual(res, 13)
+
+
+def run_caching_overload_method(q, cache_dir):
+    """
+    Used by TestOverloadMethodCaching.test_caching_overload_method
+    """
+    with override_config("CACHE_DIR", cache_dir):
+        arg = q.get()
+        cfunc = jit(nopython=True, cache=True)(cache_overload_method_usecase)
+        res = cfunc(arg)
+        q.put(res)
+        # Check cache stat
+        _assert_cache_stats(cfunc, 1, 0)
+
+
+class TestIntrinsic(TestCase):
+    def test_void_return(self):
+        """
+        Verify that returning a None from codegen function is handled
+        automatically for void functions, otherwise raise exception.
+        """
+
+        @intrinsic
+        def void_func(typingctx, a):
+            sig = types.void(types.int32)
+
+            def codegen(context, builder, signature, args):
+                pass  # do nothing, return None, should be turned into
+                # dummy value
+
+            return sig, codegen
+
+        @intrinsic
+        def non_void_func(typingctx, a):
+            sig = types.int32(types.int32)
+
+            def codegen(context, builder, signature, args):
+                pass  # oops, should be returning a value here, raise exception
+
+            return sig, codegen
+
+        @jit(nopython=True)
+        def call_void_func():
+            void_func(1)
+            return 0
+
+        @jit(nopython=True)
+        def call_non_void_func():
+            non_void_func(1)
+            return 0
+
+        # void func should work
+        self.assertEqual(call_void_func(), 0)
+        # not void function should raise exception
+        with self.assertRaises(LoweringError) as e:
+            call_non_void_func()
+        self.assertIn("non-void function returns None", e.exception.msg)
+
+    def test_ll_pointer_cast(self):
+        """
+        Usecase test: custom reinterpret cast to turn int values to pointers
+        """
+        from ctypes import CFUNCTYPE, POINTER, c_float, c_int
+
+        # Use intrinsic to make a reinterpret_cast operation
+        def unsafe_caster(result_type):
+            assert isinstance(result_type, types.CPointer)
+
+            @intrinsic
+            def unsafe_cast(typingctx, src):
+                self.assertIsInstance(typingctx, typing.Context)
+                if isinstance(src, types.Integer):
+                    sig = result_type(types.uintp)
+
+                    # defines the custom code generation
+                    def codegen(context, builder, signature, args):
+                        [src] = args
+                        rtype = signature.return_type
+                        llrtype = context.get_value_type(rtype)
+                        return builder.inttoptr(src, llrtype)
+
+                    return sig, codegen
+
+            return unsafe_cast
+
+        # make a nopython function to use our cast op.
+        # this is not usable from cpython due to the returning of a pointer.
+        def unsafe_get_ctypes_pointer(src):
+            raise NotImplementedError("not callable from python")
+
+        @overload(unsafe_get_ctypes_pointer, strict=False)
+        def array_impl_unsafe_get_ctypes_pointer(arrtype):
+            if isinstance(arrtype, types.Array):
+                unsafe_cast = unsafe_caster(types.CPointer(arrtype.dtype))
+
+                def array_impl(arr):
+                    return unsafe_cast(src=arr.ctypes.data)
+
+                return array_impl
+
+        # the ctype wrapped function for use in nopython mode
+        def my_c_fun_raw(ptr, n):
+            for i in range(n):
+                print(ptr[i])
+
+        prototype = CFUNCTYPE(None, POINTER(c_float), c_int)
+        my_c_fun = prototype(my_c_fun_raw)
+
+        # Call our pointer-cast in a @jit compiled function and use
+        # the pointer in a ctypes function
+        @jit(nopython=True)
+        def foo(arr):
+            ptr = unsafe_get_ctypes_pointer(arr)
+            my_c_fun(ptr, arr.size)
+
+        # Test
+        arr = np.arange(10, dtype=np.float32)
+        with captured_stdout() as buf:
+            foo(arr)
+            got = buf.getvalue().splitlines()
+        buf.close()
+        expect = list(map(str, arr))
+        self.assertEqual(expect, got)
+
+    def test_serialization(self):
+        """
+        Test serialization of intrinsic objects
+        """
+
+        # define a intrinsic
+        @intrinsic
+        def identity(context, x):
+            def codegen(context, builder, signature, args):
+                return args[0]
+
+            sig = x(x)
+            return sig, codegen
+
+        # use in a jit function
+        @jit(nopython=True)
+        def foo(x):
+            return identity(x)
+
+        self.assertEqual(foo(1), 1)
+
+        # get serialization memo
+        memo = _Intrinsic._memo
+        memo_size = len(memo)
+
+        # pickle foo and check memo size
+        serialized_foo = pickle.dumps(foo)
+        # increases the memo size
+        memo_size += 1
+        self.assertEqual(memo_size, len(memo))
+        # unpickle
+        foo_rebuilt = pickle.loads(serialized_foo)
+        self.assertEqual(memo_size, len(memo))
+        # check rebuilt foo
+        self.assertEqual(foo(1), foo_rebuilt(1))
+
+        # pickle identity directly
+        serialized_identity = pickle.dumps(identity)
+        # memo size unchanged
+        self.assertEqual(memo_size, len(memo))
+        # unpickle
+        identity_rebuilt = pickle.loads(serialized_identity)
+        # must be the same object
+        self.assertIs(identity, identity_rebuilt)
+        # memo size unchanged
+        self.assertEqual(memo_size, len(memo))
+
+    def test_deserialization(self):
+        """
+        Test deserialization of intrinsic
+        """
+
+        def defn(context, x):
+            def codegen(context, builder, signature, args):
+                return args[0]
+
+            return x(x), codegen
+
+        memo = _Intrinsic._memo
+        memo_size = len(memo)
+        # invoke _Intrinsic indirectly to avoid registration which keeps an
+        # internal reference inside the compiler
+        original = _Intrinsic("foo", defn)
+        self.assertIs(original._defn, defn)
+        pickled = pickle.dumps(original)
+        # by pickling, a new memo entry is created
+        memo_size += 1
+        self.assertEqual(memo_size, len(memo))
+        del original  # remove original before unpickling
+
+        # by deleting, the memo entry is NOT removed due to recent
+        # function queue
+        self.assertEqual(memo_size, len(memo))
+
+        # Manually force clear of _recent queue
+        _Intrinsic._recent.clear()
+        memo_size -= 1
+        self.assertEqual(memo_size, len(memo))
+
+        rebuilt = pickle.loads(pickled)
+        # verify that the rebuilt object is different
+        self.assertIsNot(rebuilt._defn, defn)
+
+        # the second rebuilt object is the same as the first
+        second = pickle.loads(pickled)
+        self.assertIs(rebuilt._defn, second._defn)
+
+    def test_docstring(self):
+        @intrinsic
+        def void_func(typingctx, a: int):
+            """void_func docstring"""
+            sig = types.void(types.int32)
+
+            def codegen(context, builder, signature, args):
+                pass  # do nothing, return None, should be turned into
+                # dummy value
+
+            return sig, codegen
+
+        self.assertEqual(
+            "numba.cuda.tests.test_extending", void_func.__module__
+        )
+        self.assertEqual("void_func", void_func.__name__)
+        self.assertEqual(
+            "TestIntrinsic.test_docstring.<locals>.void_func",
+            void_func.__qualname__,
+        )
+        self.assertDictEqual({"a": int}, void_func.__annotations__)
+        self.assertEqual("void_func docstring", void_func.__doc__)
+
+
+class TestRegisterJitable(unittest.TestCase):
+    def test_no_flags(self):
+        @register_jitable
+        def foo(x, y):
+            return x + y
+
+        def bar(x, y):
+            return foo(x, y)
+
+        cbar = jit(nopython=True)(bar)
+
+        expect = bar(1, 2)
+        got = cbar(1, 2)
+        self.assertEqual(expect, got)
+
+    def test_flags_no_nrt(self):
+        @register_jitable(_nrt=False)
+        def foo(n):
+            return np.arange(n)
+
+        def bar(n):
+            return foo(n)
+
+        self.assertEqual(bar(3).tolist(), [0, 1, 2])
+
+        cbar = jit(nopython=True)(bar)
+        with self.assertRaises(errors.TypingError) as raises:
+            cbar(2)
+        msg = (
+            "Only accept returning of array passed into the function as "
+            "argument"
+        )
+        self.assertIn(msg, str(raises.exception))
+
+
+class TestImportCythonFunction(unittest.TestCase):
+    @unittest.skipIf(sc is None, "Only run if SciPy >= 0.19 is installed")
+    def test_getting_function(self):
+        addr = get_cython_function_address("scipy.special.cython_special", "j0")
+        functype = ctypes.CFUNCTYPE(ctypes.c_double, ctypes.c_double)
+        _j0 = functype(addr)
+        j0 = jit(nopython=True)(lambda x: _j0(x))
+        self.assertEqual(j0(0), 1)
+
+    def test_missing_module(self):
+        with self.assertRaises(ImportError) as raises:
+            get_cython_function_address("fakemodule", "fakefunction")
+        # The quotes are not there in Python 2
+        msg = "No module named '?fakemodule'?"
+        match = re.match(msg, str(raises.exception))
+        self.assertIsNotNone(match)
+
+    @unittest.skipIf(sc is None, "Only run if SciPy >= 0.19 is installed")
+    def test_missing_function(self):
+        with self.assertRaises(ValueError) as raises:
+            get_cython_function_address("scipy.special.cython_special", "foo")
+        msg = (
+            "No function 'foo' found in __pyx_capi__ of "
+            "'scipy.special.cython_special'"
+        )
+        self.assertEqual(msg, str(raises.exception))
+
+
+@overload_method(
+    MyDummyType, "method_jit_option_check_nrt", jit_options={"_nrt": True}
+)
+def ov_method_jit_option_check_nrt(obj):
+    def imp(obj):
+        return np.arange(10)
+
+    return imp
+
+
+@overload_method(
+    MyDummyType, "method_jit_option_check_no_nrt", jit_options={"_nrt": False}
+)
+def ov_method_jit_option_check_no_nrt(obj):
+    def imp(obj):
+        return np.arange(10)
+
+    return imp
+
+
+@overload_attribute(
+    MyDummyType, "attr_jit_option_check_nrt", jit_options={"_nrt": True}
+)
+def ov_attr_jit_option_check_nrt(obj):
+    def imp(obj):
+        return np.arange(10)
+
+    return imp
+
+
+@overload_attribute(
+    MyDummyType, "attr_jit_option_check_no_nrt", jit_options={"_nrt": False}
+)
+def ov_attr_jit_option_check_no_nrt(obj):
+    def imp(obj):
+        return np.arange(10)
+
+    return imp
+
+
+class TestJitOptionsNoNRT(TestCase):
+    # Test overload*(jit_options={...}) by turning off _nrt
+
+    def check_error_no_nrt(self, func, *args, **kwargs):
+        # Check that the compilation fails with a complaint about dynamic array
+        msg = (
+            "Only accept returning of array passed into "
+            "the function as argument"
+        )
+        with self.assertRaises(errors.TypingError) as raises:
+            func(*args, **kwargs)
+        self.assertIn(msg, str(raises.exception))
+
+    def no_nrt_overload_check(self, flag):
+        def dummy():
+            return np.arange(10)
+
+        @overload(dummy, jit_options={"_nrt": flag})
+        def ov_dummy():
+            def dummy():
+                return np.arange(10)
+
+            return dummy
+
+        @njit
+        def foo():
+            return dummy()
+
+        if flag:
+            self.assertPreciseEqual(foo(), np.arange(10))
+        else:
+            self.check_error_no_nrt(foo)
+
+    def test_overload_no_nrt(self):
+        self.no_nrt_overload_check(True)
+        self.no_nrt_overload_check(False)
+
+    def test_overload_method_no_nrt(self):
+        @njit
+        def udt(x):
+            return x.method_jit_option_check_nrt()
+
+        self.assertPreciseEqual(udt(mydummy), np.arange(10))
+
+        @njit
+        def udt(x):
+            return x.method_jit_option_check_no_nrt()
+
+        self.check_error_no_nrt(udt, mydummy)
+
+    def test_overload_attribute_no_nrt(self):
+        @njit
+        def udt(x):
+            return x.attr_jit_option_check_nrt
+
+        self.assertPreciseEqual(udt(mydummy), np.arange(10))
+
+        @njit
+        def udt(x):
+            return x.attr_jit_option_check_no_nrt
+
+        self.check_error_no_nrt(udt, mydummy)
+
+
+class TestBoxingCallingJIT(TestCase):
+    def setUp(self):
+        super().setUp()
+        many = base_dummy_type_factory("mydummy2")
+        self.DynTypeType, self.DynType, self.dyn_type_type = many
+        self.dyn_type = self.DynType()
+
+    def test_unboxer_basic(self):
+        # Implements an unboxer on DynType that calls an intrinsic into the
+        # unboxer code.
+        magic_token = 0xCAFE
+        magic_offset = 123
+
+        @intrinsic
+        def my_intrinsic(typingctx, val):
+            # An intrinsic that returns `val + magic_offset`
+            def impl(context, builder, sig, args):
+                [val] = args
+                return builder.add(val, val.type(magic_offset))
+
+            sig = signature(val, val)
+            return sig, impl
+
+        @unbox(self.DynTypeType)
+        def unboxer(typ, obj, c):
+            # The unboxer that calls some jitcode
+            def bridge(x):
+                # proof that this is a jit'ed context by calling jit only
+                # intrinsic
+                return my_intrinsic(x)
+
+            args = [c.context.get_constant(types.intp, magic_token)]
+            sig = signature(types.voidptr, types.intp)
+            is_error, res = c.pyapi.call_jit_code(bridge, sig, args)
+            return NativeValue(res, is_error=is_error)
+
+        @box(self.DynTypeType)
+        def boxer(typ, val, c):
+            # The boxer that returns an integer representation
+            res = c.builder.ptrtoint(val, cgutils.intp_t)
+            return c.pyapi.long_from_ssize_t(res)
+
+        @njit
+        def passthru(x):
+            return x
+
+        out = passthru(self.dyn_type)
+        self.assertEqual(out, magic_token + magic_offset)
+
+    def test_unboxer_raise(self):
+        # Testing exception raising in jitcode called from unboxing.
+        @unbox(self.DynTypeType)
+        def unboxer(typ, obj, c):
+            # The unboxer that calls some jitcode
+            def bridge(x):
+                if x > 0:
+                    raise ValueError("cannot be x > 0")
+                return x
+
+            args = [c.context.get_constant(types.intp, 1)]
+            sig = signature(types.voidptr, types.intp)
+            is_error, res = c.pyapi.call_jit_code(bridge, sig, args)
+            return NativeValue(res, is_error=is_error)
+
+        @box(self.DynTypeType)
+        def boxer(typ, val, c):
+            # The boxer that returns an integer representation
+            res = c.builder.ptrtoint(val, cgutils.intp_t)
+            return c.pyapi.long_from_ssize_t(res)
+
+        @njit
+        def passthru(x):
+            return x
+
+        with self.assertRaises(ValueError) as raises:
+            passthru(self.dyn_type)
+        self.assertIn(
+            "cannot be x > 0",
+            str(raises.exception),
+        )
+
+    def test_boxer(self):
+        # Call jitcode inside the boxer
+        magic_token = 0xCAFE
+        magic_offset = 312
+
+        @intrinsic
+        def my_intrinsic(typingctx, val):
+            # An intrinsic that returns `val + magic_offset`
+            def impl(context, builder, sig, args):
+                [val] = args
+                return builder.add(val, val.type(magic_offset))
+
+            sig = signature(val, val)
+            return sig, impl
+
+        @unbox(self.DynTypeType)
+        def unboxer(typ, obj, c):
+            return NativeValue(c.context.get_dummy_value())
+
+        @box(self.DynTypeType)
+        def boxer(typ, val, c):
+            # Note: this doesn't do proper error handling
+            def bridge(x):
+                return my_intrinsic(x)
+
+            args = [c.context.get_constant(types.intp, magic_token)]
+            sig = signature(types.intp, types.intp)
+            is_error, res = c.pyapi.call_jit_code(bridge, sig, args)
+            return c.pyapi.long_from_ssize_t(res)
+
+        @njit
+        def passthru(x):
+            return x
+
+        r = passthru(self.dyn_type)
+        self.assertEqual(r, magic_token + magic_offset)
+
+    def test_boxer_raise(self):
+        # Call jitcode inside the boxer
+        @unbox(self.DynTypeType)
+        def unboxer(typ, obj, c):
+            return NativeValue(c.context.get_dummy_value())
+
+        @box(self.DynTypeType)
+        def boxer(typ, val, c):
+            def bridge(x):
+                if x > 0:
+                    raise ValueError("cannot do x > 0")
+                return x
+
+            args = [c.context.get_constant(types.intp, 1)]
+            sig = signature(types.intp, types.intp)
+            is_error, res = c.pyapi.call_jit_code(bridge, sig, args)
+            # The error handling
+            retval = cgutils.alloca_once(c.builder, c.pyapi.pyobj, zfill=True)
+            with c.builder.if_then(c.builder.not_(is_error)):
+                obj = c.pyapi.long_from_ssize_t(res)
+                c.builder.store(obj, retval)
+            return c.builder.load(retval)
+
+        @njit
+        def passthru(x):
+            return x
+
+        with self.assertRaises(ValueError) as raises:
+            passthru(self.dyn_type)
+        self.assertIn(
+            "cannot do x > 0",
+            str(raises.exception),
+        )
+
+
+def with_objmode_cache_ov_example(x):
+    # This is the function stub for overloading inside
+    # TestCachingOverloadObjmode.test_caching_overload_objmode
+    pass
+
+
+@skip_if_typeguard
+class TestCachingOverloadObjmode(TestCase):
+    """Test caching of the use of overload implementations that use
+    `with objmode`
+    """
+
+    _numba_parallel_test_ = False
+
+    def setUp(self):
+        warnings.simplefilter("error", errors.NumbaWarning)
+
+    def tearDown(self):
+        warnings.resetwarnings()
+
+    def test_caching_overload_objmode(self):
+        cache_dir = temp_directory(self.__class__.__name__)
+        with override_config("CACHE_DIR", cache_dir):
+
+            def realwork(x):
+                # uses numpy code
+                arr = np.arange(x) / x
+                return np.linalg.norm(arr)
+
+            def python_code(x):
+                # create indirections
+                return realwork(x)
+
+            @overload(with_objmode_cache_ov_example)
+            def _ov_with_objmode_cache_ov_example(x):
+                def impl(x):
+                    with objmode(y="float64"):
+                        y = python_code(x)
+                    return y
+
+                return impl
+
+            @njit(cache=True)
+            def testcase(x):
+                return with_objmode_cache_ov_example(x)
+
+            expect = realwork(123)
+            got = testcase(123)
+            self.assertEqual(got, expect)
+
+            testcase_cached = njit(cache=True)(testcase.py_func)
+            got = testcase_cached(123)
+            self.assertEqual(got, expect)
+
+    @classmethod
+    def check_objmode_cache_ndarray(cls):
+        def do_this(a, b):
+            return np.sum(a + b)
+
+        def do_something(a, b):
+            return np.sum(a + b)
+
+        @overload(do_something)
+        def overload_do_something(a, b):
+            def _do_something_impl(a, b):
+                with objmode(y="float64"):
+                    y = do_this(a, b)
+                return y
+
+            return _do_something_impl
+
+        @njit(cache=True)
+        def test_caching():
+            a = np.arange(20)
+            b = np.arange(20)
+            return do_something(a, b)
+
+        got = test_caching()
+        expect = test_caching.py_func()
+
+        # Check result
+        if got != expect:
+            raise AssertionError("incorrect result")
+        return test_caching
+
+    @classmethod
+    def populate_objmode_cache_ndarray_check_cache(cls):
+        cls.check_objmode_cache_ndarray()
+
+    @classmethod
+    def check_objmode_cache_ndarray_check_cache(cls):
+        disp = cls.check_objmode_cache_ndarray()
+        if len(disp.stats.cache_misses) != 0:
+            raise AssertionError("unexpected cache miss")
+        if len(disp.stats.cache_hits) <= 0:
+            raise AssertionError("unexpected missing cache hit")
+
+    def test_check_objmode_cache_ndarray(self):
+        # See issue #6130.
+        # Env is missing after cache load.
+        cache_dir = temp_directory(self.__class__.__name__)
+        with override_config("CACHE_DIR", cache_dir):
+            # Run in new process to populate the cache
+            run_in_new_process_in_cache_dir(
+                self.populate_objmode_cache_ndarray_check_cache, cache_dir
+            )
+            # Run in new process to use the cache in a fresh process.
+            res = run_in_new_process_in_cache_dir(
+                self.check_objmode_cache_ndarray_check_cache, cache_dir
+            )
+        self.assertEqual(res["exitcode"], 0)
+
+
+class TestMisc(TestCase):
+    def test_is_jitted(self):
+        def foo(x):
+            pass
+
+        self.assertFalse(is_jitted(foo))
+        self.assertTrue(is_jitted(njit(foo)))
+        self.assertFalse(is_jitted(vectorize(foo)))
+        self.assertFalse(is_jitted(vectorize(parallel=True)(foo)))
+        self.assertFalse(is_jitted(guvectorize("void(float64[:])", "(m)")(foo)))
+
+    def test_overload_arg_binding(self):
+        # See issue #7982, checks that calling a function with named args works
+        # correctly irrespective of the order in which the names are supplied.
+        @njit
+        def standard_order():
+            return np.full(shape=123, fill_value=456).shape
+
+        @njit
+        def reversed_order():
+            return np.full(fill_value=456, shape=123).shape
+
+        self.assertPreciseEqual(standard_order(), standard_order.py_func())
+        self.assertPreciseEqual(reversed_order(), reversed_order.py_func())
+
+
+class TestOverloadPreferLiteral(TestCase):
+    def test_overload(self):
+        def prefer_lit(x):
+            pass
+
+        def non_lit(x):
+            pass
+
+        def ov(x):
+            if isinstance(x, types.IntegerLiteral):
+                # With prefer_literal=False, this branch will not be reached.
+                if x.literal_value == 1:
+
+                    def impl(x):
+                        return 0xCAFE
+
+                    return impl
+                else:
+                    raise errors.TypingError("literal value")
+            else:
+
+                def impl(x):
+                    return x * 100
+
+                return impl
+
+        overload(prefer_lit, prefer_literal=True)(ov)
+        overload(non_lit)(ov)
+
+        @njit
+        def check_prefer_lit(x):
+            return prefer_lit(1), prefer_lit(2), prefer_lit(x)
+
+        a, b, c = check_prefer_lit(3)
+        self.assertEqual(a, 0xCAFE)
+        self.assertEqual(b, 200)
+        self.assertEqual(c, 300)
+
+        @njit
+        def check_non_lit(x):
+            return non_lit(1), non_lit(2), non_lit(x)
+
+        a, b, c = check_non_lit(3)
+        self.assertEqual(a, 100)
+        self.assertEqual(b, 200)
+        self.assertEqual(c, 300)
+
+    def test_overload_method(self):
+        def ov(self, x):
+            if isinstance(x, types.IntegerLiteral):
+                # With prefer_literal=False, this branch will not be reached.
+                if x.literal_value == 1:
+
+                    def impl(self, x):
+                        return 0xCAFE
+
+                    return impl
+                else:
+                    raise errors.TypingError("literal value")
+            else:
+
+                def impl(self, x):
+                    return x * 100
+
+                return impl
+
+        overload_method(
+            MyDummyType,
+            "method_prefer_literal",
+            prefer_literal=True,
+        )(ov)
+
+        overload_method(
+            MyDummyType,
+            "method_non_literal",
+            prefer_literal=False,
+        )(ov)
+
+        @njit
+        def check_prefer_lit(dummy, x):
+            return (
+                dummy.method_prefer_literal(1),
+                dummy.method_prefer_literal(2),
+                dummy.method_prefer_literal(x),
+            )
+
+        a, b, c = check_prefer_lit(MyDummy(), 3)
+        self.assertEqual(a, 0xCAFE)
+        self.assertEqual(b, 200)
+        self.assertEqual(c, 300)
+
+        @njit
+        def check_non_lit(dummy, x):
+            return (
+                dummy.method_non_literal(1),
+                dummy.method_non_literal(2),
+                dummy.method_non_literal(x),
+            )
+
+        a, b, c = check_non_lit(MyDummy(), 3)
+        self.assertEqual(a, 100)
+        self.assertEqual(b, 200)
+        self.assertEqual(c, 300)
+
+
+class TestIntrinsicPreferLiteral(TestCase):
+    def test_intrinsic(self):
+        def intrin(context, x):
+            # This intrinsic will return 0xcafe if `x` is a literal `1`.
+            sig = signature(types.intp, x)
+            if isinstance(x, types.IntegerLiteral):
+                # With prefer_literal=False, this branch will not be reached
+                if x.literal_value == 1:
+
+                    def codegen(context, builder, signature, args):
+                        atype = signature.args[0]
+                        llrtype = context.get_value_type(atype)
+                        return ir.Constant(llrtype, 0xCAFE)
+
+                    return sig, codegen
+                else:
+                    raise errors.TypingError("literal value")
+            else:
+
+                def codegen(context, builder, signature, args):
+                    atype = signature.return_type
+                    llrtype = context.get_value_type(atype)
+                    int_100 = ir.Constant(llrtype, 100)
+                    return builder.mul(args[0], int_100)
+
+                return sig, codegen
+
+        prefer_lit = intrinsic(prefer_literal=True)(intrin)
+        non_lit = intrinsic(prefer_literal=False)(intrin)
+
+        @njit
+        def check_prefer_lit(x):
+            return prefer_lit(1), prefer_lit(2), prefer_lit(x)
+
+        a, b, c = check_prefer_lit(3)
+        self.assertEqual(a, 0xCAFE)
+        self.assertEqual(b, 200)
+        self.assertEqual(c, 300)
+
+        @njit
+        def check_non_lit(x):
+            return non_lit(1), non_lit(2), non_lit(x)
+
+        a, b, c = check_non_lit(3)
+        self.assertEqual(a, 100)
+        self.assertEqual(b, 200)
+        self.assertEqual(c, 300)
+
+
+class TestNumbaInternalOverloads(TestCase):
+    def test_signatures_match_overloaded_api(self):
+        # This is a "best-effort" test to try and ensure that Numba's internal
+        # overload declarations have signatures with argument names that match
+        # the API they are overloading. The purpose of ensuring there is a
+        # match is so that users can use call-by-name for positional arguments.
+
+        # Set this to:
+        # 0 to make violations raise a ValueError (default).
+        # 1 to get violations reported to STDOUT
+        # 2 to get a verbose output of everything that was checked and its state
+        #   reported to STDOUT.
+        DEBUG = 0
+
+        # np.random.* does not have a signature exposed to `inspect`... so
+        # custom parse the docstrings.
+        def sig_from_np_random(x):
+            if not x.startswith("_"):
+                thing = getattr(np.random, x)
+                if inspect.isbuiltin(thing):
+                    docstr = thing.__doc__.splitlines()
+                    for l in docstr:
+                        if l:
+                            sl = l.strip()
+                            if sl.startswith(x):  # its the signature
+                                # special case np.random.seed, it has `self` in
+                                # the signature whereas all the other functions
+                                # do not!?
+                                if x == "seed":
+                                    sl = "seed(seed)"
+
+                                fake_impl = f"def {sl}:\n\tpass"
+                                l = {}
+                                try:
+                                    exec(fake_impl, {}, l)
+                                except SyntaxError:
+                                    # likely elipsis, e.g. rand(d0, d1, ..., dn)
+                                    if DEBUG == 2:
+                                        print(
+                                            "... skipped as cannot parse "
+                                            "signature"
+                                        )
+                                    return None
+                                else:
+                                    fn = l.get(x)
+                                    return inspect.signature(fn)
+
+        def checker(func, overload_func):
+            if DEBUG == 2:
+                print(f"Checking: {func}")
+
+            def create_message(func, overload_func, func_sig, ol_sig):
+                msg = []
+                s = (
+                    f"{func} from module '{getattr(func, '__module__')}' "
+                    "has mismatched sig."
+                )
+                msg.append(s)
+                msg.append(f"    - expected: {func_sig}")
+                msg.append(f"    -      got: {ol_sig}")
+                lineno = inspect.getsourcelines(overload_func)[1]
+                tmpsrcfile = inspect.getfile(overload_func)
+                srcfile = tmpsrcfile.replace(numba.__path__[0], "")
+                msg.append(f"from {srcfile}:{lineno}")
+                msgstr = "\n" + "\n".join(msg)
+                return msgstr
+
+            func_sig = None
+            try:
+                func_sig = inspect.signature(func)
+            except ValueError:
+                # probably a built-in/C code, see if it's a np.random function
+                if fname := getattr(func, "__name__", False):
+                    if maybe_func := getattr(np.random, fname, False):
+                        if maybe_func == func:
+                            # it's a built-in from np.random
+                            func_sig = sig_from_np_random(fname)
+
+            if func_sig is not None:
+                ol_sig = inspect.signature(overload_func)
+                x = list(func_sig.parameters.keys())
+                y = list(ol_sig.parameters.keys())
+                for a, b in zip(x[: len(y)], y):
+                    if a != b:
+                        p = func_sig.parameters[a]
+                        if p.kind == p.POSITIONAL_ONLY:
+                            # probably a built-in/C code
+                            if DEBUG == 2:
+                                print(
+                                    "... skipped as positional only "
+                                    "arguments found"
+                                )
+                            break
+                        elif "*" in str(p):  # probably *args or similar
+                            if DEBUG == 2:
+                                print("... skipped as contains *args")
+                            break
+                        else:
+                            # Only error/report on functions that have a module
+                            # or are from somewhere other than Numba.
+                            if (
+                                not func.__module__
+                                or not func.__module__.startswith("numba")
+                            ):
+                                msgstr = create_message(
+                                    func, overload_func, func_sig, ol_sig
+                                )
+                                if DEBUG != 0:
+                                    if DEBUG == 2:
+                                        print("... INVALID")
+                                    if msgstr:
+                                        print(msgstr)
+                                    break
+                                else:
+                                    raise ValueError(msgstr)
+                            else:
+                                if DEBUG == 2:
+                                    if not func.__module__:
+                                        print(
+                                            "... skipped as no __module__ "
+                                            "present"
+                                        )
+                                    else:
+                                        print("... skipped as Numba internal")
+                                break
+                else:
+                    if DEBUG == 2:
+                        print("... OK")
+
+        # Compile something to make sure that the typing context registries
+        # are populated with everything from the CPU target.
+        njit(lambda: None).compile(())
+        tyctx = numba.core.typing.context.Context()
+        tyctx.refresh()
+
+        # Walk the registries and check each function that is an overload
+        regs = tyctx._registries
+        for k, v in regs.items():
+            for item in k.functions:
+                if getattr(item, "_overload_func", False):
+                    checker(item.key, item._overload_func)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/numba_cuda/numba/cuda/tests/test_extending.py
+++ b/numba_cuda/numba/cuda/tests/test_extending.py
@@ -3,147 +3,30 @@
 
 import inspect
 import math
-import operator
-import sys
 import pickle
-import multiprocessing
-import ctypes
-import warnings
-import re
+
 
 import numpy as np
-from llvmlite import ir
 
 import numba
-from numba import njit, jit, vectorize, guvectorize, objmode
-from numba.core import types, errors, typing
-from numba.cuda import cgutils
+from numba.cuda import jit
+from numba.core import types, errors
 from numba.cuda.tests.support import (
     TestCase,
-    captured_stdout,
-    temp_directory,
-    override_config,
-    run_in_new_process_in_cache_dir,
-    skip_if_typeguard,
 )
 from numba.core.errors import LoweringError
 import unittest
 
-from numba.extending import (
-    typeof_impl,
+from numba.cuda.extending import (
     type_callable,
     lower_builtin,
-    lower_cast,
     overload,
-    overload_attribute,
     overload_method,
-    models,
-    register_model,
-    box,
-    unbox,
-    NativeValue,
     intrinsic,
     _Intrinsic,
     register_jitable,
-    get_cython_function_address,
-    is_jitted,
-    overload_classmethod,
 )
-from numba.cuda.typing.templates import (
-    ConcreteTemplate,
-    signature,
-    Registry,
-    AbstractTemplate,
-)
-
-# Pandas-like API implementation
-from .pdlike_usecase import Index, Series
-
-registry = Registry()
-infer = registry.register
-infer_global = registry.register_global
-infer_getattr = registry.register_attr
-
-
-try:
-    import scipy.special.cython_special as sc
-except ImportError:
-    sc = None
-
-
-# -----------------------------------------------------------------------
-# Define a custom type and an implicit cast on it
-
-
-class MyDummy(object):
-    pass
-
-
-class MyDummyType(types.Opaque):
-    def can_convert_to(self, context, toty):
-        if isinstance(toty, types.Number):
-            from numba.core.typeconv import Conversion
-
-            return Conversion.safe
-
-
-mydummy_type = MyDummyType("mydummy")
-mydummy = MyDummy()
-
-
-@typeof_impl.register(MyDummy)
-def typeof_mydummy(val, c):
-    return mydummy_type
-
-
-@lower_cast(MyDummyType, types.Number)
-def mydummy_to_number(context, builder, fromty, toty, val):
-    """
-    Implicit conversion from MyDummy to int.
-    """
-    return context.get_constant(toty, 42)
-
-
-def get_dummy():
-    return mydummy
-
-
-register_model(MyDummyType)(models.OpaqueModel)
-
-
-@unbox(MyDummyType)
-def unbox_index(typ, obj, c):
-    return NativeValue(c.context.get_dummy_value())
-
-
-# -----------------------------------------------------------------------
-# Define a second custom type but w/o implicit cast to Number
-
-
-def base_dummy_type_factory(name):
-    class DynType(object):
-        pass
-
-    class DynTypeType(types.Opaque):
-        pass
-
-    dyn_type_type = DynTypeType(name)
-
-    @typeof_impl.register(DynType)
-    def typeof_mydummy(val, c):
-        return dyn_type_type
-
-    register_model(DynTypeType)(models.OpaqueModel)
-    return DynTypeType, DynType, dyn_type_type
-
-
-MyDummyType2, MyDummy2, mydummy_type_2 = base_dummy_type_factory("mydummy2")
-
-
-@unbox(MyDummyType2)
-def unbox_index2(typ, obj, c):
-    return NativeValue(c.context.get_dummy_value())
-
+from numba.cuda.testing import skip_on_cudasim
 
 # -----------------------------------------------------------------------
 # Define a function's typing and implementation using the classical
@@ -183,330 +66,19 @@ def func1_unary(context, builder, sig, args):
     return context.compile_internal(builder, func1_impl, sig, args)
 
 
-# We can do the same for a known internal operation, here "print_item"
-# which we extend to support MyDummyType.
-
-
-@infer
-class PrintDummy(ConcreteTemplate):
-    key = "print_item"
-    cases = [signature(types.none, mydummy_type)]
-
-
-@lower_builtin("print_item", MyDummyType)
-def print_dummy(context, builder, sig, args):
-    [x] = args
-    pyapi = context.get_python_api(builder)
-    strobj = pyapi.unserialize(pyapi.serialize_object("hello!"))
-    pyapi.print_object(strobj)
-    pyapi.decref(strobj)
-    return context.get_dummy_value()
-
-
-# -----------------------------------------------------------------------
-# Define an overloaded function (combined API)
-
-
-def where(cond, x, y):
-    raise NotImplementedError
-
-
-def np_where(cond, x, y):
-    """
-    Wrap np.where() to allow for keyword arguments
-    """
-    return np.where(cond, x, y)
-
-
-def call_where(cond, x, y):
-    return where(cond, y=y, x=x)
-
-
-@overload(where)
-def overload_where_arrays(cond, x, y):
-    """
-    Implement where() for arrays.
-    """
-    # Choose implementation based on argument types.
-    if isinstance(cond, types.Array):
-        if x.dtype != y.dtype:
-            raise errors.TypingError("x and y should have the same dtype")
-
-        # Array where() => return an array of the same shape
-        if all(ty.layout == "C" for ty in (cond, x, y)):
-
-            def where_impl(cond, x, y):
-                """
-                Fast implementation for C-contiguous arrays
-                """
-                shape = cond.shape
-                if x.shape != shape or y.shape != shape:
-                    raise ValueError("all inputs should have the same shape")
-                res = np.empty_like(x)
-                cf = cond.flat
-                xf = x.flat
-                yf = y.flat
-                rf = res.flat
-                for i in range(cond.size):
-                    rf[i] = xf[i] if cf[i] else yf[i]
-                return res
-
-        else:
-
-            def where_impl(cond, x, y):
-                """
-                Generic implementation for other arrays
-                """
-                shape = cond.shape
-                if x.shape != shape or y.shape != shape:
-                    raise ValueError("all inputs should have the same shape")
-                res = np.empty_like(x)
-                for idx, c in np.ndenumerate(cond):
-                    res[idx] = x[idx] if c else y[idx]
-                return res
-
-        return where_impl
-
-
-# We can define another overload function for the same function, they
-# will be tried in turn until one succeeds.
-
-
-@overload(where)
-def overload_where_scalars(cond, x, y):
-    """
-    Implement where() for scalars.
-    """
-    if not isinstance(cond, types.Array):
-        if x != y:
-            raise errors.TypingError("x and y should have the same type")
-
-        def where_impl(cond, x, y):
-            """
-            Scalar where() => return a 0-dim array
-            """
-            scal = x if cond else y
-            # Can't use full_like() on Numpy < 1.8
-            arr = np.empty_like(scal)
-            arr[()] = scal
-            return arr
-
-        return where_impl
-
-
 # -----------------------------------------------------------------------
 # Overload an already defined built-in function, extending it for new types.
 
 
-@overload(len)
-def overload_len_dummy(arg):
-    if isinstance(arg, MyDummyType):
+def call_func1_nullary(res):
+    res[0] = func1()
 
-        def len_impl(arg):
-            return 13
 
-        return len_impl
+def call_func1_unary(x, res):
+    res[0] = func1(x)
 
 
-@overload(operator.add)
-def overload_add_dummy(arg1, arg2):
-    if isinstance(arg1, (MyDummyType, MyDummyType2)) and isinstance(
-        arg2, (MyDummyType, MyDummyType2)
-    ):
-
-        def dummy_add_impl(arg1, arg2):
-            return 42
-
-        return dummy_add_impl
-
-
-@overload(operator.delitem)
-def overload_dummy_delitem(obj, idx):
-    if isinstance(obj, MyDummyType) and isinstance(idx, types.Integer):
-
-        def dummy_delitem_impl(obj, idx):
-            print("del", obj, idx)
-
-        return dummy_delitem_impl
-
-
-@overload(operator.getitem)
-def overload_dummy_getitem(obj, idx):
-    if isinstance(obj, MyDummyType) and isinstance(idx, types.Integer):
-
-        def dummy_getitem_impl(obj, idx):
-            return idx + 123
-
-        return dummy_getitem_impl
-
-
-@overload(operator.setitem)
-def overload_dummy_setitem(obj, idx, val):
-    if all(
-        [
-            isinstance(obj, MyDummyType),
-            isinstance(idx, types.Integer),
-            isinstance(val, types.Integer),
-        ]
-    ):
-
-        def dummy_setitem_impl(obj, idx, val):
-            print(idx, val)
-
-        return dummy_setitem_impl
-
-
-def call_add_operator(arg1, arg2):
-    return operator.add(arg1, arg2)
-
-
-def call_add_binop(arg1, arg2):
-    return arg1 + arg2
-
-
-@overload(operator.iadd)
-def overload_iadd_dummy(arg1, arg2):
-    if isinstance(arg1, (MyDummyType, MyDummyType2)) and isinstance(
-        arg2, (MyDummyType, MyDummyType2)
-    ):
-
-        def dummy_iadd_impl(arg1, arg2):
-            return 42
-
-        return dummy_iadd_impl
-
-
-def call_iadd_operator(arg1, arg2):
-    return operator.add(arg1, arg2)
-
-
-def call_iadd_binop(arg1, arg2):
-    arg1 += arg2
-
-    return arg1
-
-
-def call_delitem(obj, idx):
-    del obj[idx]
-
-
-def call_getitem(obj, idx):
-    return obj[idx]
-
-
-def call_setitem(obj, idx, val):
-    obj[idx] = val
-
-
-@overload_method(MyDummyType, "length")
-def overload_method_length(arg):
-    def imp(arg):
-        return len(arg)
-
-    return imp
-
-
-def cache_overload_method_usecase(x):
-    return x.length()
-
-
-def call_func1_nullary():
-    return func1()
-
-
-def call_func1_unary(x):
-    return func1(x)
-
-
-def len_usecase(x):
-    return len(x)
-
-
-def print_usecase(x):
-    print(x)
-
-
-def getitem_usecase(x, key):
-    return x[key]
-
-
-def npyufunc_usecase(x):
-    return np.cos(np.sin(x))
-
-
-def get_data_usecase(x):
-    return x._data
-
-
-def get_index_usecase(x):
-    return x._index
-
-
-def is_monotonic_usecase(x):
-    return x.is_monotonic_increasing
-
-
-def make_series_usecase(data, index):
-    return Series(data, index)
-
-
-def clip_usecase(x, lo, hi):
-    return x.clip(lo, hi)
-
-
-# -----------------------------------------------------------------------
-
-
-def return_non_boxable():
-    return np
-
-
-@overload(return_non_boxable)
-def overload_return_non_boxable():
-    def imp():
-        return np
-
-    return imp
-
-
-def non_boxable_ok_usecase(sz):
-    mod = return_non_boxable()
-    return mod.arange(sz)
-
-
-def non_boxable_bad_usecase():
-    return return_non_boxable()
-
-
-def mk_func_input(f):
-    pass
-
-
-@infer_global(mk_func_input)
-class MkFuncTyping(AbstractTemplate):
-    def generic(self, args, kws):
-        assert isinstance(args[0], types.MakeFunctionLiteral)
-        return signature(types.none, *args)
-
-
-def mk_func_test_impl():
-    mk_func_input(lambda a: a)
-
-
-# -----------------------------------------------------------------------
-
-
-@overload(np.exp)
-def overload_np_exp(obj):
-    if isinstance(obj, MyDummyType):
-
-        def imp(obj):
-            # Returns a constant if a MyDummyType is seen
-            return 0xDEADBEEF
-
-        return imp
-
-
+@skip_on_cudasim("Simulator does not support extending types")
 class TestLowLevelExtending(TestCase):
     """
     Test the low-level two-tier extension API.
@@ -517,12 +89,15 @@ class TestLowLevelExtending(TestCase):
 
     def test_func1(self):
         pyfunc = call_func1_nullary
-        cfunc = jit(nopython=True)(pyfunc)
-        self.assertPreciseEqual(cfunc(), 42)
+        cfunc = jit(pyfunc)
+        res = np.zeros(1)
+        cfunc[1, 1](res)
+        self.assertPreciseEqual(res[0], 42.0)
         pyfunc = call_func1_unary
-        cfunc = jit(nopython=True)(pyfunc)
-        self.assertPreciseEqual(cfunc(None), 42)
-        self.assertPreciseEqual(cfunc(18.0), 6.0)
+        cfunc = jit(pyfunc)
+        self.assertPreciseEqual(res[0], 42.0)
+        cfunc[1, 1](18.0, res)
+        self.assertPreciseEqual(res[0], 6.0)
 
     @TestCase.run_test_in_subprocess
     def test_func1_isolated(self):
@@ -532,272 +107,12 @@ class TestLowLevelExtending(TestCase):
         self.assertIs(type_func1, type_func1_)
         self.assertIsNotNone(type_func1)
 
-    @TestCase.run_test_in_subprocess
-    def test_cast_mydummy(self):
-        pyfunc = get_dummy
-        cfunc = njit(
-            types.float64(),
-        )(pyfunc)
-        self.assertPreciseEqual(cfunc(), 42.0)
 
-
-class TestPandasLike(TestCase):
-    """
-    Test implementing a pandas-like Index object.
-    Also stresses most of the high-level API.
-    """
-
-    def test_index_len(self):
-        i = Index(np.arange(3))
-        cfunc = jit(nopython=True)(len_usecase)
-        self.assertPreciseEqual(cfunc(i), 3)
-
-    def test_index_getitem(self):
-        i = Index(np.int32([42, 8, -5]))
-        cfunc = jit(nopython=True)(getitem_usecase)
-        self.assertPreciseEqual(cfunc(i, 1), 8)
-        ii = cfunc(i, slice(1, None))
-        self.assertIsInstance(ii, Index)
-        self.assertEqual(list(ii), [8, -5])
-
-    def test_index_ufunc(self):
-        """
-        Check Numpy ufunc on an Index object.
-        """
-        i = Index(np.int32([42, 8, -5]))
-        cfunc = jit(nopython=True)(npyufunc_usecase)
-        ii = cfunc(i)
-        self.assertIsInstance(ii, Index)
-        self.assertPreciseEqual(ii._data, np.cos(np.sin(i._data)))
-
-    def test_index_get_data(self):
-        # The _data attribute is exposed with make_attribute_wrapper()
-        i = Index(np.int32([42, 8, -5]))
-        cfunc = jit(nopython=True)(get_data_usecase)
-        data = cfunc(i)
-        self.assertIs(data, i._data)
-
-    def test_index_is_monotonic(self):
-        # The is_monotonic_increasing attribute is exposed with
-        # overload_attribute()
-        cfunc = jit(nopython=True)(is_monotonic_usecase)
-        for values, expected in [
-            ([8, 42, 5], False),
-            ([5, 8, 42], True),
-            ([], True),
-        ]:
-            i = Index(np.int32(values))
-            got = cfunc(i)
-            self.assertEqual(got, expected)
-
-    def test_series_len(self):
-        i = Index(np.int32([2, 4, 3]))
-        s = Series(np.float64([1.5, 4.0, 2.5]), i)
-        cfunc = jit(nopython=True)(len_usecase)
-        self.assertPreciseEqual(cfunc(s), 3)
-
-    def test_series_get_index(self):
-        i = Index(np.int32([2, 4, 3]))
-        s = Series(np.float64([1.5, 4.0, 2.5]), i)
-        cfunc = jit(nopython=True)(get_index_usecase)
-        got = cfunc(s)
-        self.assertIsInstance(got, Index)
-        self.assertIs(got._data, i._data)
-
-    def test_series_ufunc(self):
-        """
-        Check Numpy ufunc on an Series object.
-        """
-        i = Index(np.int32([42, 8, -5]))
-        s = Series(np.int64([1, 2, 3]), i)
-        cfunc = jit(nopython=True)(npyufunc_usecase)
-        ss = cfunc(s)
-        self.assertIsInstance(ss, Series)
-        self.assertIsInstance(ss._index, Index)
-        self.assertIs(ss._index._data, i._data)
-        self.assertPreciseEqual(ss._values, np.cos(np.sin(s._values)))
-
-    def test_series_constructor(self):
-        i = Index(np.int32([42, 8, -5]))
-        d = np.float64([1.5, 4.0, 2.5])
-        cfunc = jit(nopython=True)(make_series_usecase)
-        got = cfunc(d, i)
-        self.assertIsInstance(got, Series)
-        self.assertIsInstance(got._index, Index)
-        self.assertIs(got._index._data, i._data)
-        self.assertIs(got._values, d)
-
-    def test_series_clip(self):
-        i = Index(np.int32([42, 8, -5]))
-        s = Series(np.float64([1.5, 4.0, 2.5]), i)
-        cfunc = jit(nopython=True)(clip_usecase)
-        ss = cfunc(s, 1.6, 3.0)
-        self.assertIsInstance(ss, Series)
-        self.assertIsInstance(ss._index, Index)
-        self.assertIs(ss._index._data, i._data)
-        self.assertPreciseEqual(ss._values, np.float64([1.6, 3.0, 2.5]))
-
-
+@skip_on_cudasim("Simulator does not support extending types")
 class TestHighLevelExtending(TestCase):
     """
     Test the high-level combined API.
     """
-
-    def test_where(self):
-        """
-        Test implementing a function with @overload.
-        """
-        pyfunc = call_where
-        cfunc = jit(nopython=True)(pyfunc)
-
-        def check(*args, **kwargs):
-            expected = np_where(*args, **kwargs)
-            got = cfunc(*args, **kwargs)
-            self.assertPreciseEqual(expected, got)
-
-        check(x=3, cond=True, y=8)
-        check(True, 3, 8)
-        check(
-            np.bool_([True, False, True]),
-            np.int32([1, 2, 3]),
-            np.int32([4, 5, 5]),
-        )
-
-        # The typing error is propagated
-        with self.assertRaises(errors.TypingError) as raises:
-            cfunc(np.bool_([]), np.int32([]), np.int64([]))
-        self.assertIn(
-            "x and y should have the same dtype", str(raises.exception)
-        )
-
-    def test_len(self):
-        """
-        Test re-implementing len() for a custom type with @overload.
-        """
-        cfunc = jit(nopython=True)(len_usecase)
-        self.assertPreciseEqual(cfunc(MyDummy()), 13)
-        self.assertPreciseEqual(cfunc([4, 5]), 2)
-
-    def test_print(self):
-        """
-        Test re-implementing print() for a custom type with @overload.
-        """
-        cfunc = jit(nopython=True)(print_usecase)
-        with captured_stdout():
-            cfunc(MyDummy())
-            self.assertEqual(sys.stdout.getvalue(), "hello!\n")
-
-    def test_add_operator(self):
-        """
-        Test re-implementing operator.add() for a custom type with @overload.
-        """
-        pyfunc = call_add_operator
-        cfunc = jit(nopython=True)(pyfunc)
-
-        self.assertPreciseEqual(cfunc(1, 2), 3)
-        self.assertPreciseEqual(cfunc(MyDummy2(), MyDummy2()), 42)
-
-        # this will call add(Number, Number) as MyDummy implicitly casts to
-        # Number
-        self.assertPreciseEqual(cfunc(MyDummy(), MyDummy()), 84)
-
-    def test_add_binop(self):
-        """
-        Test re-implementing '+' for a custom type via @overload(operator.add).
-        """
-        pyfunc = call_add_binop
-        cfunc = jit(nopython=True)(pyfunc)
-
-        self.assertPreciseEqual(cfunc(1, 2), 3)
-        self.assertPreciseEqual(cfunc(MyDummy2(), MyDummy2()), 42)
-
-        # this will call add(Number, Number) as MyDummy implicitly casts to
-        # Number
-        self.assertPreciseEqual(cfunc(MyDummy(), MyDummy()), 84)
-
-    def test_iadd_operator(self):
-        """
-        Test re-implementing operator.add() for a custom type with @overload.
-        """
-        pyfunc = call_iadd_operator
-        cfunc = jit(nopython=True)(pyfunc)
-
-        self.assertPreciseEqual(cfunc(1, 2), 3)
-        self.assertPreciseEqual(cfunc(MyDummy2(), MyDummy2()), 42)
-
-        # this will call add(Number, Number) as MyDummy implicitly casts to
-        # Number
-        self.assertPreciseEqual(cfunc(MyDummy(), MyDummy()), 84)
-
-    def test_iadd_binop(self):
-        """
-        Test re-implementing '+' for a custom type via @overload(operator.add).
-        """
-        pyfunc = call_iadd_binop
-        cfunc = jit(nopython=True)(pyfunc)
-
-        self.assertPreciseEqual(cfunc(1, 2), 3)
-        self.assertPreciseEqual(cfunc(MyDummy2(), MyDummy2()), 42)
-
-        # this will call add(Number, Number) as MyDummy implicitly casts to
-        # Number
-        self.assertPreciseEqual(cfunc(MyDummy(), MyDummy()), 84)
-
-    def test_delitem(self):
-        pyfunc = call_delitem
-        cfunc = jit(nopython=True)(pyfunc)
-        obj = MyDummy()
-        e = None
-
-        with captured_stdout() as out:
-            try:
-                cfunc(obj, 321)
-            except Exception as exc:
-                e = exc
-
-        if e is not None:
-            raise e
-        self.assertEqual(out.getvalue(), "del hello! 321\n")
-
-    def test_getitem(self):
-        pyfunc = call_getitem
-        cfunc = jit(nopython=True)(pyfunc)
-        self.assertPreciseEqual(cfunc(MyDummy(), 321), 321 + 123)
-
-    def test_setitem(self):
-        pyfunc = call_setitem
-        cfunc = jit(nopython=True)(pyfunc)
-        obj = MyDummy()
-        e = None
-
-        with captured_stdout() as out:
-            try:
-                cfunc(obj, 321, 123)
-            except Exception as exc:
-                e = exc
-
-        if e is not None:
-            raise e
-        self.assertEqual(out.getvalue(), "321 123\n")
-
-    def test_no_cpython_wrapper(self):
-        """
-        Test overloading whose return value cannot be represented in CPython.
-        """
-        # Test passing Module type from a @overload implementation to ensure
-        # that the *no_cpython_wrapper* flag works
-        ok_cfunc = jit(nopython=True)(non_boxable_ok_usecase)
-        n = 10
-        got = ok_cfunc(n)
-        expect = non_boxable_ok_usecase(n)
-        np.testing.assert_equal(expect, got)
-        # Verify that the Module type cannot be returned to CPython
-        bad_cfunc = jit(nopython=True)(non_boxable_bad_usecase)
-        with self.assertRaises(TypeError) as raises:
-            bad_cfunc()
-        errmsg = str(raises.exception)
-        expectmsg = "cannot convert native Module"
-        self.assertIn(expectmsg, errmsg)
 
     def test_typing_vs_impl_signature_mismatch_handling(self):
         """
@@ -813,7 +128,7 @@ class TestHighLevelExtending(TestCase):
             def _myoverload_impl(a, b, c, kw=None):
                 return impl
 
-            @jit(nopython=True)
+            @jit
             def foo(a, b, c, d):
                 myoverload(a, b, c, kw=d)
 
@@ -829,7 +144,7 @@ class TestHighLevelExtending(TestCase):
                 return -1
 
         with self.assertRaises(errors.TypingError) as e:
-            gen_ol(impl1)(1, 2, 3, 4)
+            gen_ol(impl1)[1, 1](1, 2, 3, 4)
         msg = str(e.exception)
         self.assertIn(sentinel, msg)
         self.assertIn("keyword argument default values", msg)
@@ -844,7 +159,7 @@ class TestHighLevelExtending(TestCase):
                 return -1
 
         with self.assertRaises(errors.TypingError) as e:
-            gen_ol(impl2)(1, 2, 3, 4)
+            gen_ol(impl2)[1, 1](1, 2, 3, 4)
         msg = str(e.exception)
         self.assertIn(sentinel, msg)
         self.assertIn("keyword argument names", msg)
@@ -859,7 +174,7 @@ class TestHighLevelExtending(TestCase):
                 return -1
 
         with self.assertRaises(errors.TypingError) as e:
-            gen_ol(impl3)(1, 2, 3, 4)
+            gen_ol(impl3)[1, 1](1, 2, 3, 4)
         msg = str(e.exception)
         self.assertIn(sentinel, msg)
         self.assertIn("argument names", msg)
@@ -870,7 +185,7 @@ class TestHighLevelExtending(TestCase):
         from .overload_usecases import impl4, impl5
 
         with self.assertRaises(errors.TypingError) as e:
-            gen_ol(impl4)(1, 2, 3, 4)
+            gen_ol(impl4)[1, 1](1, 2, 3, 4)
         msg = str(e.exception)
         self.assertIn(sentinel, msg)
         self.assertIn("argument names", msg)
@@ -878,7 +193,7 @@ class TestHighLevelExtending(TestCase):
         self.assertIn("First difference: 'z'", msg)
 
         with self.assertRaises(errors.TypingError) as e:
-            gen_ol(impl5)(1, 2, 3, 4)
+            gen_ol(impl5)[1, 1](1, 2, 3, 4)
         msg = str(e.exception)
         self.assertIn(sentinel, msg)
         self.assertIn("argument names", msg)
@@ -894,7 +209,7 @@ class TestHighLevelExtending(TestCase):
                 return -1
 
         with self.assertRaises(errors.TypingError) as e:
-            gen_ol(impl6)(1, 2, 3, 4)
+            gen_ol(impl6)[1, 1](1, 2, 3, 4)
         msg = str(e.exception)
         self.assertIn(sentinel, msg)
         self.assertIn("argument names", msg)
@@ -910,7 +225,7 @@ class TestHighLevelExtending(TestCase):
                 return -1
 
         with self.assertRaises(errors.TypingError) as e:
-            gen_ol(impl7)(1, 2, 3, 4)
+            gen_ol(impl7)[1, 1](1, 2, 3, 4)
         msg = str(e.exception)
         self.assertIn(sentinel, msg)
         self.assertIn("argument names", msg)
@@ -925,7 +240,7 @@ class TestHighLevelExtending(TestCase):
                 return -1
 
         with self.assertRaises(errors.TypingError) as e:
-            gen_ol(impl8)(1, 2, 3, 4)
+            gen_ol(impl8)[1, 1](1, 2, 3, 4)
         msg = str(e.exception)
         self.assertIn(sentinel, msg)
         self.assertIn("keyword argument names", msg)
@@ -939,7 +254,7 @@ class TestHighLevelExtending(TestCase):
                 return -1
 
         with self.assertRaises(errors.TypingError) as e:
-            gen_ol(impl9)(1, 2, 3, 4)
+            gen_ol(impl9)[1, 1](1, 2, 3, 4)
         msg = str(e.exception)
         self.assertIn(sentinel, msg)
         self.assertIn("keyword argument names", msg)
@@ -958,12 +273,12 @@ class TestHighLevelExtending(TestCase):
 
         overload(myoverload)(var_positional_impl)
 
-        @jit(nopython=True)
+        @jit
         def foo(a, b):
-            return myoverload(a, b, 9, kw=11)
+            myoverload(a, b, 9, kw=11)
 
         with self.assertRaises(errors.TypingError) as e:
-            foo(1, 5)
+            foo[1, 1](1, 5)
         msg = str(e.exception)
         self.assertIn("VAR_POSITIONAL (e.g. *args) argument kind", msg)
         self.assertIn("offending argument name is '*star_args_token'", msg)
@@ -979,9 +294,9 @@ class TestHighLevelExtending(TestCase):
 
             overload(myoverload, strict=strict)(impl)
 
-            @jit(nopython=True)
+            @jit
             def foo(a, b):
-                return myoverload(a, kw=11)
+                myoverload(a, kw=11)
 
             return foo
 
@@ -992,9 +307,9 @@ class TestHighLevelExtending(TestCase):
 
             return impl
 
-        gen_ol(ol1, False)(1, 2)  # no error if strictness not enforced
+        gen_ol(ol1, False)[1, 1](1, 2)  # no error if strictness not enforced
         with self.assertRaises(errors.TypingError) as e:
-            gen_ol(ol1)(1, 2)
+            gen_ol(ol1)[1, 1](1, 2)
         msg = str(e.exception)
         self.assertIn("use of VAR_KEYWORD (e.g. **kwargs) is unsupported", msg)
         self.assertIn("offending argument name is '**kws'", msg)
@@ -1007,7 +322,7 @@ class TestHighLevelExtending(TestCase):
             return impl
 
         with self.assertRaises(errors.TypingError) as e:
-            gen_ol(ol2)(1, 2)
+            gen_ol(ol2)[1, 1](1, 2)
         msg = str(e.exception)
         self.assertIn("use of VAR_KEYWORD (e.g. **kwargs) is unsupported", msg)
         self.assertIn("offending argument name is '**kws'", msg)
@@ -1021,13 +336,18 @@ class TestHighLevelExtending(TestCase):
 
             return impl
 
-        @njit
-        def bar(A):
-            return A.foo(), A.foo(20), A.foo(a_kwarg=30)
+        @jit
+        def bar(A, res):
+            res[0] = A.foo()
+            res[1] = A.foo(20)
+            res[2] = A.foo(a_kwarg=30)
 
         Z = np.arange(5)
-
-        self.assertEqual(bar(Z), (10, 20, 30))
+        res = np.zeros(3)
+        bar[1, 1](Z, res)
+        self.assertEqual(res[0], 10)
+        self.assertEqual(res[1], 20)
+        self.assertEqual(res[2], 30)
 
     def test_overload_method_literal_unpack(self):
         # Issue #3683
@@ -1043,103 +363,14 @@ class TestHighLevelExtending(TestCase):
 
                     return impl
 
-        @njit
-        def bar(A):
-            return A.litfoo(0xCAFE)
+        @jit
+        def bar(A, res):
+            res[0] = A.litfoo(0xCAFE)
 
         A = np.zeros(1)
-        bar(A)
-        self.assertEqual(bar(A), 0xCAFE)
-
-    def test_overload_ufunc(self):
-        # Issue #4133.
-        # Use an extended type (MyDummyType) to use with a customized
-        # ufunc (np.exp).
-        @njit
-        def test():
-            return np.exp(mydummy)
-
-        self.assertEqual(test(), 0xDEADBEEF)
-
-    def test_overload_method_stararg(self):
-        @overload_method(MyDummyType, "method_stararg")
-        def _ov_method_stararg(obj, val, val2, *args):
-            def get(obj, val, val2, *args):
-                return (val, val2, args)
-
-            return get
-
-        @njit
-        def foo(obj, *args):
-            # Test with expanding stararg
-            return obj.method_stararg(*args)
-
-        obj = MyDummy()
-        self.assertEqual(foo(obj, 1, 2), (1, 2, ()))
-        self.assertEqual(foo(obj, 1, 2, 3), (1, 2, (3,)))
-        self.assertEqual(foo(obj, 1, 2, 3, 4), (1, 2, (3, 4)))
-
-        @njit
-        def bar(obj):
-            # Test with explicit argument
-            return (
-                obj.method_stararg(1, 2),
-                obj.method_stararg(1, 2, 3),
-                obj.method_stararg(1, 2, 3, 4),
-            )
-
-        self.assertEqual(
-            bar(obj),
-            ((1, 2, ()), (1, 2, (3,)), (1, 2, (3, 4))),
-        )
-
-        # Check cases that put tuple type into stararg
-        # NOTE: the expected result has an extra tuple because of stararg.
-        self.assertEqual(
-            foo(obj, 1, 2, (3,)),
-            (1, 2, ((3,),)),
-        )
-        self.assertEqual(
-            foo(obj, 1, 2, (3, 4)),
-            (1, 2, ((3, 4),)),
-        )
-        self.assertEqual(
-            foo(obj, 1, 2, (3, (4, 5))),
-            (1, 2, ((3, (4, 5)),)),
-        )
-
-    def test_overload_classmethod(self):
-        # Add classmethod to a subclass of Array
-        class MyArray(types.Array):
-            pass
-
-        @overload_classmethod(MyArray, "array_alloc")
-        def ol_array_alloc(cls, nitems):
-            def impl(cls, nitems):
-                arr = np.arange(nitems)
-                return arr
-
-            return impl
-
-        @njit
-        def foo(nitems):
-            return MyArray.array_alloc(nitems)
-
-        nitems = 13
-        self.assertPreciseEqual(foo(nitems), np.arange(nitems))
-
-        # Check that the base type doesn't get the classmethod
-
-        @njit
-        def no_classmethod_in_base(nitems):
-            return types.Array.array_alloc(nitems)
-
-        with self.assertRaises(errors.TypingError) as raises:
-            no_classmethod_in_base(nitems)
-        self.assertIn(
-            "Unknown attribute 'array_alloc' of",
-            str(raises.exception),
-        )
+        res = np.zeros(1)
+        bar[1, 1](A, res)
+        self.assertEqual(res[0], 0xCAFE)
 
 
 def _assert_cache_stats(cfunc, expect_hit, expect_misses):
@@ -1151,60 +382,7 @@ def _assert_cache_stats(cfunc, expect_hit, expect_misses):
         raise AssertionError("cache not used")
 
 
-@skip_if_typeguard
-class TestOverloadMethodCaching(TestCase):
-    # Nested multiprocessing.Pool raises AssertionError:
-    # "daemonic processes are not allowed to have children"
-    _numba_parallel_test_ = False
-
-    def test_caching_overload_method(self):
-        self._cache_dir = temp_directory(self.__class__.__name__)
-        with override_config("CACHE_DIR", self._cache_dir):
-            self.run_caching_overload_method()
-
-    def run_caching_overload_method(self):
-        cfunc = jit(nopython=True, cache=True)(cache_overload_method_usecase)
-        self.assertPreciseEqual(cfunc(MyDummy()), 13)
-        _assert_cache_stats(cfunc, 0, 1)
-        llvmir = cfunc.inspect_llvm((mydummy_type,))
-        # Ensure the inner method is not a declaration
-        decls = [
-            ln
-            for ln in llvmir.splitlines()
-            if ln.startswith("declare") and "overload_method_length" in ln
-        ]
-        self.assertEqual(len(decls), 0)
-        # Test in a separate process
-        try:
-            ctx = multiprocessing.get_context("spawn")
-        except AttributeError:
-            ctx = multiprocessing
-        q = ctx.Queue()
-        p = ctx.Process(
-            target=run_caching_overload_method, args=(q, self._cache_dir)
-        )
-        p.start()
-        q.put(MyDummy())
-        p.join()
-        # Ensure subprocess exited normally
-        self.assertEqual(p.exitcode, 0)
-        res = q.get(timeout=1)
-        self.assertEqual(res, 13)
-
-
-def run_caching_overload_method(q, cache_dir):
-    """
-    Used by TestOverloadMethodCaching.test_caching_overload_method
-    """
-    with override_config("CACHE_DIR", cache_dir):
-        arg = q.get()
-        cfunc = jit(nopython=True, cache=True)(cache_overload_method_usecase)
-        res = cfunc(arg)
-        q.put(res)
-        # Check cache stat
-        _assert_cache_stats(cfunc, 1, 0)
-
-
+@skip_on_cudasim("Simulator does not support extending types")
 class TestIntrinsic(TestCase):
     def test_void_return(self):
         """
@@ -1231,88 +409,20 @@ class TestIntrinsic(TestCase):
 
             return sig, codegen
 
-        @jit(nopython=True)
+        @jit
         def call_void_func():
             void_func(1)
-            return 0
 
-        @jit(nopython=True)
+        @jit
         def call_non_void_func():
             non_void_func(1)
-            return 0
 
         # void func should work
-        self.assertEqual(call_void_func(), 0)
+        self.assertEqual(call_void_func[1, 1](), None)
         # not void function should raise exception
         with self.assertRaises(LoweringError) as e:
-            call_non_void_func()
+            call_non_void_func[1, 1]()
         self.assertIn("non-void function returns None", e.exception.msg)
-
-    def test_ll_pointer_cast(self):
-        """
-        Usecase test: custom reinterpret cast to turn int values to pointers
-        """
-        from ctypes import CFUNCTYPE, POINTER, c_float, c_int
-
-        # Use intrinsic to make a reinterpret_cast operation
-        def unsafe_caster(result_type):
-            assert isinstance(result_type, types.CPointer)
-
-            @intrinsic
-            def unsafe_cast(typingctx, src):
-                self.assertIsInstance(typingctx, typing.Context)
-                if isinstance(src, types.Integer):
-                    sig = result_type(types.uintp)
-
-                    # defines the custom code generation
-                    def codegen(context, builder, signature, args):
-                        [src] = args
-                        rtype = signature.return_type
-                        llrtype = context.get_value_type(rtype)
-                        return builder.inttoptr(src, llrtype)
-
-                    return sig, codegen
-
-            return unsafe_cast
-
-        # make a nopython function to use our cast op.
-        # this is not usable from cpython due to the returning of a pointer.
-        def unsafe_get_ctypes_pointer(src):
-            raise NotImplementedError("not callable from python")
-
-        @overload(unsafe_get_ctypes_pointer, strict=False)
-        def array_impl_unsafe_get_ctypes_pointer(arrtype):
-            if isinstance(arrtype, types.Array):
-                unsafe_cast = unsafe_caster(types.CPointer(arrtype.dtype))
-
-                def array_impl(arr):
-                    return unsafe_cast(src=arr.ctypes.data)
-
-                return array_impl
-
-        # the ctype wrapped function for use in nopython mode
-        def my_c_fun_raw(ptr, n):
-            for i in range(n):
-                print(ptr[i])
-
-        prototype = CFUNCTYPE(None, POINTER(c_float), c_int)
-        my_c_fun = prototype(my_c_fun_raw)
-
-        # Call our pointer-cast in a @jit compiled function and use
-        # the pointer in a ctypes function
-        @jit(nopython=True)
-        def foo(arr):
-            ptr = unsafe_get_ctypes_pointer(arr)
-            my_c_fun(ptr, arr.size)
-
-        # Test
-        arr = np.arange(10, dtype=np.float32)
-        with captured_stdout() as buf:
-            foo(arr)
-            got = buf.getvalue().splitlines()
-        buf.close()
-        expect = list(map(str, arr))
-        self.assertEqual(expect, got)
 
     def test_serialization(self):
         """
@@ -1329,11 +439,11 @@ class TestIntrinsic(TestCase):
             return sig, codegen
 
         # use in a jit function
-        @jit(nopython=True)
+        @jit
         def foo(x):
-            return identity(x)
+            identity(x)
 
-        self.assertEqual(foo(1), 1)
+        self.assertEqual(foo[1, 1](1), None)
 
         # get serialization memo
         memo = _Intrinsic._memo
@@ -1348,7 +458,7 @@ class TestIntrinsic(TestCase):
         foo_rebuilt = pickle.loads(serialized_foo)
         self.assertEqual(memo_size, len(memo))
         # check rebuilt foo
-        self.assertEqual(foo(1), foo_rebuilt(1))
+        self.assertEqual(foo[1, 1](1), foo_rebuilt[1, 1](1))
 
         # pickle identity directly
         serialized_identity = pickle.dumps(identity)
@@ -1425,465 +535,27 @@ class TestIntrinsic(TestCase):
         self.assertEqual("void_func docstring", void_func.__doc__)
 
 
+@skip_on_cudasim("Simulator does not support extending types")
 class TestRegisterJitable(unittest.TestCase):
     def test_no_flags(self):
         @register_jitable
         def foo(x, y):
-            return x + y
+            x[0] += y
 
         def bar(x, y):
-            return foo(x, y)
+            foo(x, y)
+            x[0] += x[0]
 
-        cbar = jit(nopython=True)(bar)
+        cbar = jit(bar)
 
-        expect = bar(1, 2)
-        got = cbar(1, 2)
-        self.assertEqual(expect, got)
+        x = np.array([1, 2])
+        bar(x, 2)
+        self.assertEqual(x[0], 6)
+        cbar[1, 1](x, 2)
+        self.assertEqual(x[0], 16)
 
-    def test_flags_no_nrt(self):
-        @register_jitable(_nrt=False)
-        def foo(n):
-            return np.arange(n)
 
-        def bar(n):
-            return foo(n)
-
-        self.assertEqual(bar(3).tolist(), [0, 1, 2])
-
-        cbar = jit(nopython=True)(bar)
-        with self.assertRaises(errors.TypingError) as raises:
-            cbar(2)
-        msg = (
-            "Only accept returning of array passed into the function as "
-            "argument"
-        )
-        self.assertIn(msg, str(raises.exception))
-
-
-class TestImportCythonFunction(unittest.TestCase):
-    @unittest.skipIf(sc is None, "Only run if SciPy >= 0.19 is installed")
-    def test_getting_function(self):
-        addr = get_cython_function_address("scipy.special.cython_special", "j0")
-        functype = ctypes.CFUNCTYPE(ctypes.c_double, ctypes.c_double)
-        _j0 = functype(addr)
-        j0 = jit(nopython=True)(lambda x: _j0(x))
-        self.assertEqual(j0(0), 1)
-
-    def test_missing_module(self):
-        with self.assertRaises(ImportError) as raises:
-            get_cython_function_address("fakemodule", "fakefunction")
-        # The quotes are not there in Python 2
-        msg = "No module named '?fakemodule'?"
-        match = re.match(msg, str(raises.exception))
-        self.assertIsNotNone(match)
-
-    @unittest.skipIf(sc is None, "Only run if SciPy >= 0.19 is installed")
-    def test_missing_function(self):
-        with self.assertRaises(ValueError) as raises:
-            get_cython_function_address("scipy.special.cython_special", "foo")
-        msg = (
-            "No function 'foo' found in __pyx_capi__ of "
-            "'scipy.special.cython_special'"
-        )
-        self.assertEqual(msg, str(raises.exception))
-
-
-@overload_method(
-    MyDummyType, "method_jit_option_check_nrt", jit_options={"_nrt": True}
-)
-def ov_method_jit_option_check_nrt(obj):
-    def imp(obj):
-        return np.arange(10)
-
-    return imp
-
-
-@overload_method(
-    MyDummyType, "method_jit_option_check_no_nrt", jit_options={"_nrt": False}
-)
-def ov_method_jit_option_check_no_nrt(obj):
-    def imp(obj):
-        return np.arange(10)
-
-    return imp
-
-
-@overload_attribute(
-    MyDummyType, "attr_jit_option_check_nrt", jit_options={"_nrt": True}
-)
-def ov_attr_jit_option_check_nrt(obj):
-    def imp(obj):
-        return np.arange(10)
-
-    return imp
-
-
-@overload_attribute(
-    MyDummyType, "attr_jit_option_check_no_nrt", jit_options={"_nrt": False}
-)
-def ov_attr_jit_option_check_no_nrt(obj):
-    def imp(obj):
-        return np.arange(10)
-
-    return imp
-
-
-class TestJitOptionsNoNRT(TestCase):
-    # Test overload*(jit_options={...}) by turning off _nrt
-
-    def check_error_no_nrt(self, func, *args, **kwargs):
-        # Check that the compilation fails with a complaint about dynamic array
-        msg = (
-            "Only accept returning of array passed into "
-            "the function as argument"
-        )
-        with self.assertRaises(errors.TypingError) as raises:
-            func(*args, **kwargs)
-        self.assertIn(msg, str(raises.exception))
-
-    def no_nrt_overload_check(self, flag):
-        def dummy():
-            return np.arange(10)
-
-        @overload(dummy, jit_options={"_nrt": flag})
-        def ov_dummy():
-            def dummy():
-                return np.arange(10)
-
-            return dummy
-
-        @njit
-        def foo():
-            return dummy()
-
-        if flag:
-            self.assertPreciseEqual(foo(), np.arange(10))
-        else:
-            self.check_error_no_nrt(foo)
-
-    def test_overload_no_nrt(self):
-        self.no_nrt_overload_check(True)
-        self.no_nrt_overload_check(False)
-
-    def test_overload_method_no_nrt(self):
-        @njit
-        def udt(x):
-            return x.method_jit_option_check_nrt()
-
-        self.assertPreciseEqual(udt(mydummy), np.arange(10))
-
-        @njit
-        def udt(x):
-            return x.method_jit_option_check_no_nrt()
-
-        self.check_error_no_nrt(udt, mydummy)
-
-    def test_overload_attribute_no_nrt(self):
-        @njit
-        def udt(x):
-            return x.attr_jit_option_check_nrt
-
-        self.assertPreciseEqual(udt(mydummy), np.arange(10))
-
-        @njit
-        def udt(x):
-            return x.attr_jit_option_check_no_nrt
-
-        self.check_error_no_nrt(udt, mydummy)
-
-
-class TestBoxingCallingJIT(TestCase):
-    def setUp(self):
-        super().setUp()
-        many = base_dummy_type_factory("mydummy2")
-        self.DynTypeType, self.DynType, self.dyn_type_type = many
-        self.dyn_type = self.DynType()
-
-    def test_unboxer_basic(self):
-        # Implements an unboxer on DynType that calls an intrinsic into the
-        # unboxer code.
-        magic_token = 0xCAFE
-        magic_offset = 123
-
-        @intrinsic
-        def my_intrinsic(typingctx, val):
-            # An intrinsic that returns `val + magic_offset`
-            def impl(context, builder, sig, args):
-                [val] = args
-                return builder.add(val, val.type(magic_offset))
-
-            sig = signature(val, val)
-            return sig, impl
-
-        @unbox(self.DynTypeType)
-        def unboxer(typ, obj, c):
-            # The unboxer that calls some jitcode
-            def bridge(x):
-                # proof that this is a jit'ed context by calling jit only
-                # intrinsic
-                return my_intrinsic(x)
-
-            args = [c.context.get_constant(types.intp, magic_token)]
-            sig = signature(types.voidptr, types.intp)
-            is_error, res = c.pyapi.call_jit_code(bridge, sig, args)
-            return NativeValue(res, is_error=is_error)
-
-        @box(self.DynTypeType)
-        def boxer(typ, val, c):
-            # The boxer that returns an integer representation
-            res = c.builder.ptrtoint(val, cgutils.intp_t)
-            return c.pyapi.long_from_ssize_t(res)
-
-        @njit
-        def passthru(x):
-            return x
-
-        out = passthru(self.dyn_type)
-        self.assertEqual(out, magic_token + magic_offset)
-
-    def test_unboxer_raise(self):
-        # Testing exception raising in jitcode called from unboxing.
-        @unbox(self.DynTypeType)
-        def unboxer(typ, obj, c):
-            # The unboxer that calls some jitcode
-            def bridge(x):
-                if x > 0:
-                    raise ValueError("cannot be x > 0")
-                return x
-
-            args = [c.context.get_constant(types.intp, 1)]
-            sig = signature(types.voidptr, types.intp)
-            is_error, res = c.pyapi.call_jit_code(bridge, sig, args)
-            return NativeValue(res, is_error=is_error)
-
-        @box(self.DynTypeType)
-        def boxer(typ, val, c):
-            # The boxer that returns an integer representation
-            res = c.builder.ptrtoint(val, cgutils.intp_t)
-            return c.pyapi.long_from_ssize_t(res)
-
-        @njit
-        def passthru(x):
-            return x
-
-        with self.assertRaises(ValueError) as raises:
-            passthru(self.dyn_type)
-        self.assertIn(
-            "cannot be x > 0",
-            str(raises.exception),
-        )
-
-    def test_boxer(self):
-        # Call jitcode inside the boxer
-        magic_token = 0xCAFE
-        magic_offset = 312
-
-        @intrinsic
-        def my_intrinsic(typingctx, val):
-            # An intrinsic that returns `val + magic_offset`
-            def impl(context, builder, sig, args):
-                [val] = args
-                return builder.add(val, val.type(magic_offset))
-
-            sig = signature(val, val)
-            return sig, impl
-
-        @unbox(self.DynTypeType)
-        def unboxer(typ, obj, c):
-            return NativeValue(c.context.get_dummy_value())
-
-        @box(self.DynTypeType)
-        def boxer(typ, val, c):
-            # Note: this doesn't do proper error handling
-            def bridge(x):
-                return my_intrinsic(x)
-
-            args = [c.context.get_constant(types.intp, magic_token)]
-            sig = signature(types.intp, types.intp)
-            is_error, res = c.pyapi.call_jit_code(bridge, sig, args)
-            return c.pyapi.long_from_ssize_t(res)
-
-        @njit
-        def passthru(x):
-            return x
-
-        r = passthru(self.dyn_type)
-        self.assertEqual(r, magic_token + magic_offset)
-
-    def test_boxer_raise(self):
-        # Call jitcode inside the boxer
-        @unbox(self.DynTypeType)
-        def unboxer(typ, obj, c):
-            return NativeValue(c.context.get_dummy_value())
-
-        @box(self.DynTypeType)
-        def boxer(typ, val, c):
-            def bridge(x):
-                if x > 0:
-                    raise ValueError("cannot do x > 0")
-                return x
-
-            args = [c.context.get_constant(types.intp, 1)]
-            sig = signature(types.intp, types.intp)
-            is_error, res = c.pyapi.call_jit_code(bridge, sig, args)
-            # The error handling
-            retval = cgutils.alloca_once(c.builder, c.pyapi.pyobj, zfill=True)
-            with c.builder.if_then(c.builder.not_(is_error)):
-                obj = c.pyapi.long_from_ssize_t(res)
-                c.builder.store(obj, retval)
-            return c.builder.load(retval)
-
-        @njit
-        def passthru(x):
-            return x
-
-        with self.assertRaises(ValueError) as raises:
-            passthru(self.dyn_type)
-        self.assertIn(
-            "cannot do x > 0",
-            str(raises.exception),
-        )
-
-
-def with_objmode_cache_ov_example(x):
-    # This is the function stub for overloading inside
-    # TestCachingOverloadObjmode.test_caching_overload_objmode
-    pass
-
-
-@skip_if_typeguard
-class TestCachingOverloadObjmode(TestCase):
-    """Test caching of the use of overload implementations that use
-    `with objmode`
-    """
-
-    _numba_parallel_test_ = False
-
-    def setUp(self):
-        warnings.simplefilter("error", errors.NumbaWarning)
-
-    def tearDown(self):
-        warnings.resetwarnings()
-
-    def test_caching_overload_objmode(self):
-        cache_dir = temp_directory(self.__class__.__name__)
-        with override_config("CACHE_DIR", cache_dir):
-
-            def realwork(x):
-                # uses numpy code
-                arr = np.arange(x) / x
-                return np.linalg.norm(arr)
-
-            def python_code(x):
-                # create indirections
-                return realwork(x)
-
-            @overload(with_objmode_cache_ov_example)
-            def _ov_with_objmode_cache_ov_example(x):
-                def impl(x):
-                    with objmode(y="float64"):
-                        y = python_code(x)
-                    return y
-
-                return impl
-
-            @njit(cache=True)
-            def testcase(x):
-                return with_objmode_cache_ov_example(x)
-
-            expect = realwork(123)
-            got = testcase(123)
-            self.assertEqual(got, expect)
-
-            testcase_cached = njit(cache=True)(testcase.py_func)
-            got = testcase_cached(123)
-            self.assertEqual(got, expect)
-
-    @classmethod
-    def check_objmode_cache_ndarray(cls):
-        def do_this(a, b):
-            return np.sum(a + b)
-
-        def do_something(a, b):
-            return np.sum(a + b)
-
-        @overload(do_something)
-        def overload_do_something(a, b):
-            def _do_something_impl(a, b):
-                with objmode(y="float64"):
-                    y = do_this(a, b)
-                return y
-
-            return _do_something_impl
-
-        @njit(cache=True)
-        def test_caching():
-            a = np.arange(20)
-            b = np.arange(20)
-            return do_something(a, b)
-
-        got = test_caching()
-        expect = test_caching.py_func()
-
-        # Check result
-        if got != expect:
-            raise AssertionError("incorrect result")
-        return test_caching
-
-    @classmethod
-    def populate_objmode_cache_ndarray_check_cache(cls):
-        cls.check_objmode_cache_ndarray()
-
-    @classmethod
-    def check_objmode_cache_ndarray_check_cache(cls):
-        disp = cls.check_objmode_cache_ndarray()
-        if len(disp.stats.cache_misses) != 0:
-            raise AssertionError("unexpected cache miss")
-        if len(disp.stats.cache_hits) <= 0:
-            raise AssertionError("unexpected missing cache hit")
-
-    def test_check_objmode_cache_ndarray(self):
-        # See issue #6130.
-        # Env is missing after cache load.
-        cache_dir = temp_directory(self.__class__.__name__)
-        with override_config("CACHE_DIR", cache_dir):
-            # Run in new process to populate the cache
-            run_in_new_process_in_cache_dir(
-                self.populate_objmode_cache_ndarray_check_cache, cache_dir
-            )
-            # Run in new process to use the cache in a fresh process.
-            res = run_in_new_process_in_cache_dir(
-                self.check_objmode_cache_ndarray_check_cache, cache_dir
-            )
-        self.assertEqual(res["exitcode"], 0)
-
-
-class TestMisc(TestCase):
-    def test_is_jitted(self):
-        def foo(x):
-            pass
-
-        self.assertFalse(is_jitted(foo))
-        self.assertTrue(is_jitted(njit(foo)))
-        self.assertFalse(is_jitted(vectorize(foo)))
-        self.assertFalse(is_jitted(vectorize(parallel=True)(foo)))
-        self.assertFalse(is_jitted(guvectorize("void(float64[:])", "(m)")(foo)))
-
-    def test_overload_arg_binding(self):
-        # See issue #7982, checks that calling a function with named args works
-        # correctly irrespective of the order in which the names are supplied.
-        @njit
-        def standard_order():
-            return np.full(shape=123, fill_value=456).shape
-
-        @njit
-        def reversed_order():
-            return np.full(fill_value=456, shape=123).shape
-
-        self.assertPreciseEqual(standard_order(), standard_order.py_func())
-        self.assertPreciseEqual(reversed_order(), reversed_order.py_func())
-
-
+@skip_on_cudasim("Simulator does not support extending types")
 class TestOverloadPreferLiteral(TestCase):
     def test_overload(self):
         def prefer_lit(x):
@@ -1913,131 +585,33 @@ class TestOverloadPreferLiteral(TestCase):
         overload(prefer_lit, prefer_literal=True)(ov)
         overload(non_lit)(ov)
 
-        @njit
-        def check_prefer_lit(x):
-            return prefer_lit(1), prefer_lit(2), prefer_lit(x)
+        @jit
+        def check_prefer_lit(x, res):
+            res[0] = prefer_lit(1)
+            res[1] = prefer_lit(2)
+            res[2] = prefer_lit(x)
 
-        a, b, c = check_prefer_lit(3)
+        res = np.zeros(3)
+        check_prefer_lit[1, 1](3, res)
+        a, b, c = res
         self.assertEqual(a, 0xCAFE)
         self.assertEqual(b, 200)
         self.assertEqual(c, 300)
 
-        @njit
-        def check_non_lit(x):
-            return non_lit(1), non_lit(2), non_lit(x)
+        @jit
+        def check_non_lit(x, res):
+            res[0] = non_lit(1)
+            res[1] = non_lit(2)
+            res[2] = non_lit(x)
 
-        a, b, c = check_non_lit(3)
-        self.assertEqual(a, 100)
-        self.assertEqual(b, 200)
-        self.assertEqual(c, 300)
-
-    def test_overload_method(self):
-        def ov(self, x):
-            if isinstance(x, types.IntegerLiteral):
-                # With prefer_literal=False, this branch will not be reached.
-                if x.literal_value == 1:
-
-                    def impl(self, x):
-                        return 0xCAFE
-
-                    return impl
-                else:
-                    raise errors.TypingError("literal value")
-            else:
-
-                def impl(self, x):
-                    return x * 100
-
-                return impl
-
-        overload_method(
-            MyDummyType,
-            "method_prefer_literal",
-            prefer_literal=True,
-        )(ov)
-
-        overload_method(
-            MyDummyType,
-            "method_non_literal",
-            prefer_literal=False,
-        )(ov)
-
-        @njit
-        def check_prefer_lit(dummy, x):
-            return (
-                dummy.method_prefer_literal(1),
-                dummy.method_prefer_literal(2),
-                dummy.method_prefer_literal(x),
-            )
-
-        a, b, c = check_prefer_lit(MyDummy(), 3)
-        self.assertEqual(a, 0xCAFE)
-        self.assertEqual(b, 200)
-        self.assertEqual(c, 300)
-
-        @njit
-        def check_non_lit(dummy, x):
-            return (
-                dummy.method_non_literal(1),
-                dummy.method_non_literal(2),
-                dummy.method_non_literal(x),
-            )
-
-        a, b, c = check_non_lit(MyDummy(), 3)
+        check_non_lit[1, 1](3, res)
+        a, b, c = res
         self.assertEqual(a, 100)
         self.assertEqual(b, 200)
         self.assertEqual(c, 300)
 
 
-class TestIntrinsicPreferLiteral(TestCase):
-    def test_intrinsic(self):
-        def intrin(context, x):
-            # This intrinsic will return 0xcafe if `x` is a literal `1`.
-            sig = signature(types.intp, x)
-            if isinstance(x, types.IntegerLiteral):
-                # With prefer_literal=False, this branch will not be reached
-                if x.literal_value == 1:
-
-                    def codegen(context, builder, signature, args):
-                        atype = signature.args[0]
-                        llrtype = context.get_value_type(atype)
-                        return ir.Constant(llrtype, 0xCAFE)
-
-                    return sig, codegen
-                else:
-                    raise errors.TypingError("literal value")
-            else:
-
-                def codegen(context, builder, signature, args):
-                    atype = signature.return_type
-                    llrtype = context.get_value_type(atype)
-                    int_100 = ir.Constant(llrtype, 100)
-                    return builder.mul(args[0], int_100)
-
-                return sig, codegen
-
-        prefer_lit = intrinsic(prefer_literal=True)(intrin)
-        non_lit = intrinsic(prefer_literal=False)(intrin)
-
-        @njit
-        def check_prefer_lit(x):
-            return prefer_lit(1), prefer_lit(2), prefer_lit(x)
-
-        a, b, c = check_prefer_lit(3)
-        self.assertEqual(a, 0xCAFE)
-        self.assertEqual(b, 200)
-        self.assertEqual(c, 300)
-
-        @njit
-        def check_non_lit(x):
-            return non_lit(1), non_lit(2), non_lit(x)
-
-        a, b, c = check_non_lit(3)
-        self.assertEqual(a, 100)
-        self.assertEqual(b, 200)
-        self.assertEqual(c, 300)
-
-
+@skip_on_cudasim("Simulator does not support extending types")
 class TestNumbaInternalOverloads(TestCase):
     def test_signatures_match_overloaded_api(self):
         # This is a "best-effort" test to try and ensure that Numba's internal
@@ -2169,8 +743,8 @@ class TestNumbaInternalOverloads(TestCase):
 
         # Compile something to make sure that the typing context registries
         # are populated with everything from the CPU target.
-        njit(lambda: None).compile(())
-        tyctx = numba.core.typing.context.Context()
+        jit(lambda: None).compile(())
+        tyctx = numba.cuda.target.CUDATypingContext()
         tyctx.refresh()
 
         # Walk the registries and check each function that is an overload

--- a/numba_cuda/numba/cuda/tests/test_extending_types.py
+++ b/numba_cuda/numba/cuda/tests/test_extending_types.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Test extending types via the numba.extending.* API.
+"""
+
+from numba.cuda import jit
+from numba.core import types
+from numba.core.errors import TypingError, NumbaTypeError
+from numba.cuda.extending import make_attribute_wrapper
+from numba.cuda.extending import overload
+from numba.core.imputils import Registry
+from numba.cuda.testing import skip_on_cudasim
+
+import unittest
+
+registry = Registry()
+lower = registry.lower
+
+
+def gen_mock_float():
+    # Stub to overload, pretending to be `float`. The real `float` function is
+    # not used as multiple registrations can collide.
+    def mock_float(x):
+        pass
+
+    return mock_float
+
+
+class TestExtTypDummy(unittest.TestCase):
+    def setUp(self):
+        class DummyType(types.Type):
+            def __init__(self):
+                super(DummyType, self).__init__(name="Dummy")
+
+        make_attribute_wrapper(DummyType, "value", "value")
+
+        # Store attributes
+        self.DummyType = DummyType
+
+    def _add_float_overload(self, mock_float_inst):
+        @overload(mock_float_inst)
+        def dummy_to_float(x):
+            if isinstance(x, self.DummyType):
+
+                def codegen(x):
+                    return float(x.value)
+
+                return codegen
+            else:
+                raise NumbaTypeError("cannot type float({})".format(x))
+
+    @skip_on_cudasim("Simulator does not support extending types")
+    def test_overload_float_error_msg(self):
+        mock_float = gen_mock_float()
+        self._add_float_overload(mock_float)
+
+        @jit
+        def foo(x):
+            mock_float(x)
+
+        with self.assertRaises(TypingError) as raises:
+            foo[1, 1](1j)
+
+        self.assertIn("cannot type float(complex128)", str(raises.exception))

--- a/numba_cuda/numba/cuda/vector_types.py
+++ b/numba_cuda/numba/cuda/vector_types.py
@@ -8,7 +8,7 @@ from typing import List, Tuple, Dict
 
 from numba import types
 from numba.cuda import cgutils
-from numba.core.extending import models
+from numba.core.datamodel import models
 from numba.core.imputils import Registry as ImplRegistry
 from numba.cuda.typing.templates import ConcreteTemplate
 from numba.cuda.typing.templates import Registry as TypingRegistry


### PR DESCRIPTION
This change vendors in numba.extending for future CUDA-specific changes. As part of the vendoring, many tests have been removed that test boxing/unboxing, rely on returning arrays allocated during a kernel execution, and other unsupported features on the GPU target. Additionally, there were tests that use the `EXTENDED_ARG` python opcode that were also removed since it's unclear if that feature is actually used.