### PR TITLE
refactor: remove unnecessary custom map and set implementations

### DIFF
--- a/numba_cuda/numba/cuda/core/ssa.py
+++ b/numba_cuda/numba/cuda/core/ssa.py
@@ -20,7 +20,7 @@ from collections import defaultdict
 from numba.cuda import config
 from numba.core import ir, errors
 from numba.cuda.core import ir_utils
-from numba.cuda.utils import OrderedSet, _lazy_pformat
+from numba.cuda.utils import _lazy_pformat
 from numba.cuda.core.analysis import compute_cfg_from_blocks
 
 
@@ -160,7 +160,7 @@ def _find_defs_violators(blocks, cfg):
     # Gather violators by number of definitions.
     # The violators are added by the order that they are seen and the algorithm
     # scan from the first to the last basic-block as they occur in bytecode.
-    violators = OrderedSet([k for k, vs in defs.items() if len(vs) > 1])
+    violators = {k: None for k, vs in defs.items() if len(vs) > 1}
     # Gather violators by uses not dominated by the one def
     doms = cfg.dominators()
     for k, use_blocks in uses.items():
@@ -169,9 +169,9 @@ def _find_defs_violators(blocks, cfg):
                 dom = doms[label]
                 def_labels = {label for _assign, label in defs[k]}
                 if not def_labels.intersection(dom):
-                    violators.add(k)
+                    violators[k] = None
                     break
-    _logger.debug("SSA violators %s", _lazy_pformat(violators))
+    _logger.debug("SSA violators %s", _lazy_pformat(list(violators)))
     return violators
 
 

--- a/numba_cuda/numba/cuda/lowering.py
+++ b/numba_cuda/numba/cuda/lowering.py
@@ -48,7 +48,7 @@ class BaseLower(object):
     def __init__(self, context, library, fndesc, func_ir, metadata=None):
         self.library = library
         self.fndesc = fndesc
-        self.blocks = utils.SortedMap(func_ir.blocks.items())
+        self.blocks = dict(sorted(func_ir.blocks.items()))
         self.func_ir = func_ir
         self.generator_info = func_ir.generator_info
         self.metadata = metadata
@@ -292,7 +292,7 @@ class BaseLower(object):
         )
 
         # Lower all blocks
-        for offset, block in sorted(self.blocks.items()):
+        for offset, block in self.blocks.items():
             bb = self.blkmap[offset]
             self.builder.position_at_end(bb)
             self.debug_print(f"# lower block: {offset}")

--- a/numba_cuda/numba/cuda/utils.py
+++ b/numba_cuda/numba/cuda/utils.py
@@ -17,7 +17,6 @@ import weakref
 import threading
 import contextlib
 import json
-import typing as _tp
 from pprint import pformat
 
 from types import ModuleType
@@ -35,7 +34,6 @@ from numba.cuda.core.config import (
 
 from numba.cuda.core import config
 
-from collections.abc import Mapping, MutableSet, MutableMapping
 
 PYVERSION = config.PYVERSION
 
@@ -352,102 +350,6 @@ def order_by_target_specificity(target, templates, fnkey=""):
         raise UnsupportedError(msg)
 
     return order
-
-
-T = _tp.TypeVar("T")
-
-
-class OrderedSet(MutableSet[T]):
-    def __init__(self, iterable: _tp.Iterable[T] = ()):
-        # Just uses a dictionary under-the-hood to maintain insertion order.
-        self._data = dict.fromkeys(iterable, None)
-
-    def __contains__(self, key):
-        return key in self._data
-
-    def __iter__(self):
-        return iter(self._data)
-
-    def __len__(self):
-        return len(self._data)
-
-    def add(self, item):
-        self._data[item] = None
-
-    def discard(self, item):
-        self._data.pop(item, None)
-
-
-class MutableSortedSet(MutableSet[T], _tp.Generic[T]):
-    """Mutable Sorted Set"""
-
-    def __init__(self, values: _tp.Iterable[T] = ()):
-        self._values = set(values)
-
-    def __len__(self):
-        return len(self._values)
-
-    def __iter__(self):
-        return iter(k for k in sorted(self._values))
-
-    def __contains__(self, x: T) -> bool:
-        return self._values.__contains__(x)
-
-    def add(self, x: T):
-        return self._values.add(x)
-
-    def discard(self, value: T):
-        self._values.discard(value)
-
-    def update(self, values):
-        self._values.update(values)
-
-
-Tk = _tp.TypeVar("Tk")
-Tv = _tp.TypeVar("Tv")
-
-
-class SortedMap(Mapping[Tk, Tv], _tp.Generic[Tk, Tv]):
-    """Immutable"""
-
-    def __init__(self, seq):
-        self._values = []
-        self._index = {}
-        for i, (k, v) in enumerate(sorted(seq)):
-            self._index[k] = i
-            self._values.append((k, v))
-
-    def __getitem__(self, k):
-        i = self._index[k]
-        return self._values[i][1]
-
-    def __len__(self):
-        return len(self._values)
-
-    def __iter__(self):
-        return iter(k for k, v in self._values)
-
-
-class MutableSortedMap(MutableMapping[Tk, Tv], _tp.Generic[Tk, Tv]):
-    def __init__(self, dct=None):
-        if dct is None:
-            dct = {}
-        self._dct: dict[Tk, Tv] = dct
-
-    def __getitem__(self, k: Tk) -> Tv:
-        return self._dct[k]
-
-    def __setitem__(self, k: Tk, v: Tv):
-        self._dct[k] = v
-
-    def __delitem__(self, k: Tk):
-        del self._dct[k]
-
-    def __len__(self) -> int:
-        return len(self._dct)
-
-    def __iter__(self) -> int:
-        return iter(k for k in sorted(self._dct))
 
 
 class UniqueDict(dict):


### PR DESCRIPTION
This PR removes some custom mapping and set implementations that I believe can be supplanted by `dict`s (and judicious use of `sorted` where applicable).