### PR TITLE
Relax the pinning to `cuda-core` to allow it floating across minor releases

### DIFF
--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -13,7 +13,7 @@ echo "Package path: ${package}"
 DEPENDENCIES=(
     "${package}"
     "cuda-python==${CUDA_VER_MAJOR_MINOR%.*}.*"
-    "cuda-core==0.4.*"
+    "cuda-core>=0.3.0,<1.0.0"
     "--group"
     "test"
 )

--- a/conda/recipes/numba-cuda/meta.yaml
+++ b/conda/recipes/numba-cuda/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - python
     - numba >=0.59.1
     - cuda-bindings >=12.9.1
-    - cuda-core ==0.4.*
+    - cuda-core >=0.3.0,<1.0.0
 
 about:
   home: {{ project_urls["Homepage"] }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,12 @@ authors = [
 license = "BSD-2-clause"
 license-files = ["LICENSE", "LICENSE.numba"]
 requires-python = ">=3.9"
-dependencies = ["numba>=0.60.0", "cuda-bindings>=12.9.1,<14.0.0", "cuda-core>=0.4.0,<0.5.0dev0"]
+dependencies = ["numba>=0.60.0", "cuda-bindings>=12.9.1,<14.0.0", "cuda-core>=0.3.2,<1.0.0"]
 
 [project.optional-dependencies]
 cu12 = [
     "cuda-bindings>=12.9.1,<13.0.0",
-    "cuda-core==0.4.*",
+    "cuda-core>=0.3.0,<1.0.0",
     "cuda-python==12.9.*",  # supports all CTK 12.x
     "nvidia-cuda-nvcc-cu12",  # for libNVVM
     "nvidia-cuda-runtime-cu12",
@@ -37,7 +37,7 @@ cu12 = [
 # TODO: Use cuda-toolkit package dependencies - e.g. cuda-toolkit[curand,nvvm,nvrtc]=13.*
 cu13 = [
     "cuda-bindings==13.*",
-    "cuda-core==0.4.0,<0.5.0dev0",
+    "cuda-core>=0.3.2,<1.0.0",
     "cuda-python==13.*",
     "nvidia-nvvm==13.*",
     "nvidia-cuda-runtime==13.*",


### PR DESCRIPTION
Requested by nvshmem4py release.