### PR TITLE
feat: add print support for int64 tuples

### DIFF
--- a/numba_cuda/numba/cuda/printimpl.py
+++ b/numba_cuda/numba/cuda/printimpl.py
@@ -32,6 +32,20 @@ def print_item(ty, context, builder, val):
     )
 
 
+@print_item.register(types.UniTuple)
+def tuple_print_impl(ty, context, builder, val):
+    if ty.dtype != types.int64:
+        raise NotImplementedError(
+            "printing unimplemented for tuples with elements of type %s" % (ty,)
+        )
+
+    nelements = val.type.count
+    argsfmt = ", ".join(["%lld"] * nelements)
+    rawfmt = f"({argsfmt})"
+    values = [builder.extract_value(val, i) for i in range(nelements)]
+    return rawfmt, values
+
+
 @print_item.register(types.Integer)
 @print_item.register(types.IntegerLiteral)
 def int_print_impl(ty, context, builder, val):

--- a/numba_cuda/numba/cuda/tests/cudapy/test_print.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_print.py
@@ -117,6 +117,17 @@ print_bfloat16[1, 1]()
 cuda.synchronize()
 """
 
+print_int64_tuple_usecase = """\
+from numba import cuda
+
+@cuda.jit
+def print_tuple(tup):
+    print(tup)
+
+print_tuple[1, 1]((1, 2, 3, 4, 5))
+cuda.synchronize()
+"""
+
 
 class TestPrint(CUDATestCase):
     # Note that in these tests we generally strip the output to avoid dealing
@@ -162,6 +173,12 @@ class TestPrint(CUDATestCase):
         lines = [line.strip() for line in output.splitlines(True)]
         expected = [str(i) for i in np.ndindex(2, 2, 2)]
         self.assertEqual(sorted(lines), expected)
+
+    def test_tuple(self):
+        output, _ = self.run_code(print_int64_tuple_usecase)
+        lines = [line.strip() for line in output.splitlines(True)]
+        expected = ["(1, 2, 3, 4, 5)"]
+        self.assertEqual(lines, expected)
 
     @skip_on_cudasim("bfloat16 on host is not yet supported.")
     def test_bfloat16(self):


### PR DESCRIPTION
Add support for printing tuples of int64. This is useful for printing array shapes in kernels.