### PR TITLE
Restrict `llvmlite` to `<0.45` for windows only 

### DIFF
--- a/ci/test_wheel.ps1
+++ b/ci/test_wheel.ps1
@@ -32,7 +32,7 @@ rapids-logger "Install wheel with test dependencies"
 $package = Resolve-Path wheel\numba_cuda*.whl | Select-Object -ExpandProperty Path
 echo "Package path: $package"
 python -m pip install "${package}[cu${CUDA_VER_MAJOR},test-cu${CUDA_VER_MAJOR}]"
-python -m pip install "llvmlite<0.45" # WAR for https://github.com/numba/llvmlite/issues/1297
+python -m pip install "llvmlite<0.45" "numba==0.61.*" # WAR for https://github.com/numba/llvmlite/issues/1297
 
 
 rapids-logger "Build tests"


### PR DESCRIPTION
xref https://github.com/NVIDIA/numba-cuda/pull/481, https://github.com/numba/llvmlite/issues/1297