### PR TITLE
Fix `test_wheel_deps_wheels.sh` to actually uninstall `nvvm` and `nvrtc` packages for CUDA 13

### DIFF
--- a/ci/test_wheel_deps_wheels.sh
+++ b/ci/test_wheel_deps_wheels.sh
@@ -29,8 +29,13 @@ python -m numba --sysinfo
 nvvm_pkgs=$(dpkg --get-selections | awk '/nvvm/ {print $1}')
 nvrtc_pkgs=$(dpkg --get-selections | awk '/nvrtc/ {print $1}')
 
-if [[ -z "$nvvm_pkgs" || -z "$nvrtc_pkgs" ]]; then
-    echo "Expected both nvvm and nvrtc packages to be present, but at least one was missing"
+if [[ -z "$nvvm_pkgs" ]]; then
+    echo "Error: expected to remove nvvm packages but didn't find any installed"
+    exit 1
+fi
+
+if [[ -z "$nvrtc_pkgs" ]]; then
+    echo "Error: expected to remove nvrtc packages but didn't find any installed"
     exit 1
 fi
 


### PR DESCRIPTION
Xref https://github.com/NVIDIA/numba-cuda/pull/699