### PR TITLE
test: fix bogus `self` argument to `Context`

### DIFF
--- a/numba_cuda/numba/cuda/tests/cudadrv/test_context_stack.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_context_stack.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import numbers
-import weakref
 
 from numba import cuda
 from numba.cuda.testing import unittest, CUDATestCase, skip_on_cudasim
@@ -90,7 +89,7 @@ class Test3rdPartyContext(CUDATestCase):
         dev = driver.binding.CUdevice(0)
         binding_hctx = the_driver.cuDevicePrimaryCtxRetain(dev)
         hctx = driver.drvapi.cu_context(int(binding_hctx))
-        ctx = driver.Context(weakref.proxy(self), hctx)
+        ctx = driver.Context(dev, hctx)
         try:
             ctx.push()
             # Check that the context from numba matches the created primary


### PR DESCRIPTION
Corrects a test that breaks when you start mucking around with `Context` internals. I am experimenting with replacing the guts of `MemoryPointer` with a `cuda.core` `Buffer` implementation, and this came up.