### PR TITLE
chore(docs): format types docs

### DIFF
--- a/docs/source/reference/types.rst
+++ b/docs/source/reference/types.rst
@@ -119,40 +119,51 @@ A number of math intrinsics that utilizes the device native computing feature
 on ``bfloat16`` are provided:
 
 .. function:: numba.cuda.bf16.htrunc(b)
+
     Round ``b`` to the nearest integer value that does not exceed ``b`` in magnitude.
 
 .. function:: numba.cuda.bf16.hceil(b)
+
     Compute the smallest integer value not less than ``b``.
 
 .. function:: numba.cuda.bf16.hfloor(b)
+
     Calculate the largest integer value which is less than or equal to ``b``.
 
 .. function:: numba.cuda.bf16.hrint(b)
+
     Round ``b`` to the nearest integer value in nv_bfloat16 floating-point format,
     with halfway cases rounded to the nearest even integer value.
 
 .. function:: numba.cuda.bf16.hsqrt(b)
+
     Calculates bfloat16 square root of input ``b`` in round-to-nearest-even mode.
 
 .. function:: numba.cuda.bf16.hrsqrt(b)
+
     Calculates bfloat16 reciprocal square root of input ``b`` in round-to-nearest-even mode.
 
 .. function:: numba.cuda.bf16.hrcp(b)
+
    Calculates bfloat16 reciprocal of input a in round-to-nearest-even mode.
 
 .. function:: numba.cuda.bf16.hlog(b)
+
     Calculates bfloat16 natural logarithm of input ``b`` in round-to-nearest-even
     mode.
 
 .. function:: numba.cuda.bf16.hlog2(b)
+
     Calculates bfloat16 binary logarithm (base-2) of input ``b`` in
     round-to-nearest-even mode.
 
 .. function:: numba.cuda.bf16.hlog10(b)
+
     Calculates bfloat16 common logarithm (base-10) of input ``b`` in
     round-to-nearest-even mode.
 
 .. function:: numba.cuda.bf16.hcos(b)
+
     Calculates bfloat16 cosine of input ``b`` in round-to-nearest-even mode.
 
 .. note::
@@ -162,6 +173,7 @@ on ``bfloat16`` are provided:
     into an intrinsic __cosf(float), which has less accurate numeric behavior.
 
 .. function:: numba.cuda.bf16.hsin(b)
+
     Calculates bfloat16 sine of input ``b`` in round-to-nearest-even mode.
 
 .. note::
@@ -170,9 +182,11 @@ on ``bfloat16`` are provided:
     into an intrinsic __sinf(float), which has less accurate numeric behavior.
 
 .. function:: numba.cuda.bf16.htanh(b)
+
     Calculates bfloat16 hyperbolic tangent function: ``tanh(b)`` in round-to-nearest-even mode.
 
 .. function:: numba.cuda.bf16.htanh_approx(b)
+
     Calculates approximate bfloat16 hyperbolic tangent function: ``tanh(b)``.
     This operation uses HW acceleration on devices of compute capability 9.x and higher.
 
@@ -182,14 +196,17 @@ on ``bfloat16`` are provided:
     tanh_approx(nan)    returns nan
 
 .. function:: numba.cuda.bf16.hexp(b)
+
     Calculates bfloat16 natural exponential function of input ``b`` in
     round-to-nearest-even mode.
 
 .. function:: numba.cuda.bf16.hexp2(b)
+
     Calculates bfloat16 binary exponential function of input ``b`` in
     round-to-nearest-even mode.
 
 .. function:: numba.cuda.bf16.hexp10(b)
+
     Calculates bfloat16 decimal exponential function of input ``b`` in
     round-to-nearest-even mode.
 


### PR DESCRIPTION
Fixes `Math Intrinsics` [docs](https://nvidia.github.io/numba-cuda/reference/types.html#math-intrinsics) format.

Long term, it'd be nice to have some docs linters in CI. (Though I noticed the common linters (sphinx-lint, doc8) don't catch all style issues like missing blank lines)