### PR TITLE
chore: disable `locked` flag to bypass https://github.com/prefix-dev/pixi/issues/5256

### DIFF
--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -123,6 +123,7 @@ jobs:
           pixi-version: "v0.62.2"
           environments: ${{ env.PIXI_ENV }}
           cache: false
+          locked: false
       - name: Python tests
         run: ${{ inputs.script }}
         env:

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -31,6 +31,7 @@ jobs:
           pixi-version: "v0.62.2"
           environments: docs
           cache: false
+          locked: false
       - name: Docs build
         run: pixi run -e docs build-docs
         env:

--- a/.github/workflows/simulator-test.yaml
+++ b/.github/workflows/simulator-test.yaml
@@ -108,6 +108,7 @@ jobs:
           pixi-version: "v0.62.2"
           environments: ${{ env.PIXI_ENV }}
           cache: false
+          locked: false
       - name: Python tests
         run: ${{ inputs.script }}
         env:


### PR DESCRIPTION
Temporary workaround to get CI passing