### PR TITLE
fix: Fix race condition in CUDA Simulator

### DIFF
--- a/numba_cuda/numba/cuda/simulator/kernelapi.py
+++ b/numba_cuda/numba/cuda/simulator/kernelapi.py
@@ -5,6 +5,7 @@
 Implements the cuda module as called from within an executing kernel
 (@cuda.jit-decorated function).
 """
+
 from collections import defaultdict
 from contextlib import contextmanager
 import sys
@@ -490,14 +491,17 @@ class FakeCUDAModule(object):
 
         raise RuntimeError("Global grid has 1-3 dimensions. %d requested" % n)
 
+
 _locks_register_lock = threading.Lock()
 _globals_locks = defaultdict(threading.Lock)
 _swap_refcount = defaultdict(int)
 _swap_orig = {}
 
+
 @contextmanager
 def swapped_cuda_module(fn, fake_cuda_module):
     from numba import cuda
+
     fn_globs = fn.__globals__
     gid = id(fn_globs)
 


### PR DESCRIPTION
## Description
There is a race condition in the CUDA simulator, specifically in the `swapped_cuda_module` context manager. 

I use the simulator for quick-running CI to avoid using up precious free GPU minutes. Occasionally, I get this error:
```
AttributeError: tid=[0, 13, 0] ctaid=[0, 0, 0]: module 'numba.cuda' has no attribute 'local'
```
It is raised from a different thread each time. The error arose more commonly after I began allocating arrays in a small helper function in its own module. The error is similar to the one raised in numba/numba#1844.

Each thread in the simulator is a `threading.Thread` object, so they share memory. Every time a device function is called, it is wrapped in this context manager:

https://github.com/NVIDIA/numba-cuda/blob/aff41e9e7ad2bc9fa54afaadf75dc58d505f7852/numba_cuda/numba/cuda/simulator/kernelapi.py#L494-L509

### Race:
Thread A and Thread B are executing device functions in the same python module. They don't need to be the same function. They must be in a separate file from the kernel definition, as the kernel replaces references on entry, run all threads, and restores only after all threads have exited.

1. Thread A launches and swaps numba.cuda for fake_cuda, yields.
2. Thread B launches and gets `orig = {}` and `repl = {}`, as no references to cuda exist in it's `__globals__` dict. Thread B yields.
3. Thread A exits, replacing fake_cuda with numba.cuda
4. Thread B calls e.g. `cuda.local.array`, and sees replaced reference to numba.cuda. `local` is not imported as part of numba.cuda when `NUMBA_ENABLE_CUDASIM==1`, so the error is thrown.

### MWE
The Gist below contains a script that reliably causes the error on my machine. It takes ~200s to hit the race on my machine, typically, so I have not added it to the test suite. It does seem to fail faster on xdist, but it has a very long runtime when it doesn't fail.

[Reproducer](https://gist.github.com/ccam80/0bc71bf30a088f0c23a4b08b2397b738)
Place all three files in the same directory, and run `cudasim_race_mwe`.

### Fix
This PR implements a per-module lock and reference count, so that the first entrance to the context for a module replaces cuda -> fake_cuda, and the last thread to exit restores fake_cuda -> cuda. There may be a performance hit associated for simulated kernels with many device function calls from many modules, but this should be small, as all threads except for the first entrant and last exit perform a single integer comparison and increment/decrement an integer counter under the lock. The short "benchmark" run in the MWE did not change duration between the patched and unpatched versions on my machine. 

```python
@contextmanager
def swapped_cuda_module(fn, fake_cuda_module):
    from numba import cuda
    fn_globs = fn.__globals__
    gid = id(fn_globs)

    # Use a lock per-modules to avoid cross-locking other modules
    lock = _globals_locks[gid]

    with lock:
        # Scan and replace globals with fake module on first entrance only
        if _swap_refcount[gid] == 0:
            orig = {k: v for k, v in fn_globs.items() if v is cuda}
            _swap_orig[gid] = orig
            for k in orig:
                fn_globs[k] = fake_cuda_module

        # Increment the reference counter on every entrance
        _swap_refcount[gid] += 1
    try:
        yield
    finally:
        with lock:
            # Decrement "number of modules using fake CUDA" counter on exit
            _swap_refcount[gid] -= 1

            # Last thread to leave the context restores real cuda
            if _swap_refcount[gid] == 0:
                fn_globs.update(_swap_orig.pop(gid))
                del _swap_refcount[gid]
                del _globals_locks[gid]
```
