### PR TITLE
[DO NOT MERGE] Test llvmlite 0.45.1 Windows wheel dependency issue

### DIFF
--- a/.github/workflows/wheel-windows-tests.yaml
+++ b/.github/workflows/wheel-windows-tests.yaml
@@ -80,9 +80,19 @@ jobs:
           $wheelFile = Get-ChildItem -Path "wheel-artifacts" -Filter "*.whl" -Recurse | Select-Object -First 1
 
           if ($wheelFile) {
-            Copy-Item $wheelFile.FullName "llvmlite-fixed.whl"
-            Write-Host "Fixed llvmlite wheel ready: llvmlite-fixed.whl"
-            Write-Host "Wheel file: $($wheelFile.FullName)"
+            # Copy the wheel file to the current directory with its original name
+            Copy-Item $wheelFile.FullName "."
+            Write-Host "Fixed llvmlite wheel ready: $($wheelFile.Name)"
+            Write-Host "Original wheel file: $($wheelFile.FullName)"
+            Write-Host "Copied to current directory: $($wheelFile.Name)"
+
+            # Verify the file exists
+            if (Test-Path $wheelFile.Name) {
+              Write-Host "Wheel file exists: $($wheelFile.Name)"
+              Write-Host "File size: $((Get-Item $wheelFile.Name).Length) bytes"
+            } else {
+              Write-Host "ERROR: Wheel file not found after copy"
+            }
           } else {
             Write-Host "No wheel file found in artifact"
             Write-Host "Available files:"

--- a/ci/test_wheel.ps1
+++ b/ci/test_wheel.ps1
@@ -38,15 +38,13 @@ python -m pip install "${package}[cu${CUDA_VER_MAJOR},test-cu${CUDA_VER_MAJOR}]"
 rapids-logger "Install fixed llvmlite 0.45.0 Windows wheel"
 
 # Check if the fixed wheel was downloaded by the workflow
-$fixed_wheel_path = "llvmlite-fixed.whl"
+# Look for any llvmlite wheel file in the current directory
+$fixed_wheel_path = Get-ChildItem -Path "." -Filter "llvmlite*.whl" | Select-Object -First 1
 
-if (Test-Path $fixed_wheel_path) {
-    rapids-logger "Installing fixed llvmlite wheel"
-    python -m pip install --force-reinstall --no-deps $fixed_wheel_path
+if ($fixed_wheel_path) {
+    rapids-logger "Installing fixed llvmlite wheel: $($fixed_wheel_path.Name)"
+    python -m pip install --force-reinstall --no-deps $fixed_wheel_path.FullName
     rapids-logger "Successfully installed fixed llvmlite wheel"
-
-    # Clean up the wheel file
-    Remove-Item $fixed_wheel_path -Force -ErrorAction SilentlyContinue
 } else {
     rapids-logger "Fixed wheel not found, falling back to version pinning"
     python -m pip install "llvmlite<0.45" "numba==0.61.*"


### PR DESCRIPTION
## Summary

Addresses llvmlite 0.45.0 Windows wheel dependency issue ([numba/llvmlite#1297](https://github.com/numba/llvmlite/issues/1297)).

## Changes

- **Workflow**: Download fixed llvmlite wheel using `gh run download` from run [18111409657](https://github.com/numba/llvmlite/actions/runs/18111409657)
- **Script**: Install pre-downloaded fixed wheel with fallback to version pinning
- **Integration**: Updated Windows wheel testing workflow

## Files Modified

- `.github/workflows/wheel-windows-tests.yaml`
- `ci/test_wheel.ps1`