### PR TITLE
[CI] Run PR workflow on merge to main

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - "pull-request/[0-9]+"
+      - "main"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}


### PR DESCRIPTION
Since we don't require branches to be up to date before merge, it would be a good idea to run CI on `main` after a merge. (Issue noted by @cpcloud)

I think this change achieves the intended effect, but someone who knows better than me should take a look :slightly_smiling_face: 