### PR TITLE
Pass the -numba-debug flag to libnvvm

### DIFF
--- a/numba_cuda/numba/cuda/cudadrv/nvvm.py
+++ b/numba_cuda/numba/cuda/cudadrv/nvvm.py
@@ -312,7 +312,7 @@ class CompilationUnit(object):
 
             return f"-{k}={v}".encode("utf-8")
 
-        debug_build = 'g' in options
+        debug_build = "g" in options
         options = [stringify_option(k, v) for k, v in options.items()]
 
         # If the -numba-debug option is supported by libnvvm, pass it to the


### PR DESCRIPTION
When using the CUDA Toolkit release 13.1 or later for debug builds, we need to pass the -numba-debug flag to libnvvm in order to enable enhanced debug information.

Closes #679
