### PR TITLE
[test] Use numpy's tolerance for float16

### DIFF
--- a/numba_cuda/numba/cuda/testing.py
+++ b/numba_cuda/numba/cuda/testing.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Iterable, Union
 from io import StringIO
 import unittest
+import numpy as np
 
 if PYVERSION >= (3, 10):
     from filecheck.matcher import Matcher
@@ -43,6 +44,8 @@ class CUDATestCase(TestCase):
     Method assertFileCheckMatches can be used to assert that a given string
     matches FileCheck checks, and is not specific to CUDADispatcher.
     """
+
+    FLOAT16_RTOL = np.finfo(np.float16).eps
 
     def setUp(self):
         self._low_occupancy_warnings = config.CUDA_LOW_OCCUPANCY_WARNINGS

--- a/numba_cuda/numba/cuda/tests/cudapy/test_intrinsics.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_intrinsics.py
@@ -629,7 +629,7 @@ class TestCudaIntrinsic(CUDATestCase):
         arg1 = np.array([3.0], dtype=np.float16)
         arg2 = np.array([4.0], dtype=np.float16)
         compiled[1, 1](ary, arg1, arg2)
-        np.testing.assert_allclose(ary[0], arg1 + arg2)
+        np.testing.assert_allclose(ary[0], arg1 + arg2, rtol=self.FLOAT16_RTOL)
 
     @skip_unless_cc_53
     def test_hadd_scalar(self):
@@ -639,7 +639,7 @@ class TestCudaIntrinsic(CUDATestCase):
         arg2 = np.float16(3.0)
         compiled[1, 1](ary, arg1, arg2)
         ref = arg1 + arg2
-        np.testing.assert_allclose(ary[0], ref)
+        np.testing.assert_allclose(ary[0], ref, rtol=self.FLOAT16_RTOL)
 
     @skip_on_cudasim("Compilation unsupported in the simulator")
     @skip_if_nvjitlink_missing("Numbast generated bindings")
@@ -657,7 +657,9 @@ class TestCudaIntrinsic(CUDATestCase):
         arg2 = np.array([3.0], dtype=np.float16)
         arg3 = np.array([4.0], dtype=np.float16)
         compiled[1, 1](ary, arg1, arg2, arg3)
-        np.testing.assert_allclose(ary[0], arg1 * arg2 + arg3)
+        np.testing.assert_allclose(
+            ary[0], arg1 * arg2 + arg3, rtol=self.FLOAT16_RTOL
+        )
 
     @skip_unless_cc_53
     def test_hfma_scalar(self):
@@ -668,7 +670,7 @@ class TestCudaIntrinsic(CUDATestCase):
         arg3 = np.float16(4.0)
         compiled[1, 1](ary, arg1, arg2, arg3)
         ref = arg1 * arg2 + arg3
-        np.testing.assert_allclose(ary[0], ref)
+        np.testing.assert_allclose(ary[0], ref, rtol=self.FLOAT16_RTOL)
 
     @skip_on_cudasim("Compilation unsupported in the simulator")
     @skip_if_nvjitlink_missing("Numbast generated bindings")
@@ -687,7 +689,7 @@ class TestCudaIntrinsic(CUDATestCase):
         arg1 = np.array([3.0], dtype=np.float16)
         arg2 = np.array([4.0], dtype=np.float16)
         compiled[1, 1](ary, arg1, arg2)
-        np.testing.assert_allclose(ary[0], arg1 - arg2)
+        np.testing.assert_allclose(ary[0], arg1 - arg2, rtol=self.FLOAT16_RTOL)
 
     @skip_unless_cc_53
     def test_hsub_scalar(self):
@@ -697,7 +699,7 @@ class TestCudaIntrinsic(CUDATestCase):
         arg2 = np.float16(1.57)
         compiled[1, 1](ary, arg1, arg2)
         ref = arg1 - arg2
-        np.testing.assert_allclose(ary[0], ref)
+        np.testing.assert_allclose(ary[0], ref, rtol=self.FLOAT16_RTOL)
 
     @skip_on_cudasim("Compilation unsupported in the simulator")
     @skip_if_nvjitlink_missing("Numbast generated bindings")
@@ -714,7 +716,7 @@ class TestCudaIntrinsic(CUDATestCase):
         arg1 = np.array([3.0], dtype=np.float16)
         arg2 = np.array([4.0], dtype=np.float16)
         compiled[1, 1](ary, arg1, arg2)
-        np.testing.assert_allclose(ary[0], arg1 * arg2)
+        np.testing.assert_allclose(ary[0], arg1 * arg2, rtol=self.FLOAT16_RTOL)
 
     @skip_unless_cc_53
     def test_hmul_scalar(self):
@@ -724,7 +726,7 @@ class TestCudaIntrinsic(CUDATestCase):
         arg2 = np.float16(1.57)
         compiled[1, 1](ary, arg1, arg2)
         ref = arg1 * arg2
-        np.testing.assert_allclose(ary[0], ref)
+        np.testing.assert_allclose(ary[0], ref, rtol=self.FLOAT16_RTOL)
 
     @skip_on_cudasim("Compilation unsupported in the simulator")
     @skip_if_nvjitlink_missing("Numbast generated bindings")
@@ -743,7 +745,7 @@ class TestCudaIntrinsic(CUDATestCase):
 
         compiled[1, 1](ary, arg1, arg2)
         ref = arg1 / arg2
-        np.testing.assert_allclose(ary[0], ref)
+        np.testing.assert_allclose(ary[0], ref, rtol=self.FLOAT16_RTOL)
 
     @skip_unless_cc_53
     def test_hdiv(self):
@@ -754,7 +756,7 @@ class TestCudaIntrinsic(CUDATestCase):
 
         compiled.forall(ary.size)(ary, arry1, arry2)
         ref = arry1 / arry2
-        np.testing.assert_allclose(ary, ref)
+        np.testing.assert_allclose(ary, ref, rtol=self.FLOAT16_RTOL)
 
     @skip_unless_cc_53
     def test_hneg(self):
@@ -762,7 +764,7 @@ class TestCudaIntrinsic(CUDATestCase):
         ary = np.zeros(1, dtype=np.float16)
         arg1 = np.array([3.0], dtype=np.float16)
         compiled[1, 1](ary, arg1)
-        np.testing.assert_allclose(ary[0], -arg1)
+        np.testing.assert_allclose(ary[0], -arg1, rtol=self.FLOAT16_RTOL)
 
     @skip_unless_cc_53
     def test_hneg_scalar(self):
@@ -771,7 +773,7 @@ class TestCudaIntrinsic(CUDATestCase):
         arg1 = np.float16(3.1415926)
         compiled[1, 1](ary, arg1)
         ref = -arg1
-        np.testing.assert_allclose(ary[0], ref)
+        np.testing.assert_allclose(ary[0], ref, rtol=self.FLOAT16_RTOL)
 
     @skip_on_cudasim("Compilation unsupported in the simulator")
     @skip_if_nvjitlink_missing("Numbast generated bindings")
@@ -787,7 +789,7 @@ class TestCudaIntrinsic(CUDATestCase):
         ary = np.zeros(1, dtype=np.float16)
         arg1 = np.array([-3.0], dtype=np.float16)
         compiled[1, 1](ary, arg1)
-        np.testing.assert_allclose(ary[0], abs(arg1))
+        np.testing.assert_allclose(ary[0], abs(arg1), rtol=self.FLOAT16_RTOL)
 
     @skip_unless_cc_53
     def test_habs_scalar(self):
@@ -796,7 +798,7 @@ class TestCudaIntrinsic(CUDATestCase):
         arg1 = np.float16(-3.1415926)
         compiled[1, 1](ary, arg1)
         ref = abs(arg1)
-        np.testing.assert_allclose(ary[0], ref)
+        np.testing.assert_allclose(ary[0], ref, rtol=self.FLOAT16_RTOL)
 
     @skip_on_cudasim("Compilation unsupported in the simulator")
     @skip_if_nvjitlink_missing("Numbast generated bindings")
@@ -849,7 +851,7 @@ class TestCudaIntrinsic(CUDATestCase):
                 kernel = cuda.jit("void(f2[:], f2[:])")(kernel)
                 kernel[1, N](r, x)
                 expected = fn(x, dtype=np.float16)
-                np.testing.assert_allclose(r, expected)
+                np.testing.assert_allclose(r, expected, rtol=self.FLOAT16_RTOL)
 
         x2 = np.random.randint(1, 10, size=N).astype(np.float16)
         for kernel, fn in zip(exp_kernels, expected_exp_functions):
@@ -857,7 +859,7 @@ class TestCudaIntrinsic(CUDATestCase):
                 kernel = cuda.jit("void(f2[:], f2[:])")(kernel)
                 kernel[1, N](r, x2)
                 expected = fn(x2, dtype=np.float16)
-                np.testing.assert_allclose(r, expected)
+                np.testing.assert_allclose(r, expected, rtol=self.FLOAT16_RTOL)
 
     @skip_unless_cc_53
     def test_hexp10(self):
@@ -876,7 +878,7 @@ class TestCudaIntrinsic(CUDATestCase):
 
         # Run the kernel
         hexp10_vectors[1, N](r, x)
-        np.testing.assert_allclose(r, 10**x)
+        np.testing.assert_allclose(r, 10**x, rtol=self.FLOAT16_RTOL)
 
     @skip_unless_cc_53
     def test_fp16_comparison(self):
@@ -948,10 +950,10 @@ class TestCudaIntrinsic(CUDATestCase):
         arg1 = np.float16(3.0)
         arg2 = np.float16(4.0)
         compiled[1, 1](ary, arg1, arg2)
-        np.testing.assert_allclose(ary[0], arg2)
+        np.testing.assert_allclose(ary[0], arg2, rtol=self.FLOAT16_RTOL)
         arg1 = np.float16(5.0)
         compiled[1, 1](ary, arg1, arg2)
-        np.testing.assert_allclose(ary[0], arg1)
+        np.testing.assert_allclose(ary[0], arg1, rtol=self.FLOAT16_RTOL)
 
     @skip_unless_cc_53
     def test_hmin(self):
@@ -960,10 +962,10 @@ class TestCudaIntrinsic(CUDATestCase):
         arg1 = np.float16(3.0)
         arg2 = np.float16(4.0)
         compiled[1, 1](ary, arg1, arg2)
-        np.testing.assert_allclose(ary[0], arg1)
+        np.testing.assert_allclose(ary[0], arg1, rtol=self.FLOAT16_RTOL)
         arg1 = np.float16(5.0)
         compiled[1, 1](ary, arg1, arg2)
-        np.testing.assert_allclose(ary[0], arg2)
+        np.testing.assert_allclose(ary[0], arg2, rtol=self.FLOAT16_RTOL)
 
     def test_cbrt_f32(self):
         compiled = cuda.jit("void(float32[:], float32)")(simple_cbrt)


### PR DESCRIPTION
Some CI runs were spuriously failing due to overly stringent tolerance for fp16 tests (#490). Use numpy's epsilon for 16b floats instead of the default relative tolerance for np.testing.assert_allclose().

This PR passes `CUDATestCase.FLOAT16_RTOL` to relevant calls to `np.testing.assert_allclose`.
Alternatively, we could add `assertAllClose` to `CUDATestCase` that infers the appropriate relative tolerance from the data types passed in.
Please let me know if we'd like to go that route instead. Thanks in advance!

<!--

Thank you for contributing to numba-cuda :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
