### PR TITLE
Correct `NUMBA_CUDA_DEVICEARRAY_IMPORT_NAME`

### DIFF
--- a/numba_cuda/numba/cuda/cext/_devicearray.h
+++ b/numba_cuda/numba/cuda/cext/_devicearray.h
@@ -8,7 +8,7 @@
     extern "C" {
 #endif
 
-#define NUMBA_DEVICEARRAY_IMPORT_NAME "numba_cuda._devicearray"
+#define NUMBA_DEVICEARRAY_IMPORT_NAME "numba.cuda.cext._devicearray"
 /* These definitions should only be used by consumers of the Device Array API.
  * Consumers access the API through the opaque pointer stored in
  * _devicearray._DEVICEARRAY_API.  We don't want these definitions in


### PR DESCRIPTION
This addresses one of the fixups required following the merge of #373.

The package name is `numba.cuda.cext`, not `numba_cuda`. However, fixing this results in a circular import during `PyCapsule_Import` when running something as simple as:

```python
from numba import cuda
```

which gives:

```
AttributeError: cannot access submodule 'cuda' of module 'numba' (most likely due to a circular import)
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/gmarkall/numbadev/numba-cuda/numba_cuda/numba/cuda/__init__.py", line 73, in <module>
    from .device_init import *
  File "/home/gmarkall/numbadev/numba-cuda/numba_cuda/numba/cuda/device_init.py", line 66, in <module>
    from .decorators import jit, declare_device
  File "/home/gmarkall/numbadev/numba-cuda/numba_cuda/numba/cuda/decorators.py", line 9, in <module>
    from numba.cuda.dispatcher import CUDADispatcher
  File "/home/gmarkall/numbadev/numba-cuda/numba_cuda/numba/cuda/dispatcher.py", line 50, in <module>
    from numba.cuda.cext import _dispatcher
ImportError: numba.cuda.cext._devicearray failed to import
```

This is because when `import_devicearray()` is called, we're partway through importing `numba.cuda`. Therefore, the `PyCapsule_Import()` fails because it tries to access packages under `numba.cuda` during its initialization, which then fails due to this circularity. This was not a problem in upstream Numba because `_devicearray` was not in the `numba.cuda` package.

In order to work around this, we can get the `_DEVICEARRAY_API` attribute of the `_devicearray` module directly from its module dict, and then use `PyCapsule_GetPointer()` to set the `DeviceArray_API` global.

<!--

Thank you for contributing to numba-cuda :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
