### PR TITLE
Revert #536 "perf: remove context threading in various pointer abstractions"

### DIFF
--- a/numba_cuda/numba/cuda/api.py
+++ b/numba_cuda/numba/cuda/api.py
@@ -21,6 +21,7 @@ current_context = devices.get_context
 gpus = devices.gpus
 
 
+@require_context
 def from_cuda_array_interface(desc, owner=None, sync=True):
     """Create a DeviceNDArray from a cuda-array-interface description.
     The ``owner`` is the owner of the underlying memory.
@@ -47,7 +48,9 @@ def from_cuda_array_interface(desc, owner=None, sync=True):
 
     cudevptr_class = driver.binding.CUdeviceptr
     devptr = cudevptr_class(desc["data"][0])
-    data = driver.MemoryPointer(devptr, size=size, owner=owner)
+    data = driver.MemoryPointer(
+        current_context(), devptr, size=size, owner=owner
+    )
     stream_ptr = desc.get("stream", None)
     if stream_ptr is not None:
         stream = external_stream(stream_ptr)

--- a/numba_cuda/numba/cuda/cudadrv/devicearray.py
+++ b/numba_cuda/numba/cuda/cudadrv/devicearray.py
@@ -108,7 +108,9 @@ class DeviceNDArrayBase(_devicearray.DeviceArray):
         else:
             # Make NULL pointer for empty allocation
             null = _driver.binding.CUdeviceptr(0)
-            gpu_data = _driver.MemoryPointer(pointer=null, size=0)
+            gpu_data = _driver.MemoryPointer(
+                context=devices.get_context(), pointer=null, size=0
+            )
             self.alloc_size = 0
 
         self.gpu_data = gpu_data

--- a/numba_cuda/numba/cuda/tests/cudadrv/test_cuda_memory.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_cuda_memory.py
@@ -87,13 +87,17 @@ class TestCudaMemory(CUDATestCase):
             dtor_invoked[0] += 1
 
         # Ensure finalizer is called when pointer is deleted
-        ptr = driver.MemoryPointer(pointer=fake_ptr, size=40, finalizer=dtor)
+        ptr = driver.MemoryPointer(
+            context=self.context, pointer=fake_ptr, size=40, finalizer=dtor
+        )
         self.assertEqual(dtor_invoked[0], 0)
         del ptr
         self.assertEqual(dtor_invoked[0], 1)
 
         # Ensure removing derived pointer doesn't call finalizer
-        ptr = driver.MemoryPointer(pointer=fake_ptr, size=40, finalizer=dtor)
+        ptr = driver.MemoryPointer(
+            context=self.context, pointer=fake_ptr, size=40, finalizer=dtor
+        )
         owned = ptr.own()
         del owned
         self.assertEqual(dtor_invoked[0], 1)

--- a/numba_cuda/numba/cuda/tests/cudadrv/test_emm_plugins.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_emm_plugins.py
@@ -3,6 +3,7 @@
 
 import ctypes
 import numpy as np
+import weakref
 
 from numba import cuda
 from numba.cuda.core import config
@@ -57,9 +58,10 @@ if not config.ENABLE_CUDASIM:
 
             # We use an AutoFreePointer so that the finalizer will be run when
             # the reference count drops to zero.
+            ctx = weakref.proxy(self.context)
             ptr = ctypes.c_void_p(alloc_count)
             return cuda.cudadrv.driver.AutoFreePointer(
-                ptr, size, finalizer=finalizer
+                ctx, ptr, size, finalizer=finalizer
             )
 
         def initialize(self):


### PR DESCRIPTION
This reverts commit 9a56516cdaf5fe216a3db3db896974e084b4fa23.

This changed the public API of `MemoryPointer` and related classes, and the context that they held was used by Arrow (see https://github.com/apache/arrow/pull/48259#issuecomment-3580532978):

> Numba interop tests fail with:

```
arrow-dev/lib/python3.12/site-packages/pyarrow/tests/test_cuda_numba_interop.py:233:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   TypeError: MemoryPointer.__init__() got multiple values for argument 'pointer'
```

This commit reverts the change, as it was intended to improve performance without changing functionality, but has had a functional change as a side effect. Following the merge of this PR, we should be able to remove some of the `@require_context` decorators with some more targeted changes.