### PR TITLE
Fix pointer APIs

### DIFF
--- a/numba_cuda/numba/cuda/api.py
+++ b/numba_cuda/numba/cuda/api.py
@@ -47,7 +47,7 @@ def from_cuda_array_interface(desc, owner=None, sync=True):
 
     cudevptr_class = driver.binding.CUdeviceptr
     devptr = cudevptr_class(desc["data"][0])
-    data = driver.MemoryPointer(devptr, size=size, owner=owner)
+    data = driver._MemoryPointer(devptr, size=size, owner=owner)
     stream_ptr = desc.get("stream", None)
     if stream_ptr is not None:
         stream = external_stream(stream_ptr)

--- a/numba_cuda/numba/cuda/cudadrv/devicearray.py
+++ b/numba_cuda/numba/cuda/cudadrv/devicearray.py
@@ -108,7 +108,7 @@ class DeviceNDArrayBase(_devicearray.DeviceArray):
         else:
             # Make NULL pointer for empty allocation
             null = _driver.binding.CUdeviceptr(0)
-            gpu_data = _driver.MemoryPointer(pointer=null, size=0)
+            gpu_data = _driver._MemoryPointer(pointer=null, size=0)
             self.alloc_size = 0
 
         self.gpu_data = gpu_data

--- a/numba_cuda/numba/cuda/tests/cudadrv/test_cuda_memory.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_cuda_memory.py
@@ -87,13 +87,13 @@ class TestCudaMemory(CUDATestCase):
             dtor_invoked[0] += 1
 
         # Ensure finalizer is called when pointer is deleted
-        ptr = driver.MemoryPointer(pointer=fake_ptr, size=40, finalizer=dtor)
+        ptr = driver._MemoryPointer(pointer=fake_ptr, size=40, finalizer=dtor)
         self.assertEqual(dtor_invoked[0], 0)
         del ptr
         self.assertEqual(dtor_invoked[0], 1)
 
         # Ensure removing derived pointer doesn't call finalizer
-        ptr = driver.MemoryPointer(pointer=fake_ptr, size=40, finalizer=dtor)
+        ptr = driver._MemoryPointer(pointer=fake_ptr, size=40, finalizer=dtor)
         owned = ptr.own()
         del owned
         self.assertEqual(dtor_invoked[0], 1)

--- a/numba_cuda/numba/cuda/tests/cudadrv/test_emm_plugins.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_emm_plugins.py
@@ -58,7 +58,7 @@ if not config.ENABLE_CUDASIM:
             # We use an AutoFreePointer so that the finalizer will be run when
             # the reference count drops to zero.
             ptr = ctypes.c_void_p(alloc_count)
-            return cuda.cudadrv.driver.AutoFreePointer(
+            return cuda.cudadrv.driver._AutoFreePointer(
                 ptr, size, finalizer=finalizer
             )
 


### PR DESCRIPTION
Public APIs were modified in #536, creating knock-on effects for users of the [External Memory Management plugin interface](https://nvidia.github.io/numba-cuda/user/external-memory.html) - e.g. Arrow and RMM. See e.g. https://github.com/apache/arrow/pull/48259/files#diff-d57b920879b21c3290244b0fe8cfee56c2581fe9b8e9d7792fead53801d51383

This PR restores the public APIs and replaces the usage of the new APIs with no `context` parameter with internal APIs prefixed by an underscore.

cc @pitrou