### PR TITLE
Fix Bf16 Test OB Error

### DIFF
--- a/numba_cuda/numba/cuda/tests/cudapy/test_bfloat16.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_bfloat16.py
@@ -557,7 +557,7 @@ class TestBfloat16HighLevelBindings(CUDATestCase):
             out[4] = bfloat16_as_int16(f4_default)
             out[5] = bfloat16_as_int16(f8_default)
 
-        out = cuda.device_array((1,), dtype="int16")
+        out = cuda.device_array((6,), dtype="int16")
         kernel[1, 1](out)
         raw = out.copy_to_host()
 


### PR DESCRIPTION
Closes #508 

This PR fixes a bug in bfloat16 tests. The result array was assigned the wrong size.