### PR TITLE
refactor: cull dead linker objects

### DIFF
--- a/numba_cuda/numba/cuda/codegen.py
+++ b/numba_cuda/numba/cuda/codegen.py
@@ -247,7 +247,7 @@ class CUDACodeLibrary(serialize.ReduceMixin, CodeLibrary):
 
         cc = self._ensure_cc(cc)
 
-        linker = driver._Linker.new(
+        linker = driver._Linker(
             max_registers=self._max_registers,
             cc=cc,
             additional_flags=["-ptx"],
@@ -308,7 +308,7 @@ class CUDACodeLibrary(serialize.ReduceMixin, CodeLibrary):
             print(ptx)
             print("=" * 80)
 
-        linker = driver._Linker.new(
+        linker = driver._Linker(
             max_registers=self._max_registers, cc=cc, lto=self._lto
         )
         self._link_all(linker, cc, ignore_nonlto=False)

--- a/numba_cuda/numba/cuda/cudadrv/driver.py
+++ b/numba_cuda/numba/cuda/cudadrv/driver.py
@@ -2326,26 +2326,6 @@ class _Linker:
         self._object_codes = []
         self.linker = None  # need at least one program
 
-    @classmethod
-    def new(
-        cls,
-        max_registers=0,
-        lineinfo=False,
-        cc=None,
-        lto=None,
-        additional_flags=None,
-    ):
-        linker = _Linker
-
-        params = (max_registers, lineinfo, cc)
-        if linker is _Linker:
-            params = (*params, lto, additional_flags)
-        else:
-            if lto or additional_flags:
-                raise ValueError("LTO and additional flags require nvjitlink")
-
-        return linker(*params)
-
     def add_cu_file(self, path):
         cu = cached_file_read(path, how="rb")
         self.add_cu(cu, os.path.basename(path))

--- a/numba_cuda/numba/cuda/memory_management/nrt.py
+++ b/numba_cuda/numba/cuda/memory_management/nrt.py
@@ -127,7 +127,7 @@ class _Runtime:
         cc = get_current_device().compute_capability
 
         # Create a new linker instance and add the cu file
-        linker = _Linker.new(cc=cc, lto=_have_nvjitlink())
+        linker = _Linker(max_registers=0, cc=cc, lto=_have_nvjitlink())
         linker.add_cu_file(memsys_mod)
 
         # Complete the linker and create a module from it

--- a/numba_cuda/numba/cuda/tests/cudadrv/test_linker.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_linker.py
@@ -114,7 +114,7 @@ class TestLinker(CUDATestCase):
     @require_context
     def test_linker_basic(self):
         """Simply go through the constructor and destructor"""
-        linker = _Linker.new(cc=(7, 5))
+        linker = _Linker(max_registers=0, cc=(7, 5))
         del linker
 
     def _test_linking(self, eager):
@@ -332,7 +332,7 @@ class TestLinker(CUDATestCase):
 
     @skip_if_nvjitlink_missing("nvJitLink not installed or new enough (>12.3)")
     def test_link_for_different_cc(self):
-        linker = _Linker.new(cc=(7, 5), lto=True)
+        linker = _Linker(max_registers=0, cc=(7, 5), lto=True)
         code = """
 __device__ int foo(int x) {
     return x + 1;


### PR DESCRIPTION
Remove the ctypes linker and inline `_LinkerBase` methods since there is only a single linker class now.

Also removes `_Linker.new` since it is now redundant with the class's `__init__` method.