### PR TITLE
ci: speed up wheel tests

### DIFF
--- a/ci/test_wheel.ps1
+++ b/ci/test_wheel.ps1
@@ -50,6 +50,6 @@ rapids-logger "Show Numba system info"
 python -m numba --sysinfo
 
 rapids-logger "Run Tests"
-python -m pytest -v
+python -m pytest -v -n auto --dist loadscope --loadscope-reorder
 
 popd

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -40,6 +40,6 @@ rapids-logger "Show Numba system info"
 python -m numba --sysinfo
 
 rapids-logger "Run Tests"
-python -m pytest -v
+python -m pytest -v -n auto --dist loadscope --loadscope-reorder
 
 popd

--- a/ci/test_wheel_deps_wheels.sh
+++ b/ci/test_wheel_deps_wheels.sh
@@ -31,6 +31,6 @@ apt remove --purge `dpkg --get-selections | grep cuda-nvvm | awk '{print $1}'` -
 apt remove --purge `dpkg --get-selections | grep cuda-nvrtc | awk '{print $1}'` -y
 
 rapids-logger "Run Tests"
-NUMBA_CUDA_TEST_BIN_DIR=$NUMBA_CUDA_TEST_BIN_DIR python -m pytest -v
+NUMBA_CUDA_TEST_BIN_DIR=$NUMBA_CUDA_TEST_BIN_DIR python -m pytest -v -n auto --dist loadscope --loadscope-reorder
 
 popd


### PR DESCRIPTION
# CI: Run tests in parallel to speed up test runs

## Summary

This PR adds parallel test execution to CI wheel tests using pytest-xdist, significantly reducing test run times by distributing tests across multiple CPU cores.

## Changes

- Updated `ci/test_wheel.ps1` to run pytest with parallel execution flags
- Updated `ci/test_wheel.sh` to run pytest with parallel execution flags
- Updated `ci/test_wheel_deps_wheels.sh` to run pytest with parallel execution flags

All three scripts now use:
- `-n auto`: Automatically detect and use available CPU cores
- `--dist loadscope`: Distribute tests by module scope to workers
- `--loadscope-reorder`: Reorder tests to minimize setup/teardown overhead

## Benefits

- Faster CI test runs by leveraging multi-core execution
- More efficient use of CI infrastructure
- Reduced wait times for test feedback
