### PR TITLE
Switch back to stable cuDF release in thirdparty tests

### DIFF
--- a/ci/test_thirdparty.sh
+++ b/ci/test_thirdparty.sh
@@ -9,8 +9,8 @@ CUDA_VER_MAJOR_MINOR=${CUDA_VER%.*}
 rapids-logger "Install cuDF Wheel"
 
 pip install \
-    --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple \
-    "cudf-cu12>=25.10.0a0,<=25.10" "dask-cuda>=25.10.0a0,<=25.10"
+    --extra-index-url=https://pypi.nvidia.com \
+    "cudf-cu12==25.10.*"
 
 
 rapids-logger "Remove Extraneous numba-cuda"


### PR DESCRIPTION
https://github.com/NVIDIA/numba-cuda/pull/402 moved us to testing nightly builds of cuDF due the 25.08 release being broken with later versions of `numba-cuda` (unfortunately in a c++ related way that wasn't dynamically patchable in our CI). With rapids stable 25.10 release now out, we should be able to switch back and avoid being blocked by a broken cuDF nightly. 
