### PR TITLE
perf: Reduce copy overhead in inline passes

### DIFF
--- a/numba_cuda/numba/cuda/core/inline_closurecall.py
+++ b/numba_cuda/numba/cuda/core/inline_closurecall.py
@@ -340,16 +340,27 @@ class InlineWorker:
         instance was initialized with a typemap and calltypes then they will be
         appropriately updated based on the arg_typs.
         """
-        # save a reference to the unmutated input callee_ir to         # return
+        # save a reference to the unmutated input callee_ir to return
         callee_ir_original = callee_ir
 
         # Always copy the callee IR, it gets mutated
         def copy_ir(the_ir):
             kernel_copy = the_ir.copy()
-            kernel_copy.blocks = {
-                block_label: copy.deepcopy(block)
-                for block_label, block in the_ir.blocks.items()
-            }
+            kernel_copy.blocks = {}
+            for block_label, block in the_ir.blocks.items():
+                new_block = block.copy()
+
+                # All tests pass on my machine without an extra shallow copy
+                # of statements in the block body. I'll leave the
+                # statement-copy commented until the PR is finalised in case
+                # it proves to be unsafe.
+
+                # new_body = block.body
+                # for idx, stmt in enumerate(new_block.body):
+                #     new_body[idx] = copy.copy(stmt)
+                # new_block.body = new_body
+
+                kernel_copy.blocks[block_label] = new_block
             return kernel_copy
 
         callee_ir = copy_ir(callee_ir)

--- a/numba_cuda/numba/cuda/core/inline_closurecall.py
+++ b/numba_cuda/numba/cuda/core/inline_closurecall.py
@@ -340,30 +340,21 @@ class InlineWorker:
         `func.__code__.co_freevars`. If `arg_typs` is given and the InlineWorker
         instance was initialized with a typemap and calltypes then they will be
         appropriately updated based on the arg_typs. If `preserve_ir` is
-        True, the callee_ir object will copied before mutating, otherwise it
+        True, the callee_ir object will be copied before mutating, otherwise it
         will be mutated in place.
         """
         # Save a reference to the incoming callee_ir
         callee_ir_original = callee_ir
 
-        # Copy the IR if it should be preserved.
+        # When preserve_ir is True, create a copy of the FunctionIR object
+        # to mutate. Set preserve_ir to False if callee_ir does not persist
+        # between calls to inline_ir.
         if preserve_ir:
             def copy_ir(the_ir):
                 kernel_copy = the_ir.copy()
                 kernel_copy.blocks = {}
                 for block_label, block in the_ir.blocks.items():
-                    new_block = block.copy()
-
-                    # All tests pass on my machine without an extra shallow copy
-                    # of statements in the block body. I'll leave the
-                    # statement-copy commented until the PR is finalised in case
-                    # it proves to be unsafe.
-
-                    # new_body = block.body
-                    # for idx, stmt in enumerate(new_block.body):
-                    #     new_body[idx] = copy.copy(stmt)
-                    # new_block.body = new_body
-
+                    new_block = copy.deepcopy(the_ir.blocks[block_label])
                     kernel_copy.blocks[block_label] = new_block
                 return kernel_copy
 
@@ -373,7 +364,6 @@ class InlineWorker:
         # inlined if a validator is present
         if self.validator is not None:
             self.validator(callee_ir)
-
 
         scope = block.scope
         instr = block.body[i]

--- a/numba_cuda/numba/cuda/core/inline_closurecall.py
+++ b/numba_cuda/numba/cuda/core/inline_closurecall.py
@@ -340,6 +340,8 @@ class InlineWorker:
         instance was initialized with a typemap and calltypes then they will be
         appropriately updated based on the arg_typs.
         """
+        # save a reference to the unmutated input callee_ir to         # return
+        callee_ir_original = callee_ir
 
         # Always copy the callee IR, it gets mutated
         def copy_ir(the_ir):
@@ -357,8 +359,7 @@ class InlineWorker:
         if self.validator is not None:
             self.validator(callee_ir)
 
-        # save an unmutated copy of the callee_ir to return
-        callee_ir_original = copy_ir(callee_ir)
+
         scope = block.scope
         instr = block.body[i]
         call_expr = instr.value

--- a/numba_cuda/numba/cuda/core/inline_closurecall.py
+++ b/numba_cuda/numba/cuda/core/inline_closurecall.py
@@ -331,39 +331,43 @@ class InlineWorker:
         self.calltypes = calltypes
 
     def inline_ir(
-        self, caller_ir, block, i, callee_ir, callee_freevars, arg_typs=None
+        self, caller_ir, block, i, callee_ir, callee_freevars,
+        arg_typs=None, preserve_ir=True,
     ):
         """Inlines the callee_ir in the caller_ir at statement index i of block
         `block`, callee_freevars are the free variables for the callee_ir. If
         the callee_ir is derived from a function `func` then this is
         `func.__code__.co_freevars`. If `arg_typs` is given and the InlineWorker
         instance was initialized with a typemap and calltypes then they will be
-        appropriately updated based on the arg_typs.
+        appropriately updated based on the arg_typs. If `preserve_ir` is
+        True, the callee_ir object will copied before mutating, otherwise it
+        will be mutated in place.
         """
-        # save a reference to the unmutated input callee_ir to return
+        # Save a reference to the incoming callee_ir
         callee_ir_original = callee_ir
 
-        # Always copy the callee IR, it gets mutated
-        def copy_ir(the_ir):
-            kernel_copy = the_ir.copy()
-            kernel_copy.blocks = {}
-            for block_label, block in the_ir.blocks.items():
-                new_block = block.copy()
+        # Copy the IR if it should be preserved.
+        if preserve_ir:
+            def copy_ir(the_ir):
+                kernel_copy = the_ir.copy()
+                kernel_copy.blocks = {}
+                for block_label, block in the_ir.blocks.items():
+                    new_block = block.copy()
 
-                # All tests pass on my machine without an extra shallow copy
-                # of statements in the block body. I'll leave the
-                # statement-copy commented until the PR is finalised in case
-                # it proves to be unsafe.
+                    # All tests pass on my machine without an extra shallow copy
+                    # of statements in the block body. I'll leave the
+                    # statement-copy commented until the PR is finalised in case
+                    # it proves to be unsafe.
 
-                # new_body = block.body
-                # for idx, stmt in enumerate(new_block.body):
-                #     new_body[idx] = copy.copy(stmt)
-                # new_block.body = new_body
+                    # new_body = block.body
+                    # for idx, stmt in enumerate(new_block.body):
+                    #     new_body[idx] = copy.copy(stmt)
+                    # new_block.body = new_body
 
-                kernel_copy.blocks[block_label] = new_block
-            return kernel_copy
+                    kernel_copy.blocks[block_label] = new_block
+                return kernel_copy
 
-        callee_ir = copy_ir(callee_ir)
+            callee_ir = copy_ir(callee_ir)
 
         # check that the contents of the callee IR is something that can be
         # inlined if a validator is present
@@ -480,7 +484,8 @@ class InlineWorker:
         callee_ir = self.run_untyped_passes(function)
         freevars = function.__code__.co_freevars
         return self.inline_ir(
-            caller_ir, block, i, callee_ir, freevars, arg_typs=arg_typs
+            caller_ir, block, i, callee_ir, freevars,
+            arg_typs=arg_typs, preserve_ir=False,
         )
 
     def run_untyped_passes(self, func, enable_ssa=False):


### PR DESCRIPTION
### PR description

This PR contains changes to the InlineWorker called during the `InlineInlinables` and `InlineOverloads` passes. The `inline_ir` method accepts a `callee_ir` FunctionIR object, which is deepcopied for safety before being mutated. The deepcopy operation is taxing in kernels with many large nested inlined device functions. Further information, including compile time results, is available in #688.

This PR contains two changes to the safety-copy portion of the `inline_ir` method and it's call site in `inline_function`.

1. The `callee_ir` object was copied once to create a mutable version, then that mutable copy was copied again to preserve the original. 4279abd saves a reference to the incoming `callee_ir` on entry, then copies this for the mutable copy, saving one copy operation. This affords a ~40% performance improvement for the same outcome.
```diff
+       # save a reference to the unmutated input callee_ir to         # return
+       callee_ir_original = callee_ir

        # Always copy the callee IR, it gets mutated
        def copy_ir(the_ir):
            kernel_copy = the_ir.copy()
            kernel_copy.blocks = {}
            for block_label, block in the_ir.blocks.items():
                new_block = copy.deepcopy(the_ir.blocks[block_label])
                kernel_copy.blocks[block_label] = new_block
            return kernel_copy

        callee_ir = copy_ir(callee_ir)

        # check that the contents of the callee IR is something that can be
        # inlined if a validator is present
        if self.validator is not None:
            self.validator(callee_ir)

-       # save an unmutated copy of the callee_ir to return
-       callee_ir_original = copy_ir(callee_ir)
```

2. In the `InlineInlinables` pass, `inline_ir` is called from the `inline_function` entry point. `inline_function` runs all untyped passes on the function to be inlined, generating a new `callee_ir` object per inline. The preserved unmutated `callee_ir_original` is returned, but never consumed. There is therefore no need to preserve the unmutated `callee_ir` object when entering from `inline_function`. 893d8a8 adds a `preserve_ir=True` argument to `inline_ir` and calls it with `preserve_ir=False`. 

`inline_ir` is also called from the `InlineOverload` pass, which does keep and reuse `callee_ir`. This (and all future) entry points fall back to the default `persist_ir=True` argument, so the provided ir is not mutated.

```diff
 # Copy the IR if it should be preserved.
+       if preserve_ir:
            def copy_ir(the_ir):
                kernel_copy = the_ir.copy()
            kernel_copy.blocks = {}
            for block_label, block in the_ir.blocks.items():
                new_block = copy.deepcopy(the_ir.blocks[block_label])
                kernel_copy.blocks[block_label] = new_block
            return kernel_copy
            callee_ir = copy_ir(callee_ir)

```

### Tests
No tests have been added, as I'm not sure what would change except for performance if this test regressed. All tests in the numba-cuda suite pass, as do regression tests for ir mutation in numba's test_ir_inlining suite. 