### PR TITLE
[MNT] Drop NUMBA_CUDA_USE_NVIDIA_BINDING; always use cuda.core and cuda.bindings as fallback

### DIFF
--- a/ci/test_conda_ctypes_binding.sh
+++ b/ci/test_conda_ctypes_binding.sh
@@ -76,7 +76,7 @@ popd
 
 
 rapids-logger "Run Tests"
-NUMBA_CUDA_USE_NVIDIA_BINDING=0 NUMBA_CUDA_TEST_BIN_DIR=$NUMBA_CUDA_TEST_BIN_DIR pytest --pyargs numba.cuda.tests -v
+NUMBA_CUDA_TEST_BIN_DIR=$NUMBA_CUDA_TEST_BIN_DIR pytest --pyargs numba.cuda.tests -v
 
 popd
 

--- a/ci/test_wheel_ctypes_binding.sh
+++ b/ci/test_wheel_ctypes_binding.sh
@@ -24,7 +24,7 @@ python -m pip install \
 #
 #NUMBA_CUDA_TEST_BIN_DIR=$(python -c "$PY_SCRIPT")
 #pushd $NUMBA_CUDA_TEST_BIN_DIR
-#NUMBA_CUDA_USE_NVIDIA_BINDING=0 make
+## ctypes mode removed
 #popd
 
 
@@ -36,10 +36,10 @@ mkdir -p "${RAPIDS_TESTS_DIR}"
 pushd "${RAPIDS_TESTS_DIR}"
 
 rapids-logger "Show Numba system info"
-NUMBA_CUDA_USE_NVIDIA_BINDING=0 python -m numba --sysinfo
+python -m numba --sysinfo
 
 rapids-logger "Run Tests"
-# NUMBA_CUDA_USE_NVIDIA_BINDING=0 NUMBA_CUDA_TEST_BIN_DIR=$NUMBA_CUDA_TEST_BIN_DIR python -m pytest --pyargs numba.cuda.tests -v
-NUMBA_CUDA_USE_NVIDIA_BINDING=0 python -m pytest --pyargs numba.cuda.tests -v
+# NUMBA_CUDA_TEST_BIN_DIR=$NUMBA_CUDA_TEST_BIN_DIR python -m pytest --pyargs numba.cuda.tests -v
+python -m pytest --pyargs numba.cuda.tests -v
 
 popd

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -108,12 +108,11 @@ target.
    Enable warnings if a kernel is launched with host memory which forces a copy to and
    from the device. This option is on by default (default value is 1).
 
-.. envvar:: NUMBA_CUDA_USE_NVIDIA_BINDING
+.. note::
 
-   When set to 1, Numba will attempt to use the `NVIDIA CUDA Python binding
-   <https://nvidia.github.io/cuda-python/>`_ to make calls to the driver API
-   instead of using its own ctypes binding. This defaults to 1 (on). Set to
-   0 to use the ctypes bindings.
+   Numba-CUDA always uses the NVIDIA CUDA Python bindings. The legacy ctypes
+   bindings and the ``NUMBA_CUDA_USE_NVIDIA_BINDING`` environment variable have
+   been removed.
 
 .. envvar:: NUMBA_CUDA_INCLUDE_PATH
 

--- a/docs/source/user/bindings.rst
+++ b/docs/source/user/bindings.rst
@@ -5,25 +5,19 @@
 CUDA Bindings
 =============
 
-Numba supports two bindings to the CUDA Driver APIs: its own internal bindings
-based on ctypes, and the official `NVIDIA CUDA Python bindings
-<https://nvidia.github.io/cuda-python/>`_. Functionality is equivalent between
-the two bindings.
-
-The internal bindings are used by default. If the NVIDIA bindings are installed,
-then they can be used by setting the environment variable
-``NUMBA_CUDA_USE_NVIDIA_BINDING`` to ``1`` prior to the import of Numba. Once
-Numba has been imported, the selected binding cannot be changed.
+Numba-CUDA uses the official `NVIDIA CUDA Python bindings
+<https://nvidia.github.io/cuda-python/>`_ for all CUDA Driver interactions.
+The legacy internal ctypes bindings have been removed and the
+``NUMBA_CUDA_USE_NVIDIA_BINDING`` environment variable no longer has any effect.
 
 
 Per-Thread Default Streams
 --------------------------
 
 Responsibility for handling Per-Thread Default Streams (PTDS) is delegated to
-the NVIDIA bindings when they are in use. To use PTDS with the NVIDIA bindings,
-set the environment variable ``CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM`` to
-``1`` instead of Numba's environmnent variable
-:envvar:`NUMBA_CUDA_PER_THREAD_DEFAULT_STREAM`.
+the NVIDIA bindings. To use PTDS, set the environment variable
+``CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM`` to ``1`` instead of Numba's
+environment variable :envvar:`NUMBA_CUDA_PER_THREAD_DEFAULT_STREAM`.
 
 .. seealso::
 
@@ -35,13 +29,5 @@ set the environment variable ``CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM`` to
 Roadmap
 -------
 
-In Numba 0.56, the NVIDIA Bindings will be used by default, if they are
-installed.
-
-In future versions of Numba:
-
-- The internal bindings will be deprecated.
-- The internal bindings will be removed.
-
-At present, no specific release is planned for the deprecation or removal of
-the internal bindings.
+The ctypes-based internal bindings have been removed in favor of the NVIDIA
+bindings. Future work focuses on expanding usage of ``cuda.core`` APIs.

--- a/docs/source/user/installation.rst
+++ b/docs/source/user/installation.rst
@@ -61,14 +61,9 @@ Configuration
 CUDA Bindings
 -------------
 
-Numba supports interacting with the CUDA Driver API via either the `NVIDIA CUDA
-Python bindings <https://nvidia.github.io/cuda-python/>`_ or its own ctypes-based
-bindings. Functionality is equivalent between the two binding choices. The
-NVIDIA bindings are the default, and the ctypes bindings are now deprecated.
-
-If you do not want to use the NVIDIA bindings, the (deprecated) ctypes bindings
-can be enabled by setting the environment variable
-:envvar:`NUMBA_CUDA_USE_NVIDIA_BINDING` to ``"0"``.
+Numba-CUDA uses the `NVIDIA CUDA Python bindings <https://nvidia.github.io/cuda-python/>`_
+for interacting with the CUDA Driver API. The legacy ctypes bindings and the
+``NUMBA_CUDA_USE_NVIDIA_BINDING`` environment variable have been removed.
 
 
 .. _cudatoolkit-lookup:
@@ -79,28 +74,13 @@ CUDA Driver and Toolkit search paths
 Default behavior
 ~~~~~~~~~~~~~~~~
 
-When using the NVIDIA bindings, searches for the CUDA driver and toolkit
-libraries use its `built-in path-finding logic <https://github.com/NVIDIA/cuda-python/tree/main/cuda_bindings/cuda/bindings/_path_finder>`_.
-
-Ctypes bindings (deprecated) behavior
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-When using the ctypes bindings, Numba searches for a CUDA toolkit installation
-in the following order:
-
-1. Conda-installed CUDA Toolkit packages
-2. Pip-installed CUDA Toolkit packages
-3. The environment variable ``CUDA_HOME``, which points to the directory of the
-   installed CUDA toolkit (i.e. ``/home/user/cuda-12``)
-4. System-wide installation at exactly ``/usr/local/cuda`` on Linux platforms.
-   Versioned installation paths (i.e. ``/usr/local/cuda-12.0``) are intentionally
-   ignored. Users can use ``CUDA_HOME`` to select specific versions.
+Searches for the CUDA driver and toolkit libraries use the NVIDIA bindings'
+`built-in path-finding logic <https://github.com/NVIDIA/cuda-python/tree/main/cuda_bindings/cuda/bindings/_path_finder>`_.
 
 In addition to the CUDA toolkit libraries, which can be installed by conda into
 an environment or installed system-wide by the `CUDA SDK installer
 <https://developer.nvidia.com/cuda-downloads>`_, the CUDA target in Numba also
-requires an up-to-date NVIDIA driver.  Updated NVIDIA drivers are also installed
-by the CUDA SDK installer, so there is no need to do both. If the ``libcuda``
-library is in a non-standard location, users can set environment variable
+requires an up-to-date NVIDIA driver. If the ``libcuda`` library is in a
+non-standard location, users can set environment variable
 :envvar:`NUMBA_CUDA_DRIVER` to the file path (not the directory path) of the
 shared library file.

--- a/numba_cuda/numba/cuda/__init__.py
+++ b/numba_cuda/numba/cuda/__init__.py
@@ -27,45 +27,22 @@ if getattr(config, "CUDA_ENABLE_PYNVJITLINK", None) is None:
         )
         config.CUDA_ENABLE_PYNVJITLINK = pynvjitlink_auto_enabled
 
-# Upstream numba sets CUDA_USE_NVIDIA_BINDING to 0 by default, so it always
-# exists. Override, but not if explicitly set to 0 in the envioronment.
-_nvidia_binding_enabled_in_env = _readenv(
-    "NUMBA_CUDA_USE_NVIDIA_BINDING", bool, None
-)
-if _nvidia_binding_enabled_in_env is False:
-    USE_NV_BINDING = False
-else:
-    USE_NV_BINDING = True
-    config.CUDA_USE_NVIDIA_BINDING = USE_NV_BINDING
-if config.CUDA_USE_NVIDIA_BINDING:
-    if not (
-        importlib.util.find_spec("cuda")
-        and importlib.util.find_spec("cuda.bindings")
-    ):
-        raise ImportError(
-            "CUDA bindings not found. Please pip install the "
-            "cuda-bindings package. Alternatively, install "
-            "numba-cuda[cuXY], where XY is the required CUDA "
-            "version, to install the binding automatically. "
-            "If no CUDA bindings are desired, set the env var "
-            "NUMBA_CUDA_USE_NVIDIA_BINDING=0 to enable ctypes "
-            "bindings."
-        )
+# Require NVIDIA CUDA bindings at import time
+if not (
+    importlib.util.find_spec("cuda")
+    and importlib.util.find_spec("cuda.bindings")
+):
+    raise ImportError(
+        "NVIDIA CUDA Python bindings not found. Install the 'cuda' package "
+        "(e.g. pip install nvidia-cuda-python or numba-cuda[cuXY])."
+    )
 
 if config.CUDA_ENABLE_PYNVJITLINK:
-    if USE_NV_BINDING and not pynvjitlink_auto_enabled:
+    if not pynvjitlink_auto_enabled:
         warnings.warn(
-            "Explicitly enabling pynvjitlink is no longer necessary. "
-            "NVIDIA bindings are enabled. cuda.core will be used "
-            "in place of pynvjitlink."
+            "Explicit pynvjitlink enablement is unnecessary; cuda.core will be "
+            "used where available."
         )
-    elif pynvjitlink_auto_enabled:
-        # Ignore the fact that pynvjitlink is enabled, because that was an
-        # automatic decision based on discovering pynvjitlink was present; the
-        # user didn't ask for it
-        pass
-    else:
-        raise RuntimeError("nvJitLink requires the NVIDIA CUDA bindings. ")
 
 if config.ENABLE_CUDASIM:
     from .simulator_init import *

--- a/numba_cuda/numba/cuda/cudadrv/driver.py
+++ b/numba_cuda/numba/cuda/cudadrv/driver.py
@@ -57,7 +57,7 @@ from .linkable_code import LinkableCode, LTOIR, Fatbin, Object
 from numba.cuda.utils import cached_file_read
 from numba.cuda.cudadrv import enums, drvapi, nvrtc
 
-USE_NV_BINDING = config.CUDA_USE_NVIDIA_BINDING
+USE_NV_BINDING = True
 
 if USE_NV_BINDING:
     from cuda.bindings import driver as binding
@@ -82,7 +82,7 @@ _py_incref = ctypes.pythonapi.Py_IncRef
 _py_decref.argtypes = [ctypes.py_object]
 _py_incref.argtypes = [ctypes.py_object]
 
-USE_NV_BINDING = config.CUDA_USE_NVIDIA_BINDING
+USE_NV_BINDING = True
 
 if USE_NV_BINDING:
     from cuda.bindings import driver as binding

--- a/numba_cuda/numba/cuda/cudadrv/mappings.py
+++ b/numba_cuda/numba/cuda/cudadrv/mappings.py
@@ -1,28 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-from numba import config
-from . import enums
+from cuda.bindings.driver import CUjitInputType
 
-if config.CUDA_USE_NVIDIA_BINDING:
-    from cuda.bindings.driver import CUjitInputType
-
-    FILE_EXTENSION_MAP = {
-        "o": CUjitInputType.CU_JIT_INPUT_OBJECT,
-        "ptx": CUjitInputType.CU_JIT_INPUT_PTX,
-        "a": CUjitInputType.CU_JIT_INPUT_LIBRARY,
-        "lib": CUjitInputType.CU_JIT_INPUT_LIBRARY,
-        "cubin": CUjitInputType.CU_JIT_INPUT_CUBIN,
-        "fatbin": CUjitInputType.CU_JIT_INPUT_FATBINARY,
-        "ltoir": CUjitInputType.CU_JIT_INPUT_NVVM,
-    }
-else:
-    FILE_EXTENSION_MAP = {
-        "o": enums.CU_JIT_INPUT_OBJECT,
-        "ptx": enums.CU_JIT_INPUT_PTX,
-        "a": enums.CU_JIT_INPUT_LIBRARY,
-        "lib": enums.CU_JIT_INPUT_LIBRARY,
-        "cubin": enums.CU_JIT_INPUT_CUBIN,
-        "fatbin": enums.CU_JIT_INPUT_FATBINARY,
-        "ltoir": enums.CU_JIT_INPUT_NVVM,
-    }
+FILE_EXTENSION_MAP = {
+    "o": CUjitInputType.CU_JIT_INPUT_OBJECT,
+    "ptx": CUjitInputType.CU_JIT_INPUT_PTX,
+    "a": CUjitInputType.CU_JIT_INPUT_LIBRARY,
+    "lib": CUjitInputType.CU_JIT_INPUT_LIBRARY,
+    "cubin": CUjitInputType.CU_JIT_INPUT_CUBIN,
+    "fatbin": CUjitInputType.CU_JIT_INPUT_FATBINARY,
+    "ltoir": CUjitInputType.CU_JIT_INPUT_NVVM,
+}

--- a/numba_cuda/numba/cuda/cudadrv/nvrtc.py
+++ b/numba_cuda/numba/cuda/cudadrv/nvrtc.py
@@ -1,23 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-from ctypes import byref, c_char, c_char_p, c_int, c_size_t, c_void_p, POINTER
-from enum import IntEnum
 from numba.cuda.cudadrv.error import (
     CCSupportError,
     NvrtcError,
-    NvrtcBuiltinOperationFailure,
-    NvrtcCompilationError,
-    NvrtcSupportError,
 )
 from numba import config
 from numba.cuda.cuda_paths import get_cuda_paths
 from numba.cuda.utils import _readenv
 
-import functools
 import os
-import threading
 import warnings
+import functools
 
 NVRTC_EXTRA_SEARCH_PATHS = _readenv(
     "NUMBA_CUDA_NVRTC_EXTRA_SEARCH_PATHS", str, ""
@@ -25,268 +19,34 @@ NVRTC_EXTRA_SEARCH_PATHS = _readenv(
 if not hasattr(config, "NUMBA_CUDA_NVRTC_EXTRA_SEARCH_PATHS"):
     config.CUDA_NVRTC_EXTRA_SEARCH_PATHS = NVRTC_EXTRA_SEARCH_PATHS
 
-# Opaque handle for compilation unit
-nvrtc_program = c_void_p
+try:
+    # Prefer cuda.core for compilation
+    from cuda.core.experimental import Program, ProgramOptions  # type: ignore
+    _HAVE_CORE = True
+except Exception:  # pragma: no cover - environment dependent
+    _HAVE_CORE = False
 
-# Result code
-nvrtc_result = c_int
-
-if config.CUDA_USE_NVIDIA_BINDING:
-    from cuda.bindings import nvrtc as bindings_nvrtc
-    from cuda.core.experimental import Program, ProgramOptions
-
-
-class NvrtcResult(IntEnum):
-    NVRTC_SUCCESS = 0
-    NVRTC_ERROR_OUT_OF_MEMORY = 1
-    NVRTC_ERROR_PROGRAM_CREATION_FAILURE = 2
-    NVRTC_ERROR_INVALID_INPUT = 3
-    NVRTC_ERROR_INVALID_PROGRAM = 4
-    NVRTC_ERROR_INVALID_OPTION = 5
-    NVRTC_ERROR_COMPILATION = 6
-    NVRTC_ERROR_BUILTIN_OPERATION_FAILURE = 7
-    NVRTC_ERROR_NO_NAME_EXPRESSIONS_AFTER_COMPILATION = 8
-    NVRTC_ERROR_NO_LOWERED_NAMES_BEFORE_COMPILATION = 9
-    NVRTC_ERROR_NAME_EXPRESSION_NOT_VALID = 10
-    NVRTC_ERROR_INTERNAL_ERROR = 11
+try:
+    # Use bindings for version / supported archs and as fallback for gaps
+    from cuda.bindings import nvrtc as bindings_nvrtc  # type: ignore
+    _HAVE_BINDINGS = True
+except Exception:  # pragma: no cover - environment dependent
+    bindings_nvrtc = None
+    _HAVE_BINDINGS = False
 
 
-_nvrtc_lock = threading.Lock()
-
-
-class NvrtcProgram:
-    """
-    A class for managing the lifetime of nvrtcProgram instances. Instances of
-    the class own an nvrtcProgram; when an instance is deleted, the underlying
-    nvrtcProgram is destroyed using the appropriate NVRTC API.
-    """
-
-    def __init__(self, nvrtc, handle):
-        self._nvrtc = nvrtc
-        self._handle = handle
-
-    @property
-    def handle(self):
-        return self._handle
-
-    def __del__(self):
-        if self._handle:
-            self._nvrtc.destroy_program(self)
-
-
-class NVRTC:
-    """
-    Provides a Pythonic interface to the NVRTC APIs, abstracting away the C API
-    calls.
-
-    The sole instance of this class is a process-wide singleton, similar to the
-    NVVM interface. Initialization is protected by a lock and uses the standard
-    (for Numba) open_cudalib function to load the NVRTC library.
-    """
-
-    _PROTOTYPES = {
-        # nvrtcResult nvrtcVersion(int *major, int *minor)
-        "nvrtcVersion": (nvrtc_result, POINTER(c_int), POINTER(c_int)),
-        # nvrtcResult nvrtcCreateProgram(nvrtcProgram *prog,
-        #                                const char *src,
-        #                                const char *name,
-        #                                int numHeaders,
-        #                                const char * const *headers,
-        #                                const char * const *includeNames)
-        "nvrtcCreateProgram": (
-            nvrtc_result,
-            nvrtc_program,
-            c_char_p,
-            c_char_p,
-            c_int,
-            POINTER(c_char_p),
-            POINTER(c_char_p),
-        ),
-        # nvrtcResult nvrtcDestroyProgram(nvrtcProgram *prog);
-        "nvrtcDestroyProgram": (nvrtc_result, POINTER(nvrtc_program)),
-        # nvrtcResult nvrtcCompileProgram(nvrtcProgram prog,
-        #                                 int numOptions,
-        #                                 const char * const *options)
-        "nvrtcCompileProgram": (
-            nvrtc_result,
-            nvrtc_program,
-            c_int,
-            POINTER(c_char_p),
-        ),
-        # nvrtcResult nvrtcGetPTXSize(nvrtcProgram prog, size_t *ptxSizeRet);
-        "nvrtcGetPTXSize": (nvrtc_result, nvrtc_program, POINTER(c_size_t)),
-        # nvrtcResult nvrtcGetPTX(nvrtcProgram prog, char *ptx);
-        "nvrtcGetPTX": (nvrtc_result, nvrtc_program, c_char_p),
-        # nvrtcResult nvrtcGetCUBINSize(nvrtcProgram prog,
-        #                               size_t *cubinSizeRet);
-        "nvrtcGetCUBINSize": (nvrtc_result, nvrtc_program, POINTER(c_size_t)),
-        # nvrtcResult nvrtcGetCUBIN(nvrtcProgram prog, char *cubin);
-        "nvrtcGetCUBIN": (nvrtc_result, nvrtc_program, c_char_p),
-        # nvrtcResult nvrtcGetProgramLogSize(nvrtcProgram prog,
-        #                                    size_t *logSizeRet);
-        "nvrtcGetProgramLogSize": (
-            nvrtc_result,
-            nvrtc_program,
-            POINTER(c_size_t),
-        ),
-        # nvrtcResult nvrtcGetProgramLog(nvrtcProgram prog, char *log);
-        "nvrtcGetProgramLog": (nvrtc_result, nvrtc_program, c_char_p),
-        # nvrtcResult nvrtcGetNumSupportedArchs(int *numArchs);
-        "nvrtcGetNumSupportedArchs": (nvrtc_result, POINTER(c_int)),
-        # nvrtcResult nvrtcGetSupportedArchs(int *supportedArchs);
-        "nvrtcGetSupportedArchs": (nvrtc_result, POINTER(c_int)),
-        # nvrtcResult nvrtcGetLTOIRSize(nvrtcProgram prog, size_t *ltoSizeRet);
-        "nvrtcGetLTOIRSize": (nvrtc_result, nvrtc_program, POINTER(c_size_t)),
-        # nvrtcResult nvrtcGetLTOIR(nvrtcProgram prog, char *lto);
-        "nvrtcGetLTOIR": (nvrtc_result, nvrtc_program, c_char_p),
-    }
-
-    # Singleton reference
-    __INSTANCE = None
-
-    def __new__(cls):
-        with _nvrtc_lock:
-            if config.CUDA_USE_NVIDIA_BINDING:
-                raise RuntimeError(
-                    "NVRTC objects should not be used with cuda-python bindings"
-                )
-            if cls.__INSTANCE is None:
-                from numba.cuda.cudadrv.libs import open_cudalib
-
-                cls.__INSTANCE = inst = object.__new__(cls)
-                try:
-                    lib = open_cudalib("nvrtc")
-                except OSError as e:
-                    cls.__INSTANCE = None
-                    raise NvrtcSupportError("NVRTC cannot be loaded") from e
-
-                # Find & populate functions
-                for name, proto in inst._PROTOTYPES.items():
-                    func = getattr(lib, name)
-                    func.restype = proto[0]
-                    func.argtypes = proto[1:]
-
-                    @functools.wraps(func)
-                    def checked_call(*args, func=func, name=name):
-                        error = func(*args)
-                        if error == NvrtcResult.NVRTC_ERROR_COMPILATION:
-                            raise NvrtcCompilationError()
-                        elif (
-                            error
-                            == NvrtcResult.NVRTC_ERROR_BUILTIN_OPERATION_FAILURE
-                        ):
-                            raise NvrtcBuiltinOperationFailure()
-                        elif error != NvrtcResult.NVRTC_SUCCESS:
-                            try:
-                                error_name = NvrtcResult(error).name
-                            except ValueError:
-                                error_name = (
-                                    "Unknown nvrtc_result "
-                                    f"(error code: {error})"
-                                )
-                            msg = f"Failed to call {name}: {error_name}"
-                            raise NvrtcError(msg)
-
-                    setattr(inst, name, checked_call)
-
-        return cls.__INSTANCE
-
-    @functools.cache
-    def get_supported_archs(self):
-        """
-        Get Supported Architectures by NVRTC as list of arch tuples.
-        """
-        num = c_int()
-        self.nvrtcGetNumSupportedArchs(byref(num))
-        archs = (c_int * num.value)()
-        self.nvrtcGetSupportedArchs(archs)
-        return [(archs[i] // 10, archs[i] % 10) for i in range(num.value)]
-
-    def get_version(self):
-        """
-        Get the NVRTC version as a tuple (major, minor).
-        """
-        major = c_int()
-        minor = c_int()
-        self.nvrtcVersion(byref(major), byref(minor))
-        return major.value, minor.value
-
-    def create_program(self, src, name):
-        """
-        Create an NVRTC program with managed lifetime.
-        """
-        if isinstance(src, str):
-            src = src.encode()
-        if isinstance(name, str):
-            name = name.encode()
-
-        handle = nvrtc_program()
-
-        # The final three arguments are for passing the contents of headers -
-        # this is not supported, so there are 0 headers and the header names
-        # and contents are null.
-        self.nvrtcCreateProgram(byref(handle), src, name, 0, None, None)
-        return NvrtcProgram(self, handle)
-
-    def compile_program(self, program, options):
-        """
-        Compile an NVRTC program. Compilation may fail due to a user error in
-        the source; this function returns ``True`` if there is a compilation
-        error and ``False`` on success.
-        """
-        # We hold a list of encoded options to ensure they can't be collected
-        # prior to the call to nvrtcCompileProgram
-        encoded_options = [opt.encode() for opt in options]
-        option_pointers = [c_char_p(opt) for opt in encoded_options]
-        c_options_type = c_char_p * len(options)
-        c_options = c_options_type(*option_pointers)
-        try:
-            self.nvrtcCompileProgram(program.handle, len(options), c_options)
-            return False
-        except (NvrtcCompilationError, NvrtcBuiltinOperationFailure):
-            return True
-
-    def destroy_program(self, program):
-        """
-        Destroy an NVRTC program.
-        """
-        self.nvrtcDestroyProgram(byref(program.handle))
-
-    def get_compile_log(self, program):
-        """
-        Get the compile log as a Python string.
-        """
-        log_size = c_size_t()
-        self.nvrtcGetProgramLogSize(program.handle, byref(log_size))
-
-        log = (c_char * log_size.value)()
-        self.nvrtcGetProgramLog(program.handle, log)
-
-        return log.value.decode()
-
-    def get_ptx(self, program):
-        """
-        Get the compiled PTX as a Python string.
-        """
-        ptx_size = c_size_t()
-        self.nvrtcGetPTXSize(program.handle, byref(ptx_size))
-
-        ptx = (c_char * ptx_size.value)()
-        self.nvrtcGetPTX(program.handle, ptx)
-
-        return ptx.value.decode()
-
-    def get_lto(self, program):
-        """
-        Get the compiled LTOIR as a Python bytes object.
-        """
-        lto_size = c_size_t()
-        self.nvrtcGetLTOIRSize(program.handle, byref(lto_size))
-
-        lto = b" " * lto_size.value
-        self.nvrtcGetLTOIR(program.handle, lto)
-
-        return lto
+@functools.cache
+def _get_nvrtc_version():
+    if not _HAVE_BINDINGS:
+        raise RuntimeError(
+            "NVIDIA CUDA bindings are required to determine NVRTC version"
+        )
+    retcode, major, minor = bindings_nvrtc.nvrtcVersion()
+    if retcode != bindings_nvrtc.nvrtcResult.NVRTC_SUCCESS:
+        raise RuntimeError(
+            f"{retcode.name} when calling nvrtcVersion()"
+        )
+    return (major, minor)
 
 
 def compile(src, name, cc, ltoir=False):
@@ -304,17 +64,7 @@ def compile(src, name, cc, ltoir=False):
     :return: The compiled PTX and compilation log
     :rtype: tuple
     """
-
-    if config.CUDA_USE_NVIDIA_BINDING:
-        retcode, *version = bindings_nvrtc.nvrtcVersion()
-        if retcode != bindings_nvrtc.nvrtcResult.NVRTC_SUCCESS:
-            raise RuntimeError(
-                f"{retcode.name} when calling nvrtcGetSupportedArchs()"
-            )
-        version = tuple(version)
-    else:
-        nvrtc = NVRTC()
-        version = nvrtc.get_version()
+    version = _get_nvrtc_version()
 
     ver_str = lambda version: ".".join(str(v) for v in version)
     supported_ccs = get_supported_ccs()
@@ -341,10 +91,7 @@ def compile(src, name, cc, ltoir=False):
     #   being optimized away.
     major, minor = found
 
-    if config.CUDA_USE_NVIDIA_BINDING:
-        arch = f"sm_{major}{minor}"
-    else:
-        arch = f"--gpu-architecture=compute_{major}{minor}"
+    arch = f"sm_{major}{minor}"
 
     cuda_include_dir = get_cuda_paths()["include_dir"].info
     cuda_includes = [f"{cuda_include_dir}"]
@@ -377,70 +124,39 @@ def compile(src, name, cc, ltoir=False):
 
     includes = [numba_include, *cuda_includes, nrt_include, *extra_includes]
 
-    if config.CUDA_USE_NVIDIA_BINDING:
-        options = ProgramOptions(
-            arch=arch,
-            include_path=includes,
-            relocatable_device_code=True,
-            link_time_optimization=ltoir,
-            name=name,
+    if not _HAVE_CORE:
+        raise NvrtcError(
+            "cuda.core.experimental.Program is required for compilation; "
+            "please install a recent NVIDIA CUDA Python package."
         )
 
-        class Logger:
-            def __init__(self):
-                self.log = []
+    options = ProgramOptions(
+        arch=arch,
+        include_path=includes,
+        relocatable_device_code=True,
+        link_time_optimization=ltoir,
+        name=name,
+    )
 
-            def write(self, msg):
-                self.log.append(msg)
+    class Logger:
+        def __init__(self):
+            self.log = []
 
-        logger = Logger()
-        if isinstance(src, bytes):
-            src = src.decode("utf8")
+        def write(self, msg):
+            self.log.append(msg)
 
-        prog = Program(src, "c++", options=options)
-        result = prog.compile("ltoir" if ltoir else "ptx", logs=logger)
-        log = ""
-        if logger.log:
-            log = logger.log
-            joined_logs = "\n".join(log)
-            warnings.warn(f"NVRTC log messages: {joined_logs}")
-        return result, log
+    logger = Logger()
+    if isinstance(src, bytes):
+        src = src.decode("utf8")
 
-    else:
-        program = nvrtc.create_program(src, name)
-        includes = [f"-I{path}" for path in includes]
-        options = [
-            arch,
-            *includes,
-            "-rdc",
-            "true",
-        ]
-
-        if ltoir:
-            options.append("-dlto")
-
-        # Compile the program
-        compile_error = nvrtc.compile_program(program, options)
-
-        # Get log from compilation
-        log = nvrtc.get_compile_log(program)
-
-        # If the compile failed, provide the log in an exception
-        if compile_error:
-            msg = f"NVRTC Compilation failure whilst compiling {name}:\n\n{log}"
-            raise NvrtcError(msg)
-
-        # Otherwise, if there's any content in the log, present it as a warning
-        if log:
-            msg = f"NVRTC log messages whilst compiling {name}:\n\n{log}"
-            warnings.warn(msg)
-
-        if ltoir:
-            ltoir = nvrtc.get_lto(program)
-            return ltoir, log
-        else:
-            ptx = nvrtc.get_ptx(program)
-            return ptx, log
+    prog = Program(src, "c++", options=options)
+    result = prog.compile("ltoir" if ltoir else "ptx", logs=logger)
+    log = ""
+    if logger.log:
+        log = logger.log
+        joined_logs = "\n".join(log)
+        warnings.warn(f"NVRTC log messages: {joined_logs}")
+    return result, log
 
 
 def find_closest_arch(mycc):
@@ -488,12 +204,13 @@ def get_lowest_supported_cc():
 
 
 def get_supported_ccs():
-    if config.CUDA_USE_NVIDIA_BINDING:
-        retcode, archs = bindings_nvrtc.nvrtcGetSupportedArchs()
-        if retcode != bindings_nvrtc.nvrtcResult.NVRTC_SUCCESS:
-            raise RuntimeError(
-                f"{retcode.name} when calling nvrtcGetSupportedArchs()"
-            )
-        return [(arch // 10, arch % 10) for arch in archs]
-    else:
-        return NVRTC().get_supported_archs()
+    if not _HAVE_BINDINGS:
+        raise RuntimeError(
+            "NVIDIA CUDA bindings are required to query supported archs"
+        )
+    retcode, archs = bindings_nvrtc.nvrtcGetSupportedArchs()
+    if retcode != bindings_nvrtc.nvrtcResult.NVRTC_SUCCESS:
+        raise RuntimeError(
+            f"{retcode.name} when calling nvrtcGetSupportedArchs()"
+        )
+    return [(arch // 10, arch % 10) for arch in archs]

--- a/numba_cuda/numba/cuda/cudadrv/runtime.py
+++ b/numba_cuda/numba/cuda/cudadrv/runtime.py
@@ -8,23 +8,12 @@ The toolkit version can now be obtained from NVRTC, so we don't use a binding
 to the runtime anymore. This file is provided to maintain the existing API.
 """
 
-from numba import config
-from numba.cuda.cudadrv.nvrtc import NVRTC
+from numba.cuda.cudadrv.nvrtc import _get_nvrtc_version
 
 
 class Runtime:
     def get_version(self):
-        if config.CUDA_USE_NVIDIA_BINDING:
-            from cuda.bindings import nvrtc
-
-            retcode, *version = nvrtc.nvrtcVersion()
-            if retcode != nvrtc.nvrtcResult.NVRTC_SUCCESS:
-                raise RuntimeError(
-                    f"{retcode.name} when calling nvrtcGetVersion()"
-                )
-            return tuple(version)
-        else:
-            return NVRTC().get_version()
+        return _get_nvrtc_version()
 
 
 runtime = Runtime()

--- a/numba_cuda/numba/cuda/tests/cudadrv/test_linker.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_linker.py
@@ -190,12 +190,8 @@ class TestLinker(CUDATestCase):
 
         link = str(test_data_dir / "error.cu")
 
-        if config.CUDA_USE_NVIDIA_BINDING:
-            from cuda.core.experimental._utils.cuda_utils import NVRTCError
-
-            errty = NVRTCError
-        else:
-            errty = NvrtcError
+        from cuda.core.experimental._utils.cuda_utils import NVRTCError
+        errty = NVRTCError
         with self.assertRaises(errty) as e:
 
             @cuda.jit("void(int32)", link=[link])
@@ -204,11 +200,7 @@ class TestLinker(CUDATestCase):
 
         msg = e.exception.args[0]
         # Check the error message refers to the NVRTC compile
-        nvrtc_err_str = (
-            "NVRTC_ERROR_COMPILATION"
-            if config.CUDA_USE_NVIDIA_BINDING
-            else "NVRTC Compilation failure"
-        )
+        nvrtc_err_str = "NVRTC_ERROR_COMPILATION"
         self.assertIn(nvrtc_err_str, msg)
         # Check the expected error in the CUDA source is reported
         self.assertIn('identifier "SYNTAX" is undefined', msg)

--- a/numba_cuda/numba/cuda/tests/cudadrv/test_module_callbacks.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_module_callbacks.py
@@ -17,10 +17,7 @@ from numba.cuda.testing import (
 if not config.ENABLE_CUDASIM:
     from cuda.bindings.driver import cuModuleGetGlobal, cuMemcpyHtoD
 
-    if config.CUDA_USE_NVIDIA_BINDING:
-        from cuda.bindings.driver import CUmodule as cu_module_type
-    else:
-        from numba.cuda.cudadrv.drvapi import cu_module as cu_module_type
+    from cuda.bindings.driver import CUmodule as cu_module_type
 
 
 def wipe_all_modules_in_context():
@@ -35,8 +32,6 @@ def wipe_all_modules_in_context():
 
 
 def get_hashable_handle_value(handle):
-    if not config.CUDA_USE_NVIDIA_BINDING:
-        handle = handle.value
     return handle
 
 

--- a/numba_cuda/numba/cuda/tests/cudadrv/test_nvjitlink.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_nvjitlink.py
@@ -45,10 +45,8 @@ if TEST_BIN_DIR:
 
 
 @unittest.skipIf(
-    not config.CUDA_USE_NVIDIA_BINDING
-    or not TEST_BIN_DIR
-    or not _have_nvjitlink(),
-    "NVIDIA cuda bindings not enabled or nvJitLink not installed or new enough (>12.3)",
+    not TEST_BIN_DIR or not _have_nvjitlink(),
+    "nvJitLink not installed or new enough (>12.3)",
 )
 @skip_on_cudasim("Linking unsupported in the simulator")
 class TestLinker(CUDATestCase):

--- a/numba_cuda/numba/cuda/tests/cudapy/test_errors.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_errors.py
@@ -94,9 +94,6 @@ class TestJitErrors(CUDATestCase):
         self.assertIn("NameError: name 'floor' is not defined", excstr)
 
     @skip_on_cudasim("Simulator does not use nvjitlink")
-    @unittest.skipIf(
-        config.CUDA_USE_NVIDIA_BINDING, "NVIDIA cuda bindings enabled"
-    )
     def test_lto_without_nvjitlink_error(self):
         with self.assertRaisesRegex(RuntimeError, "LTO requires nvjitlink"):
 

--- a/numba_cuda/numba/cuda/tests/nrt/test_nrt.py
+++ b/numba_cuda/numba/cuda/tests/nrt/test_nrt.py
@@ -172,16 +172,7 @@ class TestNrtLinking(CUDATestCase):
         cc = get_current_device().compute_capability
         ptx, _ = compile(src, "external_nrt.cu", cc)
 
-        @cuda.jit(
-            link=[
-                PTXSource(
-                    ptx.code
-                    if config.CUDA_USE_NVIDIA_BINDING
-                    else ptx.encode(),
-                    nrt=True,
-                )
-            ]
-        )
+        @cuda.jit(link=[PTXSource(ptx.code, nrt=True)])
         def kernel():
             allocate_deallocate_handle()
 


### PR DESCRIPTION
### Summary

Historically, `numba-cuda` supported two binding layers (ctypes and cuda-python). This change simplifies maintenance and aligns with the long-term direction to use cuda.core while leveraging cuda.bindings to fill gaps.

### What changed?
- Remove the NUMBA_CUDA_USE_NVIDIA_BINDING environment variable and all ctypes-based CUDA paths.
- Require CUDA Python package at import.
- Always prefer cuda.core APIs; use cuda.bindings where required

### Breaking changes
- The NUMBA_CUDA_USE_NVIDIA_BINDING env var no longer exists.
- Legacy ctypes-based NVRTC/driver paths are removed.
- cuda/cuda.bindings must be installed for Numba-CUDA to import.

Fixes: https://github.com/NVIDIA/numba-cuda/issues/154

