### PR TITLE
Generalize the concurrency group for main merges

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,7 +10,12 @@ on:
       - "main"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  group: >-
+    ${{
+      (github.ref == 'refs/heads/main') &&
+      format('{0}-{1}', github.workflow, github.run_id) ||
+      format('{0}-{1}', github.workflow, github.ref)
+    }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This should ensure all merges to main run to completion while PRs will cancel previous jobs if new commits are pushed.