### PR TITLE
ci: pin pixi in ci due to lockfile mismatch in 0.60.0

### DIFF
--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -120,7 +120,7 @@ jobs:
       - name: Setup pixi
         uses: prefix-dev/setup-pixi@fef5c9568ca6c4ff7707bf840ab0692ba3f08293
         with:
-          pixi-version: "0.59.0"
+          pixi-version: "v0.59.0"
           environments: ${{ env.PIXI_ENV }}
           cache: false
       - name: Python tests

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup pixi
         uses: prefix-dev/setup-pixi@fef5c9568ca6c4ff7707bf840ab0692ba3f08293
         with:
-          pixi-version: "0.59.0"
+          pixi-version: "v0.59.0"
           environments: docs
           cache: false
       - name: Docs build

--- a/.github/workflows/simulator-test.yaml
+++ b/.github/workflows/simulator-test.yaml
@@ -105,7 +105,7 @@ jobs:
       - name: Setup pixi
         uses: prefix-dev/setup-pixi@fef5c9568ca6c4ff7707bf840ab0692ba3f08293
         with:
-          pixi-version: "0.59.0"
+          pixi-version: "v0.59.0"
           environments: ${{ env.PIXI_ENV }}
           cache: false
       - name: Python tests


### PR DESCRIPTION
Pin pixi to 0.59.0 due to https://github.com/prefix-dev/pixi/issues/5055.