### PR TITLE
Remove some unnecessary uses of ContextResettingTestCase

### DIFF
--- a/numba_cuda/numba/cuda/tests/cudadrv/test_inline_ptx.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_inline_ptx.py
@@ -4,12 +4,12 @@
 from llvmlite import ir
 
 from numba.cuda.cudadrv import nvvm
-from numba.cuda.testing import unittest, ContextResettingTestCase
+from numba.cuda.testing import unittest, CUDATestCase
 from numba.cuda.testing import skip_on_cudasim
 
 
 @skip_on_cudasim("Inline PTX cannot be used in the simulator")
-class TestCudaInlineAsm(ContextResettingTestCase):
+class TestCudaInlineAsm(CUDATestCase):
     def test_inline_rsqrt(self):
         mod = ir.Module(__name__)
         mod.triple = "nvptx64-nvidia-cuda"

--- a/numba_cuda/numba/cuda/tests/cudadrv/test_pinned.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_pinned.py
@@ -5,10 +5,10 @@ import numpy as np
 import platform
 
 from numba import cuda
-from numba.cuda.testing import unittest, ContextResettingTestCase
+from numba.cuda.testing import unittest, CUDATestCase
 
 
-class TestPinned(ContextResettingTestCase):
+class TestPinned(CUDATestCase):
     def _run_copies(self, A):
         A0 = np.copy(A)
 

--- a/numba_cuda/numba/cuda/tests/cudadrv/test_profiler.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_profiler.py
@@ -2,13 +2,13 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import unittest
-from numba.cuda.testing import ContextResettingTestCase
+from numba.cuda.testing import CUDATestCase
 from numba import cuda
 from numba.cuda.testing import skip_on_cudasim
 
 
 @skip_on_cudasim("CUDA Profiler unsupported in the simulator")
-class TestProfiler(ContextResettingTestCase):
+class TestProfiler(CUDATestCase):
     def test_profiling(self):
         with cuda.profiling():
             a = cuda.device_array(10)

--- a/numba_cuda/numba/cuda/tests/cudadrv/test_reset_device.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_reset_device.py
@@ -4,11 +4,11 @@
 import threading
 from numba import cuda
 from numba.cuda.cudadrv.driver import driver
-from numba.cuda.testing import unittest, ContextResettingTestCase
+from numba.cuda.testing import unittest, CUDATestCase
 from queue import Queue
 
 
-class TestResetDevice(ContextResettingTestCase):
+class TestResetDevice(CUDATestCase):
     def test_reset_device(self):
         def newthread(exception_queue):
             try:

--- a/numba_cuda/numba/cuda/tests/cudadrv/test_select_device.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_select_device.py
@@ -9,7 +9,7 @@ from queue import Queue
 
 import numpy as np
 from numba import cuda
-from numba.cuda.testing import unittest, ContextResettingTestCase
+from numba.cuda.testing import unittest, CUDATestCase
 
 
 def newthread(exception_queue):
@@ -21,12 +21,12 @@ def newthread(exception_queue):
         stream.synchronize()
         del dA
         del stream
-        cuda.close()
+        cuda.synchronize()
     except Exception as e:
         exception_queue.put(e)
 
 
-class TestSelectDevice(ContextResettingTestCase):
+class TestSelectDevice(CUDATestCase):
     def test_select_device(self):
         exception_queue = Queue()
         for i in range(10):

--- a/numba_cuda/numba/cuda/tests/cudapy/test_cuda_array_interface.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_cuda_array_interface.py
@@ -5,14 +5,14 @@ import numpy as np
 
 from numba import vectorize, guvectorize
 from numba import cuda
-from numba.cuda.testing import unittest, ContextResettingTestCase, ForeignArray
+from numba.cuda.testing import unittest, CUDATestCase, ForeignArray
 from numba.cuda.testing import skip_on_cudasim, skip_if_external_memmgr
 from numba.cuda.tests.support import linux_only, override_config
 from unittest.mock import call, patch
 
 
 @skip_on_cudasim("CUDA Array Interface is not supported in the simulator")
-class TestCudaArrayInterface(ContextResettingTestCase):
+class TestCudaArrayInterface(CUDATestCase):
     def assertPointersEqual(self, a, b):
         self.assertEqual(
             a.device_ctypes_pointer.value, b.device_ctypes_pointer.value

--- a/numba_cuda/numba/cuda/tests/cudapy/test_ipc.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_ipc.py
@@ -15,7 +15,7 @@ from numba.cuda.testing import (
     skip_on_cudasim,
     skip_under_cuda_memcheck,
     skip_on_wsl2,
-    ContextResettingTestCase,
+    CUDATestCase,
     ForeignArray,
 )
 from numba.cuda.tests.support import linux_only, windows_only
@@ -95,7 +95,7 @@ def ipc_array_test(ipcarr, result_queue):
 @skip_on_cudasim("Ipc not available in CUDASIM")
 @skip_on_arm("CUDA IPC not supported on ARM in Numba")
 @skip_on_wsl2("CUDA IPC unreliable on WSL2; skipping IPC tests")
-class TestIpcMemory(ContextResettingTestCase):
+class TestIpcMemory(CUDATestCase):
     def test_ipc_handle(self):
         # prepare data for IPC
         arr = np.arange(10, dtype=np.intp)
@@ -264,7 +264,7 @@ def staged_ipc_array_test(ipcarr, device_num, result_queue):
 @skip_on_cudasim("Ipc not available in CUDASIM")
 @skip_on_arm("CUDA IPC not supported on ARM in Numba")
 @skip_on_wsl2("CUDA IPC unreliable on WSL2; skipping IPC tests")
-class TestIpcStaged(ContextResettingTestCase):
+class TestIpcStaged(CUDATestCase):
     def test_staged(self):
         # prepare data for IPC
         arr = np.arange(10, dtype=np.intp)
@@ -324,7 +324,7 @@ class TestIpcStaged(ContextResettingTestCase):
 
 @windows_only
 @skip_on_cudasim("Ipc not available in CUDASIM")
-class TestIpcNotSupported(ContextResettingTestCase):
+class TestIpcNotSupported(CUDATestCase):
     def test_unsupported(self):
         arr = np.arange(10, dtype=np.intp)
         devarr = cuda.to_device(arr)


### PR DESCRIPTION
Some cases that I think look safe to remove; a few more complicated ones still remain.

Testing on CI for now - seems to pass locally for me.