### PR TITLE
chore: clean up dead workaround for unavailable `lru_cache`

### DIFF
--- a/numba_cuda/numba/cuda/cudadrv/devicearray.py
+++ b/numba_cuda/numba/cuda/cudadrv/devicearray.py
@@ -27,13 +27,6 @@ from numba.cuda.api_util import prepare_shape_strides_dtype
 from numba.cuda.core.errors import NumbaPerformanceWarning
 from warnings import warn
 
-try:
-    lru_cache = getattr(functools, "lru_cache")(None)
-except AttributeError:
-    # Python 3.1 or lower
-    def lru_cache(func):
-        return func
-
 
 def is_cuda_ndarray(obj):
     "Check if an object is a CUDA ndarray"
@@ -510,7 +503,7 @@ class DeviceRecord(DeviceNDArrayBase):
             stream.synchronize()
 
 
-@lru_cache
+@functools.lru_cache
 def _assign_kernel(ndim):
     """
     A separate method so we don't need to compile code every assignment (!).


### PR DESCRIPTION
Remove a workaround that has not been needed since Python 3.2