### PR TITLE
Don't use `MemoryLeakMixin` for tests that don't use NRT

### DIFF
--- a/numba_cuda/numba/cuda/tests/cudapy/test_ufuncs.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_ufuncs.py
@@ -10,12 +10,10 @@ from numba import cuda, types, njit, typeof
 from numba.cuda import config
 from numba.cuda.np import numpy_support
 from numba.cuda.tests.support import TestCase
-from numba.cuda.tests.support import MemoryLeakMixin
 
 
-class BaseUFuncTest(MemoryLeakMixin):
+class BaseUFuncTest:
     def setUp(self):
-        super(BaseUFuncTest, self).setUp()
         self.inputs = [
             (np.uint32(0), types.uint32),
             (np.uint32(1), types.uint32),

--- a/numba_cuda/numba/cuda/tests/test_analysis.py
+++ b/numba_cuda/numba/cuda/tests/test_analysis.py
@@ -15,10 +15,7 @@ from numba.cuda.utils import PYVERSION
 from numba.cuda.core import postproc, rewrites, ir_utils
 from numba.cuda.core.options import ParallelOptions
 from numba.cuda.core.inline_closurecall import InlineClosureCallPass
-from numba.cuda.tests.support import (
-    TestCase,
-    MemoryLeakMixin,
-)
+from numba.cuda.tests.support import TestCase
 from numba.cuda.core.analysis import (
     dead_branch_prune,
     rewrite_semantic_constants,
@@ -51,7 +48,7 @@ def compile_to_ir(func):
     return func_ir
 
 
-class TestBranchPruneBase(MemoryLeakMixin, TestCase):
+class TestBranchPruneBase(TestCase):
     """
     Tests branch pruning
     """


### PR DESCRIPTION
Some recent vendorings resulted in the `MemoryLeakMixin` class being a base for some tests. The side effect of this is that it now enables NRT stats counting on-device. There seem to be some cleanup issues with NRT stats counting (it ought to be robust when used with tests in general, but as #517 notes, it seems not to be).

In order to reduce the incidence of spurious failures from this (especially when testing on a fast machine), we disable the `MemoryLeakMixin` for tests that aren't using NRT (which is still experimental for CUDA anyway).