### PR TITLE
Allow registering an ArgHandler

### DIFF
--- a/numba_cuda/numba/cuda/tests/cudapy/test_extending.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_extending.py
@@ -496,6 +496,8 @@ class TestArgHandlerRegistration(CUDATestCase):
 
         class PassedArgHandler_float32:
             def prepare_args(self, ty, val, **kwargs):
+                if val.arr.dtype != np.float32:
+                    return ty, val
                 return types.float32[::1], val.arr
 
         @cuda.jit(


### PR DESCRIPTION
This PR allows a user to register extra arg handling for any type they wish to pass to a kernel. Arg handlers must inherit from `ArgHandlerBase` and implement the required handling. Then, a user may pass it to `register_arg_handler`, potentially upon the import of a library that expects to pass a custom object to a numba kernel. 