### PR TITLE
pyproject.toml: add search path for Pyrefly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,3 +160,6 @@ test = { features = ["test"], solve-group = "test" }
 
 [tool.pixi.tasks]
 test = { cmd = ["pytest", "$PIXI_PROJECT_ROOT/numba_cuda/numba/cuda/tests"] }
+
+[tool.pyrefly]
+search-path = ["./numba_cuda"]


### PR DESCRIPTION
This allows Pyrefly to locate `numba.cuda` code within the `numba_cuda` package instead of in the installed Numba package. With this change, using Pyrefly as an LSP behaves "as expected" - i.e. suggestions / info based on code in `numba_cuda` are provided instead of those from the legacy upstream CUDA target.

An example within nvim, where `compile_all()` (which only exists in Numba-CUDA) is picked up:

<img width="1865" height="443" alt="pyrefly" src="https://github.com/user-attachments/assets/c89a29a7-a732-43b3-86a3-fb06911631c5" />
