### PR TITLE
Vendor in typeconv for future CUDA-specific changes

### DIFF
--- a/numba_cuda/numba/cuda/_internal/cuda_fp16.py
+++ b/numba_cuda/numba/cuda/_internal/cuda_fp16.py
@@ -124,7 +124,7 @@ class _type_class_unnamed1362071(Type):
         self.bitwidth = 2 * 8
 
     def can_convert_from(self, typingctx, other):
-        from numba.core.typeconv import Conversion
+        from numba.cuda.typeconv import Conversion
 
         if other in []:
             return Conversion.safe
@@ -174,7 +174,7 @@ class _type_class_unnamed1362180(Type):
         self.bitwidth = 4 * 8
 
     def can_convert_from(self, typingctx, other):
-        from numba.core.typeconv import Conversion
+        from numba.cuda.typeconv import Conversion
 
         if other in []:
             return Conversion.safe
@@ -7903,9 +7903,9 @@ def _fp16_binary_operator(l_key, retty):
                 #  - Conversion.safe
 
                 if (
-                    (convertible == numba.core.typeconv.Conversion.exact)
-                    or (convertible == numba.core.typeconv.Conversion.promote)
-                    or (convertible == numba.core.typeconv.Conversion.safe)
+                    (convertible == numba.cuda.typeconv.Conversion.exact)
+                    or (convertible == numba.cuda.typeconv.Conversion.promote)
+                    or (convertible == numba.cuda.typeconv.Conversion.safe)
                 ):
                     return signature(retty, types.float16, types.float16)
 

--- a/numba_cuda/numba/cuda/core/typeinfer.py
+++ b/numba_cuda/numba/cuda/core/typeinfer.py
@@ -48,7 +48,7 @@ from numba.core.errors import (
     NumbaValueError,
 )
 from numba.cuda.core.funcdesc import qualifying_prefix
-from numba.core.typeconv import Conversion
+from numba.cuda.typeconv import Conversion
 
 _logger = logging.getLogger(__name__)
 

--- a/numba_cuda/numba/cuda/target.py
+++ b/numba_cuda/numba/cuda/target.py
@@ -88,7 +88,7 @@ class CUDATypingContext(typing.BaseContext):
     def can_convert(self, fromty, toty):
         """
         Check whether conversion is possible from *fromty* to *toty*.
-        If successful, return a numba.typeconv.Conversion instance;
+        If successful, return a numba.cuda.typeconv.Conversion instance;
         otherwise None is returned.
         """
 

--- a/numba_cuda/numba/cuda/tests/cudapy/test_typeinfer.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_typeinfer.py
@@ -4,7 +4,7 @@
 import itertools
 
 from numba.core import errors, types, typing
-from numba.core.typeconv import Conversion
+from numba.cuda.typeconv import Conversion
 
 from numba.cuda.testing import CUDATestCase, skip_on_cudasim
 from numba.tests.test_typeconv import CompatibilityTestMixin

--- a/numba_cuda/numba/cuda/typeconv/__init__.py
+++ b/numba_cuda/numba/cuda/typeconv/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+from .castgraph import Conversion  # noqa F401

--- a/numba_cuda/numba/cuda/typeconv/castgraph.py
+++ b/numba_cuda/numba/cuda/typeconv/castgraph.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+from collections import defaultdict
+import enum
+
+
+class Conversion(enum.IntEnum):
+    """
+    A conversion kind from one type to the other.  The enum members
+    are ordered from stricter to looser.
+    """
+
+    # The two types are identical
+    exact = 1
+    # The two types are of the same kind, the destination type has more
+    # extension or precision than the source type (e.g. float32 -> float64,
+    # or int32 -> int64)
+    promote = 2
+    # The source type can be converted to the destination type without loss
+    # of information (e.g. int32 -> int64).  Note that the conversion may
+    # still fail explicitly at runtime (e.g. Optional(int32) -> int32)
+    safe = 3
+    # The conversion may appear to succeed at runtime while losing information
+    # or precision (e.g. int32 -> uint32, float64 -> float32, int64 -> int32,
+    # etc.)
+    unsafe = 4
+
+    # This value is only used internally
+    nil = 99
+
+
+class CastSet(object):
+    """A set of casting rules.
+
+    There is at most one rule per target type.
+    """
+
+    def __init__(self):
+        self._rels = {}
+
+    def insert(self, to, rel):
+        old = self.get(to)
+        setrel = min(rel, old)
+        self._rels[to] = setrel
+        return old != setrel
+
+    def items(self):
+        return self._rels.items()
+
+    def get(self, item):
+        return self._rels.get(item, Conversion.nil)
+
+    def __len__(self):
+        return len(self._rels)
+
+    def __repr__(self):
+        body = [
+            "{rel}({ty})".format(rel=rel, ty=ty)
+            for ty, rel in self._rels.items()
+        ]
+        return "{" + ", ".join(body) + "}"
+
+    def __contains__(self, item):
+        return item in self._rels
+
+    def __iter__(self):
+        return iter(self._rels.keys())
+
+    def __getitem__(self, item):
+        return self._rels[item]
+
+
+class TypeGraph(object):
+    """A graph that maintains the casting relationship of all types.
+
+    This simplifies the definition of casting rules by automatically
+    propagating the rules.
+    """
+
+    def __init__(self, callback=None):
+        """
+        Args
+        ----
+        - callback: callable or None
+            It is called for each new casting rule with
+            (from_type, to_type, castrel).
+        """
+        assert callback is None or callable(callback)
+        self._forwards = defaultdict(CastSet)
+        self._backwards = defaultdict(set)
+        self._callback = callback
+
+    def get(self, ty):
+        return self._forwards[ty]
+
+    def propagate(self, a, b, baserel):
+        backset = self._backwards[a]
+
+        # Forward propagate the relationship to all nodes that b leads to
+        for child in self._forwards[b]:
+            rel = max(baserel, self._forwards[b][child])
+            if a != child:
+                if self._forwards[a].insert(child, rel):
+                    self._callback(a, child, rel)
+                self._backwards[child].add(a)
+
+            # Propagate the relationship from nodes that connects to a
+            for backnode in backset:
+                if backnode != child:
+                    backrel = max(rel, self._forwards[backnode][a])
+                    if self._forwards[backnode].insert(child, backrel):
+                        self._callback(backnode, child, backrel)
+                    self._backwards[child].add(backnode)
+
+        # Every node that leads to a connects to b
+        for child in self._backwards[a]:
+            rel = max(baserel, self._forwards[child][a])
+            if b != child:
+                if self._forwards[child].insert(b, rel):
+                    self._callback(child, b, rel)
+                self._backwards[b].add(child)
+
+    def insert_rule(self, a, b, rel):
+        self._forwards[a].insert(b, rel)
+        self._callback(a, b, rel)
+        self._backwards[b].add(a)
+        self.propagate(a, b, rel)
+
+    def promote(self, a, b):
+        self.insert_rule(a, b, Conversion.promote)
+
+    def safe(self, a, b):
+        self.insert_rule(a, b, Conversion.safe)
+
+    def unsafe(self, a, b):
+        self.insert_rule(a, b, Conversion.unsafe)

--- a/numba_cuda/numba/cuda/typeconv/rules.py
+++ b/numba_cuda/numba/cuda/typeconv/rules.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import itertools
+from .typeconv import TypeManager, TypeCastingRules
+from numba.core import types
+from numba.cuda import config
+
+
+default_type_manager = TypeManager()
+
+
+def dump_number_rules():
+    tm = default_type_manager
+    for a, b in itertools.product(types.number_domain, types.number_domain):
+        print(a, "->", b, tm.check_compatible(a, b))
+
+
+if config.USE_LEGACY_TYPE_SYSTEM:  # Old type system
+
+    def _init_casting_rules(tm):
+        tcr = TypeCastingRules(tm)
+        tcr.safe_unsafe(types.boolean, types.int8)
+        tcr.safe_unsafe(types.boolean, types.uint8)
+
+        tcr.promote_unsafe(types.int8, types.int16)
+        tcr.promote_unsafe(types.uint8, types.uint16)
+
+        tcr.promote_unsafe(types.int16, types.int32)
+        tcr.promote_unsafe(types.uint16, types.uint32)
+
+        tcr.promote_unsafe(types.int32, types.int64)
+        tcr.promote_unsafe(types.uint32, types.uint64)
+
+        tcr.safe_unsafe(types.uint8, types.int16)
+        tcr.safe_unsafe(types.uint16, types.int32)
+        tcr.safe_unsafe(types.uint32, types.int64)
+
+        tcr.safe_unsafe(types.int8, types.float16)
+        tcr.safe_unsafe(types.int16, types.float32)
+        tcr.safe_unsafe(types.int32, types.float64)
+
+        tcr.unsafe_unsafe(types.int16, types.float16)
+        tcr.unsafe_unsafe(types.int32, types.float32)
+        # XXX this is inconsistent with the above; but we want to prefer
+        # float64 over int64 when typing a heterogeneous operation,
+        # e.g. `float64 + int64`.  Perhaps we need more granularity in the
+        # conversion kinds.
+        tcr.safe_unsafe(types.int64, types.float64)
+        tcr.safe_unsafe(types.uint64, types.float64)
+
+        tcr.promote_unsafe(types.float16, types.float32)
+        tcr.promote_unsafe(types.float32, types.float64)
+
+        tcr.safe(types.float32, types.complex64)
+        tcr.safe(types.float64, types.complex128)
+
+        tcr.promote_unsafe(types.complex64, types.complex128)
+
+        # Allow integers to cast ot void*
+        tcr.unsafe_unsafe(types.uintp, types.voidptr)
+
+        return tcr
+else:  # New type system
+    # Currently left as empty
+    # If no casting rules are required we may opt to remove
+    # this framework upon deprecation
+    def _init_casting_rules(tm):
+        tcr = TypeCastingRules(tm)
+        return tcr
+
+
+default_casting_rules = _init_casting_rules(default_type_manager)

--- a/numba_cuda/numba/cuda/typeconv/typeconv.py
+++ b/numba_cuda/numba/cuda/typeconv/typeconv.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+try:
+    # This is usually the the first C extension import performed when importing
+    # Numba, if it fails to import, provide some feedback
+    from numba.core.typeconv import _typeconv
+except ImportError as e:
+    base_url = "https://numba.readthedocs.io/en/stable"
+    dev_url = f"{base_url}/developer/contributing.html"
+    user_url = f"{base_url}/user/faq.html#numba-could-not-be-imported"
+    dashes = "-" * 80
+    msg = (
+        f"Numba could not be imported.\n{dashes}\nIf you are seeing this "
+        "message and are undertaking Numba development work, you may need "
+        "to rebuild Numba.\nPlease see the development set up guide:\n\n"
+        f"{dev_url}.\n\n{dashes}\nIf you are not working on Numba "
+        f"development, the original error was: '{str(e)}'.\nFor help, "
+        f"please visit:\n\n{user_url}\n"
+    )
+    raise ImportError(msg)
+
+from numba.cuda.typeconv import castgraph, Conversion
+from numba.core import types
+
+
+class TypeManager(object):
+    # The character codes used by the C/C++ API (_typeconv.cpp)
+    _conversion_codes = {
+        Conversion.safe: ord("s"),
+        Conversion.unsafe: ord("u"),
+        Conversion.promote: ord("p"),
+    }
+
+    def __init__(self):
+        self._ptr = _typeconv.new_type_manager()
+        self._types = set()
+
+    def select_overload(
+        self, sig, overloads, allow_unsafe, exact_match_required
+    ):
+        sig = [t._code for t in sig]
+        overloads = [[t._code for t in s] for s in overloads]
+        return _typeconv.select_overload(
+            self._ptr, sig, overloads, allow_unsafe, exact_match_required
+        )
+
+    def check_compatible(self, fromty, toty):
+        if not isinstance(toty, types.Type):
+            raise ValueError(
+                "Specified type '%s' (%s) is not a Numba type"
+                % (toty, type(toty))
+            )
+        name = _typeconv.check_compatible(self._ptr, fromty._code, toty._code)
+        conv = Conversion[name] if name is not None else None
+        assert conv is not Conversion.nil
+        return conv
+
+    def set_compatible(self, fromty, toty, by):
+        code = self._conversion_codes[by]
+        _typeconv.set_compatible(self._ptr, fromty._code, toty._code, code)
+        # Ensure the types don't die, otherwise they may be recreated with
+        # other type codes and pollute the hash table.
+        self._types.add(fromty)
+        self._types.add(toty)
+
+    def set_promote(self, fromty, toty):
+        self.set_compatible(fromty, toty, Conversion.promote)
+
+    def set_unsafe_convert(self, fromty, toty):
+        self.set_compatible(fromty, toty, Conversion.unsafe)
+
+    def set_safe_convert(self, fromty, toty):
+        self.set_compatible(fromty, toty, Conversion.safe)
+
+    def get_pointer(self):
+        return _typeconv.get_pointer(self._ptr)
+
+
+class TypeCastingRules(object):
+    """
+    A helper for establishing type casting rules.
+    """
+
+    def __init__(self, tm):
+        self._tm = tm
+        self._tg = castgraph.TypeGraph(self._cb_update)
+
+    def promote(self, a, b):
+        """
+        Set `a` can promote to `b`
+        """
+        self._tg.promote(a, b)
+
+    def unsafe(self, a, b):
+        """
+        Set `a` can unsafe convert to `b`
+        """
+        self._tg.unsafe(a, b)
+
+    def safe(self, a, b):
+        """
+        Set `a` can safe convert to `b`
+        """
+        self._tg.safe(a, b)
+
+    def promote_unsafe(self, a, b):
+        """
+        Set `a` can promote to `b` and `b` can unsafe convert to `a`
+        """
+        self.promote(a, b)
+        self.unsafe(b, a)
+
+    def safe_unsafe(self, a, b):
+        """
+        Set `a` can safe convert to `b` and `b` can unsafe convert to `a`
+        """
+        self._tg.safe(a, b)
+        self._tg.unsafe(b, a)
+
+    def unsafe_unsafe(self, a, b):
+        """
+        Set `a` can unsafe convert to `b` and `b` can unsafe convert to `a`
+        """
+        self._tg.unsafe(a, b)
+        self._tg.unsafe(b, a)
+
+    def _cb_update(self, a, b, rel):
+        """
+        Callback for updating.
+        """
+        if rel == Conversion.promote:
+            self._tm.set_promote(a, b)
+        elif rel == Conversion.safe:
+            self._tm.set_safe_convert(a, b)
+        elif rel == Conversion.unsafe:
+            self._tm.set_unsafe_convert(a, b)
+        else:
+            raise AssertionError(rel)

--- a/numba_cuda/numba/cuda/types.py
+++ b/numba_cuda/numba/cuda/types.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from numba.core import types
-from numba.core.typeconv import Conversion
+from numba.cuda.typeconv import Conversion
 
 
 class Dim3(types.Type):

--- a/numba_cuda/numba/cuda/typing/context.py
+++ b/numba_cuda/numba/cuda/typing/context.py
@@ -10,7 +10,7 @@ import contextlib
 import operator
 
 from numba.core import types, errors
-from numba.core.typeconv import Conversion, rules
+from numba.cuda.typeconv import Conversion, rules
 from numba.core.typing.typeof import typeof, Purpose
 from numba.core.typing import templates
 from numba.cuda import utils


### PR DESCRIPTION
This PR vendors in `numba.core.typeconv` for CUDA-specific customizations. The `_typeconv` C extension can be vendored in after PR https://github.com/NVIDIA/numba-cuda/pull/373 gets merged in; it already contains the necessary cpp and hpp files for `_typeconv`.