### PR TITLE
Mmason nvidia/bugfix/lto linking

### DIFF
--- a/numba_cuda/numba/cuda/cudadrv/driver.py
+++ b/numba_cuda/numba/cuda/cudadrv/driver.py
@@ -3065,7 +3065,9 @@ class _Linker(_LinkerBase):
         )
 
     def get_linked_ptx(self):
-        self.linker = Linker(*self._object_codes, options=self._get_linker_options(ptx=True))
+        self.linker = Linker(
+            *self._object_codes, options=self._get_linker_options(ptx=True)
+        )
 
         result = self.linker.link("ptx")
         self.close()
@@ -3078,7 +3080,9 @@ class _Linker(_LinkerBase):
         self.linker.close()
 
     def complete(self):
-        self.linker = Linker(*self._object_codes, options=self._get_linker_options(ptx=False))
+        self.linker = Linker(
+            *self._object_codes, options=self._get_linker_options(ptx=False)
+        )
         result = self.linker.link("cubin")
         self.close()
         self._complete = True


### PR DESCRIPTION
Update linker options to only set link_time_optimization=True if LTO-IR code is being linked.

Move linker option creation to a separate function to reduce duplicate code,
and remove self.options in favor of computing the options on the fly.
