### PR TITLE
Remove dangling references to NUMBA_CUDA_ENABLE_MINOR_VERSION_COMPATIBILITY

### DIFF
--- a/numba_cuda/numba/cuda/core/config.py
+++ b/numba_cuda/numba/cuda/core/config.py
@@ -494,10 +494,6 @@ class _EnvReloader(object):
             "NUMBA_CUDA_PER_THREAD_DEFAULT_STREAM", int, 0
         )
 
-        CUDA_ENABLE_MINOR_VERSION_COMPATIBILITY = _readenv(
-            "NUMBA_CUDA_ENABLE_MINOR_VERSION_COMPATIBILITY", int, 0
-        )
-
         # Location of the CUDA include files
         if IS_WIN32:
             cuda_path = os.environ.get("CUDA_PATH")

--- a/numba_cuda/numba/cuda/testing.py
+++ b/numba_cuda/numba/cuda/testing.py
@@ -276,14 +276,6 @@ def skip_if_curand_kernel_missing(fn):
     return unittest.skipUnless(curand_kernel_h_file, reason)(fn)
 
 
-def skip_if_mvc_enabled(reason):
-    """Skip a test if Minor Version Compatibility is enabled"""
-    assert isinstance(reason, str)
-    return unittest.skipIf(
-        config.CUDA_ENABLE_MINOR_VERSION_COMPATIBILITY, reason
-    )
-
-
 def cc_X_or_above(major, minor):
     if not config.ENABLE_CUDASIM:
         cc = devices.get_context().device.compute_capability


### PR DESCRIPTION
Removes some outdated CUDA 11 related MVC code, this PR removes it. 