### PR TITLE
Fix packaging quirks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center"><img src="docs/source/_static/numba-green-icon-rgb.svg" width="200"/></div>
+<div align="center"><img src="https://raw.githubusercontent.com/NVIDIA/numba-cuda/main/docs/source/_static/numba-green-icon-rgb.svg" width="200"/></div>
 
 # Numba CUDA Target
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@
 build-backend = "setuptools.build_meta"
 requires = [
     "setuptools",
-    "wheel",
 ]
 
 [project]


### PR DESCRIPTION
This PR fixes two packaging issues identified in #85:

1. **README image URL**: Changed from relative path to absolute URL so the image displays correctly on PyPI
   - Changed: `docs/source/_static/numba-green-icon-rgb.svg`
   - To: `https://raw.githubusercontent.com/NVIDIA/numba-cuda/main/docs/source/_static/numba-green-icon-rgb.svg`

2. **pyproject.toml build-system.requires**: Removed unnecessary 'wheel' dependency
   - Modern setuptools has wheel vendored, so this dependency is not needed
   - Removed `"wheel"` from the requires list

Fixes #85