### PR TITLE
perf: remove duplicated size computation

### DIFF
--- a/numba_cuda/numba/cuda/cudadrv/devicearray.py
+++ b/numba_cuda/numba/cuda/cudadrv/devicearray.py
@@ -90,26 +90,27 @@ class DeviceNDArrayBase(_devicearray.DeviceArray):
         if isinstance(strides, int):
             strides = (strides,)
         dtype = np.dtype(dtype)
-        self.ndim = len(shape)
-        if len(strides) != self.ndim:
+        itemsize = dtype.itemsize
+        self.ndim = ndim = len(shape)
+        if len(strides) != ndim:
             raise ValueError("strides not match ndim")
-        self._dummy = dummyarray.Array.from_desc(
-            0, shape, strides, dtype.itemsize
+        self._dummy = dummy = dummyarray.Array.from_desc(
+            0, shape, strides, itemsize
         )
         # confirm that all elements of shape are ints
         if not all(isinstance(dim, (int, np.integer)) for dim in shape):
             raise TypeError("all elements of shape must be ints")
-        self.shape = self._dummy.shape
-        self.strides = self._dummy.strides
+        self.shape = shape = dummy.shape
+        self.strides = strides = dummy.strides
         self.dtype = dtype
-        self.size = self._dummy.size
+        self.size = size = dummy.size
         # prepare gpu memory
-        if self.size > 0:
-            self.alloc_size = _driver.memory_size_from_info(
-                self.shape, self.strides, self.dtype.itemsize
+        if size:
+            self.alloc_size = alloc_size = _driver.memory_size_from_info(
+                shape, strides, itemsize
             )
             if gpu_data is None:
-                gpu_data = devices.get_context().memalloc(self.alloc_size)
+                gpu_data = devices.get_context().memalloc(alloc_size)
         else:
             # Make NULL pointer for empty allocation
             null = _driver.binding.CUdeviceptr(0)


### PR DESCRIPTION
This PR removes some overhead caused by repeated computation of array `size` by forwarding attributes from the underlying dummy array.