### PR TITLE
Adding `pixi run test` and `pixi run test-par` support

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -4679,35 +4679,71 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45-default_hfdba357_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45-default_h4852527_105.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cccl-3.1.4-hd4ab2ea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py314h4a8dc5f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-bindings-13.1.1-py314ha0b5721_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cccl-13.1.115-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-64-13.1.115-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-core-0.5.0-cuda13_py314h025f531_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-64-13.1.115-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-crt-tools-13.1.115-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-13.1.80-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-dev-13.1.80-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-64-13.1.80-h376f20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-static-13.1.80-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-64-13.1.80-h376f20c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-64-13.1.80-h376f20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cuobjdump-13.1.115-hffce074_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-64-13.1.80-h376f20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-libraries-13.1.0-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-13.1.115-hcdd1206_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-64-13.1.115-he91c749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-impl-13.1.115-h85509e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-tools-13.1.115-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc_linux-64-13.1.115-hb2fc203_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvdisasm-13.1.115-hffce074_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvrtc-13.1.80-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-impl-13.1.80-h4bc722e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-13.1.115-h69a702a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-64-13.1.115-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-impl-13.1.115-h4bc722e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-tools-13.1.115-h4bc722e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-opencl-13.1.80-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-pathfinder-1.3.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-python-13.1.1-pyhc455866_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-runtime-13.1.0-ha804496_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-13.1-h2ff5cdb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-hc5723f1_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-15.2.0-h862fb80_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-hda75c37_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-15.2.0-h2d7d49d_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.16-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_105.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-5_h4a7cf45_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-h3ff7636_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-5_h0358290_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcublas-13.2.0.9-h676940d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcufft-12.1.0.31-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-1.16.0.49-hd07211c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-10.4.1.34-h676940d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcusolver-12.0.7.41-h676940d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcusparse-12.7.2.19-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.3-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_116.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_16.conda
@@ -4715,10 +4751,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnpp-13.0.2.21-h676940d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvfatbin-13.1.80-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvjitlink-13.1.80-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvjpeg-13.0.2.28-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvptxcompiler-dev-13.1.115-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-64-13.1.115-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.2.0-h90f66d4_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.2-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_116.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
@@ -4729,6 +4772,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.63.1-py314h8169c2f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.3.5-py314h2b28147_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2025.06.13-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.0-h26f9b46_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.1-pyhcf101f3_0.conda
@@ -4747,6 +4792,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-60.0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_ha0e22de_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -4763,35 +4809,70 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/arm-variant-1.2.0-sbsa.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45-default_h5f4c503_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.45-default_hf1166c9_105.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cccl-3.1.4-h9248bf7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cffi-2.0.0-py314h0bd77cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-bindings-13.1.1-py314h91eeaa4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cccl-13.1.115-h579c4fd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-aarch64-13.1.115-h579c4fd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-core-0.5.0-cuda13_py314hd7bf176_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-aarch64-13.1.115-h579c4fd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-crt-tools-13.1.115-h579c4fd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-13.1.80-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-dev-13.1.80-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-aarch64-13.1.80-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-static-13.1.80-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-aarch64-13.1.80-h8f3c8d4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-aarch64-13.1.80-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cuobjdump-13.1.115-h2079400_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-aarch64-13.1.80-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-libraries-13.1.0-h8af1aa0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-13.1.115-ha346c71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-aarch64-13.1.115-h4310d6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-impl-13.1.115-h614329b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-tools-13.1.115-h614329b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc_linux-aarch64-13.1.115-h9ee44f0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvdisasm-13.1.115-h40ab4d6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvrtc-13.1.80-h8f3c8d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-impl-13.1.80-h7b14b0b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-13.1.115-he9431aa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-aarch64-13.1.115-h579c4fd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-impl-13.1.115-h7b14b0b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-tools-13.1.115-h7b14b0b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-pathfinder-1.3.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-python-13.1.1-pyhc455866_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-runtime-13.1.0-ha804496_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-13.1-h2ff5cdb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-15.2.0-habb1d5c_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-15.2.0-h0139441_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-15.2.0-h03e2352_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-15.2.0-ha9de7cb_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.2-hb1525cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.16-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45-default_h1979696_105.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.11.0-5_haddc8a3_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.77-h68e9139_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.11.0-5_hd72aa62_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcublas-13.2.0.9-he38c790_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcufft-12.1.0.31-h8f3c8d4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcufile-1.16.0.49-hbf501ad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurand-10.4.1.34-he38c790_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcusolver-12.0.7.41-he38c790_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcusparse-12.7.2.19-h8f3c8d4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.7.3-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-hd65408f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h55c397f_116.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_16.conda
@@ -4800,10 +4881,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.1-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmpdec-4.0.0-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnl-3.11.0-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnpp-13.0.2.21-he38c790_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvfatbin-13.1.80-h8f3c8d4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvjitlink-13.1.80-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvjpeg-13.0.2.28-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvptxcompiler-dev-13.1.115-h579c4fd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-aarch64-13.1.115-h579c4fd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.30-pthreads_h9d3fd7e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-15.2.0-he19c465_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.51.2-h10b116e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_116.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.10-hf9559e3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.10-hf9559e3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.41.3-h1022ec0_0.conda
@@ -4832,6 +4920,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rdma-core-60.0-he839754_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h561c983_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -4848,15 +4937,39 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-h4c7d964_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cccl-3.1.4-hc38addc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.0.0-py314h5a2d7ad_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-bindings-13.1.1-py314hd8fd7ce_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-cccl-13.1.115-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_win-64-13.1.115-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-core-0.5.0-cuda13_py314hc4d8058_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_win-64-13.1.115-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-crt-tools-13.1.115-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-cudart-13.1.80-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-cudart-dev-13.1.80-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_win-64-13.1.80-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-cudart-static-13.1.80-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_win-64-13.1.80-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_win-64-13.1.80-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-cuobjdump-13.1.115-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-libraries-13.1.0-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvcc-13.1.115-h8f04d04_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_win-64-13.1.115-h36c15f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvcc-impl-13.1.115-h53cbb54_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvcc-tools-13.1.115-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvcc_win-64-13.1.115-hd70436c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvdisasm-13.1.115-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvrtc-13.1.80-hac47afa_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvvm-impl-13.1.80-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvvm-13.1.115-h719f0c7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_win-64-13.1.115-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvvm-impl-13.1.115-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvvm-tools-13.1.115-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-opencl-13.1.80-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-pathfinder-1.3.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-python-13.1.1-pyhc455866_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-runtime-13.1.0-h7428d3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-13.1-h2ff5cdb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
@@ -4865,8 +4978,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/icu-78.2-h637d24d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.16-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/khronos-opencl-icd-loader-2024.10.24-h2466b09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.11.0-5_hf2e6a31_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.11.0-5_h2a3cdd5_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcublas-13.2.0.9-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcufft-12.1.0.31-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurand-10.4.1.34-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcusolver-12.0.7.41-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcusparse-12.7.2.19-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.3-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h52bdfb6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-15.2.0-h8ee18e1_16.conda
@@ -4876,7 +4995,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.11.0-5_hf9ab0e9_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libmpdec-4.0.0-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libnpp-13.0.2.21-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libnvfatbin-13.1.80-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libnvjitlink-13.1.80-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libnvjpeg-13.0.2.28-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libnvptxcompiler-dev-13.1.115-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_win-64-13.1.115-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.51.2-hf5d6505_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_10.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-16-2.15.1-h3cfd58e_1.conda
@@ -4889,6 +5013,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.63.1-py314h36f8cf2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.3.5-py314h06c3c77_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/opencl-headers-2025.06.13-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.0-h725018a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.1-pyhcf101f3_0.conda
@@ -4916,6 +5041,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_34.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.36.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-h7dcff83_34.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/vswhere-3.1.7-h40126e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - conda: .
@@ -5560,6 +5687,13 @@ packages:
   purls: []
   size: 1599680
   timestamp: 1763075766288
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cccl-3.1.4-hd4ab2ea_0.conda
+  sha256: 2bb5b3e0af37a107b266716ecc4a9532c2b09ca24c9b0004f9e27e132f2d3241
+  md5: 7039493ab0a00ae05ba92a1d535b2222
+  license: Apache-2.0 AND BSD-3-Clause AND BSD-2-Clause AND BSL-1.0 AND NCSA AND MIT AND LicenseRef-NVIDIA-Software-License
+  purls: []
+  size: 1601321
+  timestamp: 1765929402443
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cccl-2.1.0-h8af1aa0_2.conda
   sha256: 02dd74b7f043abad2a65032015258fff79eef67c2cf0cd6fb0245b35e7beef21
   md5: e1b3138863a75a5ee437a0ae19d3841f
@@ -5595,6 +5729,13 @@ packages:
   purls: []
   size: 1600534
   timestamp: 1763075408654
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cccl-3.1.4-h9248bf7_0.conda
+  sha256: c4b60ddb88291acaf90b156c5c51fd76bab6ba8c126b150efac52f09a01901fd
+  md5: 5213c6760c7cbb433733b4ac058e8cce
+  license: Apache-2.0 AND BSD-3-Clause AND BSD-2-Clause AND BSL-1.0 AND NCSA AND MIT AND LicenseRef-NVIDIA-Software-License
+  purls: []
+  size: 1602115
+  timestamp: 1765929769848
 - conda: https://conda.anaconda.org/conda-forge/win-64/cccl-2.1.0-h57928b3_2.conda
   sha256: 6a3b65b77bbf9e86992968148a44b208453898ff6ea5e33917d5fc4e5277b09f
   md5: 87256564e83de478aed15df7d9146283
@@ -5630,6 +5771,13 @@ packages:
   purls: []
   size: 1596751
   timestamp: 1763075230093
+- conda: https://conda.anaconda.org/conda-forge/win-64/cccl-3.1.4-hc38addc_0.conda
+  sha256: 56c9fff8639e17ccd3573932bdcc8d9df4f82833611740ae7457d46ec17fc5e7
+  md5: 963a806a0deac764090c03045c31ba6f
+  license: Apache-2.0 AND BSD-3-Clause AND BSD-2-Clause AND BSL-1.0 AND NCSA AND MIT AND LicenseRef-NVIDIA-Software-License
+  purls: []
+  size: 1597895
+  timestamp: 1765929239281
 - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.1.4-pyhd8ed1ab_0.conda
   sha256: 110338066d194a715947808611b763857c15458f8b3b97197387356844af9450
   md5: eacc711330cd46939f66cd401ff9c44b
@@ -6510,6 +6658,17 @@ packages:
   purls: []
   size: 22945
   timestamp: 1757017469187
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cccl-13.1.115-ha770c72_0.conda
+  sha256: 2c9bad2f96d1348451d94d9de68ee922ab1a828e34b8359ad9c46682bd04aee2
+  md5: cf4c9a58c0f03ad6c001ef7bfed9da71
+  depends:
+  - cccl 3.1.4
+  - cuda-cccl_linux-64 13.1.115
+  - cuda-version >=13.1,<13.2.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 23125
+  timestamp: 1768272313063
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cccl-13.1.78-ha770c72_0.conda
   sha256: 013a02aaea1701c57aa1533ba45a1e62953837d6318c295b8fcc0741a28d7988
   md5: d1a4bac6898ce32783881a8bf2108202
@@ -6583,6 +6742,18 @@ packages:
   purls: []
   size: 23090
   timestamp: 1757017469659
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cccl-13.1.115-h579c4fd_0.conda
+  sha256: cda354aea8abfc2a22527e30dfa8ed78d56afe8235b26bad30d9b503126dd76d
+  md5: f021efaf5769a39d5eb00a293762ce07
+  depends:
+  - arm-variant * sbsa
+  - cccl 3.1.4
+  - cuda-cccl_linux-aarch64 13.1.115
+  - cuda-version >=13.1,<13.2.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 23173
+  timestamp: 1768272346066
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cccl-13.1.78-h579c4fd_0.conda
   sha256: 4811229c5499ffa460a035929e2decb78bc7d22ea8c154434811f8da9f9de4a0
   md5: a96e935d222ca52924bb57179a89d8dc
@@ -6650,6 +6821,17 @@ packages:
   purls: []
   size: 23353
   timestamp: 1757017666411
+- conda: https://conda.anaconda.org/conda-forge/win-64/cuda-cccl-13.1.115-h57928b3_0.conda
+  sha256: 879bf20430f69830966cee63d7d0792b60570e2d31230763676a7fcc98969eeb
+  md5: 5cf443e45b0337a3e441b2faecf72bc9
+  depends:
+  - cccl 3.1.4
+  - cuda-cccl_win-64 13.1.115
+  - cuda-version >=13.1,<13.2.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 23420
+  timestamp: 1768272379721
 - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-cccl-13.1.78-h57928b3_0.conda
   sha256: 4333589edebfb9a8546717464dfafaaa2cabe88ad95c7966074874806497f53a
   md5: d37e7c539167833d941fbec6e58773f0
@@ -6733,6 +6915,15 @@ packages:
   purls: []
   size: 1143068
   timestamp: 1757017456077
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-64-13.1.115-ha770c72_0.conda
+  sha256: 0715f15da71587238600f0584bc8d243d8fde602c3d8856f421b58dff3fb9422
+  md5: a179486129ff28d053bb16fdb533568e
+  depends:
+  - cuda-version >=13.1,<13.2.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 1277295
+  timestamp: 1768272295906
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-64-13.1.78-ha770c72_0.conda
   sha256: 372fe6323eefeda72a789a5c05522ba977f5379593f9ac1ae1b040c1aae7377f
   md5: b6700130de993a87e5729cb2bb14a3ad
@@ -6794,6 +6985,16 @@ packages:
   purls: []
   size: 1141138
   timestamp: 1757017459617
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-aarch64-13.1.115-h579c4fd_0.conda
+  sha256: 82fcc47ac040e4db316d9548f9d50f26cf958ce5a91d808a5ad9ab30068b7256
+  md5: 5fb57a3acae0fa3ba0b3050142879d01
+  depends:
+  - arm-variant * sbsa
+  - cuda-version >=13.1,<13.2.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 1280034
+  timestamp: 1768272332978
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-aarch64-13.1.78-h579c4fd_0.conda
   sha256: 67a7bf4aad554e0e42648e21d2add6716edd09a301115caa2cd3fd667a1d4b7c
   md5: 96043b9e7c77bb5055dbf3b09a45137b
@@ -6849,6 +7050,15 @@ packages:
   purls: []
   size: 1140962
   timestamp: 1757017623257
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_win-64-13.1.115-h57928b3_0.conda
+  sha256: 521f861066e83e08987c04dd44ca8e04c0c837f4cc12d8f6e216d74b13545aee
+  md5: 7dd1bb1ded9fdb79adfbaa18ffe3e3c4
+  depends:
+  - cuda-version >=13.1,<13.2.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 1270876
+  timestamp: 1768272353154
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_win-64-13.1.78-h57928b3_0.conda
   sha256: 44f16217ba40f9959b63f23b88f878098dd2ef446e0ea37112ded10fe093db94
   md5: a99dc218cce4e2e5bdf2991d652b3804
@@ -7369,6 +7579,15 @@ packages:
   purls: []
   size: 95746
   timestamp: 1757021345670
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-64-13.1.115-ha770c72_0.conda
+  sha256: 82ae1f3e492146722e258e237daa537f4d4df8157b2dfa49a0869eb41a11d284
+  md5: 3723bca2a84e6cc0f0a98427b71bec73
+  depends:
+  - cuda-version >=13.1,<13.2.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 96480
+  timestamp: 1768280269206
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-64-13.1.80-ha770c72_0.conda
   sha256: f868b3e8f30438d7d0d6a5243bc43ef8d8c6984efe5b5fce98e6087487975f99
   md5: 86aeefaf6820c950c624eefedcebef7d
@@ -7419,6 +7638,16 @@ packages:
   purls: []
   size: 95711
   timestamp: 1757021337458
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-aarch64-13.1.115-h579c4fd_0.conda
+  sha256: 960ded06dffe01b8decdb31d24c151c549d10e0f4b862086310057bea96e1d60
+  md5: c6c2265e35eb85d66f8c4ea753fd306c
+  depends:
+  - arm-variant * sbsa
+  - cuda-version >=13.1,<13.2.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 96143
+  timestamp: 1768280061409
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-aarch64-13.1.80-h579c4fd_0.conda
   sha256: 5d9bcb1aa64d16f3d638be821112c2dcfb5275e8b64ee65f43ac9475e6c88d82
   md5: 1a92b7c3df80bd31e3084c22515f2776
@@ -7465,6 +7694,15 @@ packages:
   purls: []
   size: 96927
   timestamp: 1757021294408
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_win-64-13.1.115-h57928b3_0.conda
+  sha256: 423090e794fb941daf1f55c9970b38fda1d4d433d2368f701903087f97244914
+  md5: a0334799d64b5ab2c8cc7bc348f531f9
+  depends:
+  - cuda-version >=13.1,<13.2.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 96656
+  timestamp: 1768280132737
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_win-64-13.1.80-h57928b3_0.conda
   sha256: 2438d010de855dc014016739fb1eb1f6481a04e2d9f275fc16710a2260eaed8a
   md5: 67129cdc95fab147e425171ef56c44bf
@@ -7510,6 +7748,15 @@ packages:
   purls: []
   size: 29931
   timestamp: 1757021356880
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-crt-tools-13.1.115-ha770c72_0.conda
+  sha256: 272c3e100c40f261f3322613ed3829b7cbec7e107bf25bd5c3328ec9416dc341
+  md5: 2463b351f519d6a915e05a60668aea13
+  depends:
+  - cuda-version >=13.1,<13.2.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 30124
+  timestamp: 1768280280700
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-crt-tools-13.1.80-ha770c72_0.conda
   sha256: 692f6b593a826303467c450a79afcb1a1739e1c21fc78186400f9cc624f3740b
   md5: dde36cb0b7d2882adbd8c5cbc13480d7
@@ -7560,6 +7807,16 @@ packages:
   purls: []
   size: 30038
   timestamp: 1757021339160
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-crt-tools-13.1.115-h579c4fd_0.conda
+  sha256: a76bcffda612363cef641748251273003d3bd43ae70fa51a0a0c01be106de3e5
+  md5: fdc4479b45ce5ddd362a268ad2847b6d
+  depends:
+  - arm-variant * sbsa
+  - cuda-version >=13.1,<13.2.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 30165
+  timestamp: 1768280063313
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-crt-tools-13.1.80-h579c4fd_0.conda
   sha256: 22dad7e77e015881b7e8c6bc7f66704cc1fd4ea86a5a103643cfe204bb04dafc
   md5: 315f856fc919e47f461192a11bda1351
@@ -7606,6 +7863,15 @@ packages:
   purls: []
   size: 30522
   timestamp: 1757021311108
+- conda: https://conda.anaconda.org/conda-forge/win-64/cuda-crt-tools-13.1.115-h57928b3_0.conda
+  sha256: d6cff40989e02a097f7f32aaf1d81e4f6bb23c4df3fb70b837166e7c0ba74a7e
+  md5: 83bdc5602bb8fe61e19987ee3122b926
+  depends:
+  - cuda-version >=13.1,<13.2.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 30521
+  timestamp: 1768280149422
 - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-crt-tools-13.1.80-h57928b3_0.conda
   sha256: aa21c91442b593cdf2132ca512e67cb4c833c521becda8dd7255a8a001c9af5a
   md5: 5505c462da06d2eb4df66c6b233b2410
@@ -8985,6 +9251,19 @@ packages:
   purls: []
   size: 273310
   timestamp: 1757022289476
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cuobjdump-13.1.115-hffce074_0.conda
+  sha256: 8acee240c795158af331a2da0f96cbdca0f2bf7c9badd17ea404c8e6ae04bf0d
+  md5: 67d4cd43081aee40f944df6c45dfe696
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-nvdisasm
+  - cuda-version >=13.1,<13.2.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 296940
+  timestamp: 1768275814535
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cuobjdump-13.1.80-hffce074_0.conda
   sha256: 8bacac883bf399e60342e1e00e567418af4e780ba4aa3cb2120b368648045b59
   md5: 8dfc987a40c1a2d7d1e15c4cf6a747a3
@@ -9064,6 +9343,18 @@ packages:
   purls: []
   size: 279905
   timestamp: 1757022329102
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cuobjdump-13.1.115-h2079400_0.conda
+  sha256: a6822efc766334a5ec1ce110eeaedf066a6048c3ba7285a51c13fd594882326f
+  md5: 28c1e4adc22202fbda1935181f9df6b0
+  depends:
+  - cuda-nvdisasm
+  - cuda-version >=13.1,<13.2.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 282542
+  timestamp: 1768275894241
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cuobjdump-13.1.80-h2079400_0.conda
   sha256: 2a263256ffd2e08b6169904acd87705e7cde13ab2e33e76d9525a030f04c4960
   md5: 7a12fd1022ea1225a63513ded052f287
@@ -9140,6 +9431,19 @@ packages:
   purls: []
   size: 5237993
   timestamp: 1757022457808
+- conda: https://conda.anaconda.org/conda-forge/win-64/cuda-cuobjdump-13.1.115-hac47afa_0.conda
+  sha256: d0e9c1adfb90fe2105ef6f74d1bc093f765cb039b42060c21f36a6ebde044494
+  md5: e3a38d8cf2dc23cad45e8f5255630179
+  depends:
+  - cuda-nvdisasm
+  - cuda-version >=13.1,<13.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 5460813
+  timestamp: 1768275928765
 - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-cuobjdump-13.1.80-hac47afa_0.conda
   sha256: f70565f6260c688c0ce2d7bfdb8448a1a0b2a41dc810b2c12719437d3ca5a834
   md5: bcbcffb0b4c227da59137a2bfbd076d1
@@ -9607,6 +9911,17 @@ packages:
   purls: []
   size: 24902
   timestamp: 1762289415743
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-13.1.115-hcdd1206_0.conda
+  sha256: ef49d282e7ae6abfce11fdd7aa59a74fbf08b001aa8c2addb1b783e3917aacb5
+  md5: c50bb7775d8d99cdc51c0dfa8c638362
+  depends:
+  - cuda-nvcc_linux-64 13.1.115.*
+  - gcc_linux-64
+  - gxx_linux-64
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 24989
+  timestamp: 1768285999378
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-13.1.80-hcdd1206_0.conda
   sha256: d572a852716359281ccd95483b6d1d1e29c338a002e0fdc21f658bd27c8b4fb0
   md5: 56434e86a5cdc70ef40d3b0c0c455249
@@ -9673,6 +9988,17 @@ packages:
   purls: []
   size: 24944
   timestamp: 1762289394229
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-13.1.115-ha346c71_0.conda
+  sha256: 83cc26b5778884233a23178447333150d6ba3fbb7ab017e0dbf064466131f963
+  md5: 2e2ababa725cb191f16a44f3fbfe9456
+  depends:
+  - cuda-nvcc_linux-aarch64 13.1.115.*
+  - gcc_linux-aarch64
+  - gxx_linux-aarch64
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 25008
+  timestamp: 1768286017231
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-13.1.80-ha346c71_100.conda
   sha256: bdb3d0b2147124158c3529f8d110b3734caad4e2003b7070d1843ac29171b2ba
   md5: 3b5f3451b39d135dc53282c9be19356a
@@ -9734,6 +10060,16 @@ packages:
   purls: []
   size: 25416
   timestamp: 1762289434033
+- conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvcc-13.1.115-h8f04d04_0.conda
+  sha256: d719bcb21f7a5f97d057d64677f122025b4e2c171b8d35b10ce2fa3c3720389e
+  md5: a91f25002e4941eb95f399285f3c459b
+  depends:
+  - cuda-nvcc_win-64 13.1.115.*
+  - vs2019_win-64
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 25533
+  timestamp: 1768286015819
 - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvcc-13.1.80-h8f04d04_0.conda
   sha256: 58d1d09a6a871321c8a27cbf51dfd3fbd7a050ec11223ce1d15e6b412032782e
   md5: 7b270b84cf1d7a4d65572de197755413
@@ -9813,6 +10149,21 @@ packages:
   purls: []
   size: 28946
   timestamp: 1757021683159
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-64-13.1.115-he91c749_0.conda
+  sha256: 2d63a4f43bd4410ecef87c41aeffa2035f511870d7fc696eb0b3a9d05595cc66
+  md5: 59397a8efd2c86c8d0d4ea6c1fcd9c8b
+  depends:
+  - cuda-crt-dev_linux-64 13.1.115 ha770c72_0
+  - cuda-nvvm-dev_linux-64 13.1.115 ha770c72_0
+  - cuda-version >=13.1,<13.2.0a0
+  - libgcc >=6
+  - libnvptxcompiler-dev_linux-64 13.1.115 ha770c72_0
+  constrains:
+  - gcc_impl_linux-64 >=6,<16.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 29084
+  timestamp: 1768280571872
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-64-13.1.80-he91c749_0.conda
   sha256: 9359a4dd94a101778ec634ef4c0aefa14dc56bd21c19cd47954bd50ba6944c2f
   md5: ba5bfbc377155ecb98ec41edb85edd15
@@ -9902,6 +10253,22 @@ packages:
   purls: []
   size: 29072
   timestamp: 1757021613549
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-aarch64-13.1.115-h4310d6a_0.conda
+  sha256: 195cbbee2a694d9f8932c5933073e85b4ea447acf6ff4b49891e59ddc280e49f
+  md5: 4ad7de91e5224f197c1b957b7989a0f6
+  depends:
+  - arm-variant * sbsa
+  - cuda-crt-dev_linux-aarch64 13.1.115 h579c4fd_0
+  - cuda-nvvm-dev_linux-aarch64 13.1.115 h579c4fd_0
+  - cuda-version >=13.1,<13.2.0a0
+  - libgcc >=6
+  - libnvptxcompiler-dev_linux-aarch64 13.1.115 h579c4fd_0
+  constrains:
+  - gcc_impl_linux-aarch64 >=6,<16.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 29142
+  timestamp: 1768280307772
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-aarch64-13.1.80-h4310d6a_0.conda
   sha256: 306ab187524f3e7c5378fb18eb598ca23aa2e87f44e1bbc9efbc83dd50800380
   md5: ad2aeb2a53e9b2995f678a9c66437812
@@ -9973,6 +10340,18 @@ packages:
   purls: []
   size: 23895447
   timestamp: 1757021716243
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_win-64-13.1.115-h36c15f3_0.conda
+  sha256: 2fcf80f3261e8d89130ea4ddd6af01c894eb49ea5243d395e23ab60a5f3f6f5b
+  md5: 996b533098bfdcfb0a8c263351add548
+  depends:
+  - cuda-crt-dev_win-64 13.1.115 h57928b3_0
+  - cuda-nvvm-dev_win-64 13.1.115 h57928b3_0
+  - cuda-version >=13.1,<13.2.0a0
+  - libnvptxcompiler-dev_win-64 13.1.115 h57928b3_0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 25349447
+  timestamp: 1768280494603
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_win-64-13.1.80-h36c15f3_0.conda
   sha256: e9b35b1d907fc1015fb0dfd5d011aa6cb86e995a21a2597bc43c9b207bc6387c
   md5: 0e674547dff3f1da79073dee70f2e6a1
@@ -10068,6 +10447,23 @@ packages:
   purls: []
   size: 28077
   timestamp: 1757021695541
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-impl-13.1.115-h85509e4_0.conda
+  sha256: 5c6a64f9a8f40d31d58c1df848d0125b61405ab4e0e695501cdd0fc2b657f675
+  md5: 45ee3f07446a4f800060d7f868d1d5e3
+  depends:
+  - cuda-cudart >=13.1.80,<14.0a0
+  - cuda-cudart-dev
+  - cuda-nvcc-dev_linux-64 13.1.115 he91c749_0
+  - cuda-nvcc-tools 13.1.115 he02047a_0
+  - cuda-nvvm-impl 13.1.115 h4bc722e_0
+  - cuda-version >=13.1,<13.2.0a0
+  - libnvptxcompiler-dev 13.1.115 ha770c72_0
+  constrains:
+  - gcc_impl_linux-64 >=6,<16.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 28190
+  timestamp: 1768280584899
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-impl-13.1.80-h85509e4_0.conda
   sha256: 6519faf152d441a1efbafd821e297fdedaa7af330e5d1ef973bc6f4048407ca7
   md5: d7a89b97109395b491ffc716cc690a9b
@@ -10171,6 +10567,24 @@ packages:
   purls: []
   size: 28154
   timestamp: 1757021621068
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-impl-13.1.115-h614329b_0.conda
+  sha256: 3ab080230970fd0109cd1c3208d262f5e5ada17062a94722a4cc22c464938ada
+  md5: 00f628bdd96dc63f5ddc1fc4fb98d53e
+  depends:
+  - arm-variant * sbsa
+  - cuda-cudart >=13.1.80,<14.0a0
+  - cuda-cudart-dev
+  - cuda-nvcc-dev_linux-aarch64 13.1.115 h4310d6a_0
+  - cuda-nvcc-tools 13.1.115 h614329b_0
+  - cuda-nvvm-impl 13.1.115 h7b14b0b_0
+  - cuda-version >=13.1,<13.2.0a0
+  - libnvptxcompiler-dev 13.1.115 h579c4fd_0
+  constrains:
+  - gcc_impl_linux-aarch64 >=6,<16.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 28311
+  timestamp: 1768280315857
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-impl-13.1.80-h614329b_0.conda
   sha256: f33d1884d087c360cb420e2724c2164bfd00d190d88c71a9cf6e8db9d4616357
   md5: f72f44dff8432bd4387ebaa8c5e55f9b
@@ -10269,6 +10683,22 @@ packages:
   purls: []
   size: 28549
   timestamp: 1757021766306
+- conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvcc-impl-13.1.115-h53cbb54_0.conda
+  sha256: 79cfd307281759273ab4c02f6b97680e27f10a0fc9b7d2e1e31d530bbf8ae84a
+  md5: 44e51db496dc8d9ec363a59cea770563
+  depends:
+  - cuda-cudart-dev
+  - cuda-nvcc-dev_win-64 13.1.115 h36c15f3_0
+  - cuda-nvcc-tools 13.1.115 he0c23c2_0
+  - cuda-nvvm-impl 13.1.115 h2466b09_0
+  - cuda-version >=13.1,<13.2.0a0
+  - libnvptxcompiler-dev 13.1.115 h57928b3_0
+  constrains:
+  - vc >=14.2
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 28608
+  timestamp: 1768280548147
 - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvcc-impl-13.1.80-h53cbb54_0.conda
   sha256: 2826f5476dc0867dda8e02a4e96832535616ff68b15e71001b2f27451dc2d8fd
   md5: e62304d9b941122f40bff755a40eef7b
@@ -10363,6 +10793,22 @@ packages:
   purls: []
   size: 28824961
   timestamp: 1757021588514
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-tools-13.1.115-he02047a_0.conda
+  sha256: b3c2a01616140c721b6b862f9292b9f90f9a7dc63f82cfd8e4f4d5abf006109a
+  md5: 92d8589fde5681db8c996572b43aa276
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-crt-tools 13.1.115 ha770c72_0
+  - cuda-nvvm-tools 13.1.115 h4bc722e_0
+  - cuda-version >=13.1,<13.2.0a0
+  - libgcc >=12
+  - libstdcxx >=12
+  constrains:
+  - gcc_impl_linux-64 >=6,<16.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 32524161
+  timestamp: 1768280483844
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-tools-13.1.80-he02047a_0.conda
   sha256: f9500a49b314a7a9310e7fc8cd270c7fd72ff7a13676a199a208ad59db517007
   md5: 7dfbda2a7080747831a1b1096c450ad4
@@ -10457,6 +10903,22 @@ packages:
   purls: []
   size: 25207775
   timestamp: 1757021545690
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-tools-13.1.115-h614329b_0.conda
+  sha256: 57e04b654fae96fb9702c4900248e2e22bef5a3c7ece24e72cf6f9bfa4e7f7fb
+  md5: 6ea312f22e8e8874f64a2e3c21075fe5
+  depends:
+  - arm-variant * sbsa
+  - cuda-crt-tools 13.1.115 h579c4fd_0
+  - cuda-nvvm-tools 13.1.115 h7b14b0b_0
+  - cuda-version >=13.1,<13.2.0a0
+  - libgcc >=12
+  - libstdcxx >=12
+  constrains:
+  - gcc_impl_linux-aarch64 >=6,<16.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 26832356
+  timestamp: 1768280248459
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-tools-13.1.80-h614329b_0.conda
   sha256: f71a3a11be8a8f35b6ac05bf36592a5e95b0643b59d449ed20b07644c6ab49b5
   md5: 5a8fa0fdf0deb9bb6f76ba79faf2f595
@@ -10541,6 +11003,20 @@ packages:
   purls: []
   size: 28275
   timestamp: 1757021668128
+- conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvcc-tools-13.1.115-he0c23c2_0.conda
+  sha256: 4379dd362bee27a06212cbaa7e6690d571f2d041eb774dd59bf10ead482a998e
+  md5: 6bdb23d018ba8c34682a8d0502db291a
+  depends:
+  - cuda-crt-tools 13.1.115 h57928b3_0
+  - cuda-nvvm-tools 13.1.115 h2466b09_0
+  - cuda-version >=13.1,<13.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 28332
+  timestamp: 1768280436252
 - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvcc-tools-13.1.80-he0c23c2_0.conda
   sha256: 1d11128061e9747cd6b26ff81d56ae09ee5483a6e63be28958fac6d6fb40092b
   md5: cb8767d44fc3d16d71333cdd6543cef2
@@ -10630,6 +11106,21 @@ packages:
   purls: []
   size: 26850
   timestamp: 1762289415201
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc_linux-64-13.1.115-hb2fc203_0.conda
+  sha256: 09b3a960bc322d086c5e01dfb4c736b8517c2e31e9e0d3b437eabb6b3d2c69b4
+  md5: 7364535de1919bea48c4a5b355aa02e7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-cudart-dev_linux-64 13.1.*
+  - cuda-driver-dev_linux-64 13.1.*
+  - cuda-nvcc-dev_linux-64 13.1.115.*
+  - cuda-nvcc-impl 13.1.115.*
+  - cuda-nvcc-tools 13.1.115.*
+  - sysroot_linux-64 >=2.17,<3.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 26945
+  timestamp: 1768285998863
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc_linux-64-13.1.80-hb2fc203_0.conda
   sha256: d0f022e5b14537462119ebd0ffd77464a6bd8cc9f55072c308385f99d812541a
   md5: 978ee67796fe8c0ced2cd9663f5f7585
@@ -10718,6 +11209,21 @@ packages:
   purls: []
   size: 26954
   timestamp: 1762289393657
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc_linux-aarch64-13.1.115-h9ee44f0_0.conda
+  sha256: 5579f5050f7fff3905fa70ad6be07c51c9a52518fe5d458999603ea757b0f10a
+  md5: 7caea0e825b26e6798c351a0b97ff002
+  depends:
+  - arm-variant * sbsa
+  - cuda-cudart-dev_linux-aarch64 13.1.*
+  - cuda-driver-dev_linux-aarch64 13.1.*
+  - cuda-nvcc-dev_linux-aarch64 13.1.115.*
+  - cuda-nvcc-impl 13.1.115.*
+  - cuda-nvcc-tools 13.1.115.*
+  - sysroot_linux-aarch64 >=2.17,<3.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 27070
+  timestamp: 1768286016645
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc_linux-aarch64-13.1.80-h9ee44f0_100.conda
   sha256: f982a59f187970b7868f8cb73231dc884f0680b6a0ea1696ec5aae17191cde9f
   md5: 5d2ee7902ad260b77c72bee7a2f6471a
@@ -10793,6 +11299,18 @@ packages:
   purls: []
   size: 26556
   timestamp: 1762289433235
+- conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvcc_win-64-13.1.115-hd70436c_0.conda
+  sha256: 71b20f2f8d4e3b12dc38a917a6e890c3850a14d802338c54e863349678eb2cde
+  md5: 196a42210f8e71a5e3d8fc6d5d62b925
+  depends:
+  - cuda-cudart-dev_win-64 13.1.*
+  - cuda-nvcc-dev_win-64 13.1.115.*
+  - cuda-nvcc-impl 13.1.115.*
+  - cuda-nvcc-tools 13.1.115.*
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 26707
+  timestamp: 1768286015099
 - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvcc_win-64-13.1.80-hd70436c_0.conda
   sha256: d0c16157f070ce3cdeecfb5fd97eb053ff50423f33a671508c4086ee0e71d7e0
   md5: 3ce307c8fc9fced1e06045cf28e86cc0
@@ -10852,6 +11370,18 @@ packages:
   purls: []
   size: 4170893
   timestamp: 1757018328550
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvdisasm-13.1.115-hffce074_0.conda
+  sha256: b1dd35d918a9afb698dde2503b2972cd60a4c4a33c48e83c7709040fdbdbc953
+  md5: fdefb48859324f59d65792ae7ba1dd59
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=13.1,<13.2.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 4197613
+  timestamp: 1768272805479
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvdisasm-13.1.80-hffce074_0.conda
   sha256: ac4c8f988cfe5e3fb82080f82d8ea000384dcfca0dec048c99b3d28374c7c3aa
   md5: 0344e59470cbe51d99311900667f5b8d
@@ -10916,6 +11446,20 @@ packages:
   purls: []
   size: 4123249
   timestamp: 1757018366629
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvdisasm-13.1.115-h40ab4d6_0.conda
+  sha256: 4e315c2ec0db1298c0f73ed3b6b1a1b2f8648ad51ace85f5daa0e03f8fad1d07
+  md5: 78b9eed1adf9d1830872f25428882aa5
+  depends:
+  - arm-variant * sbsa
+  - cuda-version >=13.1,<13.2.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - arm-variant * sbsa
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 4124319
+  timestamp: 1768272830682
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvdisasm-13.1.80-h40ab4d6_0.conda
   sha256: efa7b4321de3b296487b7c955600fcf45f5c99d18809ebc4520b7a9bb84bc472
   md5: 908a880ba8427c7f88b114901658b193
@@ -10978,6 +11522,18 @@ packages:
   purls: []
   size: 4335208
   timestamp: 1757018496784
+- conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvdisasm-13.1.115-hac47afa_0.conda
+  sha256: 9c9e8b9421cf6e578b1518c3486c0a12ef900c7d01dd5a0544e5718e8d29d433
+  md5: 607778619a254799ed43bc2af5b33d89
+  depends:
+  - cuda-version >=13.1,<13.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 4339492
+  timestamp: 1768272930786
 - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvdisasm-13.1.80-hac47afa_0.conda
   sha256: 369b6a1df20caae67b8ff11014a09eebfe3d20f19c225d8467f23e9f72c04b96
   md5: 3c23d86b4ae083e8b787be5a91d1299c
@@ -11277,6 +11833,17 @@ packages:
   purls: []
   size: 24927
   timestamp: 1762289415536
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-13.1.115-h69a702a_0.conda
+  sha256: 100e9d1a98b3bf48c21b6864fa170319376c116fb817c5add159b393a15bb10f
+  md5: 005ed889be00c5a99b21c021f62c07e6
+  depends:
+  - cuda-nvvm-dev_linux-64 13.1.115.*
+  - cuda-nvvm-impl 13.1.115.*
+  - cuda-nvvm-tools 13.1.115.*
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 25010
+  timestamp: 1768285999181
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-13.1.80-h69a702a_0.conda
   sha256: 84f971ab146e2c822103cfe06f478ece244747a6f2aa565be639a4709d0a1579
   md5: 9250c651d8758c8f665dff7519ef21ff
@@ -11332,6 +11899,17 @@ packages:
   purls: []
   size: 24968
   timestamp: 1762289394010
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-13.1.115-he9431aa_0.conda
+  sha256: de093b90d49321becd7d908cd2404187ee2019db87019a027daae2a31947df90
+  md5: b37a8264226df1032cb49d1bea25a6da
+  depends:
+  - cuda-nvvm-dev_linux-aarch64 13.1.115.*
+  - cuda-nvvm-impl 13.1.115.*
+  - cuda-nvvm-tools 13.1.115.*
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 25064
+  timestamp: 1768286017002
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-13.1.80-he9431aa_100.conda
   sha256: b5ac0f9e6dd13f492f74e250a6fc8039446c0f57a13688a2e37c289a2a775871
   md5: 8eaa96210e2afe99d38147b511f211c4
@@ -11387,6 +11965,17 @@ packages:
   purls: []
   size: 25426
   timestamp: 1762289433673
+- conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvvm-13.1.115-h719f0c7_0.conda
+  sha256: 0b159a707cbc19cb283c4f42251eb905a5d813d239276c2f4aeefb4489327ccb
+  md5: e19c0c1f114ddaca8ad4734258367b89
+  depends:
+  - cuda-nvvm-dev_win-64 13.1.115.*
+  - cuda-nvvm-impl 13.1.115.*
+  - cuda-nvvm-tools 13.1.115.*
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 25586
+  timestamp: 1768286015475
 - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvvm-13.1.80-h719f0c7_0.conda
   sha256: e3fa398e7358eb04e8673c546c91d85c601428e7c9ba2607ce26a06c8b2af2a0
   md5: 84eecc20d7bd6c0067643b1978aa568e
@@ -11434,6 +12023,15 @@ packages:
   purls: []
   size: 27954
   timestamp: 1757021367553
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-64-13.1.115-ha770c72_0.conda
+  sha256: cae8dd604706bed7c5a19d35cabdab2ce549182e98cfd603c5b603a5c787cfdd
+  md5: f468fd93b5f654b49799daaccd0067fc
+  depends:
+  - cuda-version >=13.1,<13.2.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 28066
+  timestamp: 1768280291614
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-64-13.1.80-ha770c72_0.conda
   sha256: 591b40b0aa8d502682ff1e622960f721c211a204ddaee4cc2f0d28168dfcc34e
   md5: bc17c904040f11a51c106570d51fa539
@@ -11484,6 +12082,16 @@ packages:
   purls: []
   size: 28061
   timestamp: 1757021345227
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-aarch64-13.1.115-h579c4fd_0.conda
+  sha256: 81c2e2c1cd27b03b4f2dbb2045324bc51b93b8991752d9ca45b46aa79c65ec2b
+  md5: a9b9e6db86417d145e9db74f41fcd1f1
+  depends:
+  - arm-variant * sbsa
+  - cuda-version >=13.1,<13.2.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 28157
+  timestamp: 1768280070110
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-aarch64-13.1.80-h579c4fd_0.conda
   sha256: 6bad2da798e4486056b60cd4fb72d0952aa7cac00f957f9c7a0756920ccfa951
   md5: bfd488eac8fdcb5c7e03b9e939883e07
@@ -11530,6 +12138,15 @@ packages:
   purls: []
   size: 28190
   timestamp: 1757021325756
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_win-64-13.1.115-h57928b3_0.conda
+  sha256: 8bf83fe74aafac4b1a2558ac76417878b9dcab520677295458b1b77b3eef2200
+  md5: 5c8a8a41f12e2ff631ae8396c8041152
+  depends:
+  - cuda-version >=13.1,<13.2.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 28248
+  timestamp: 1768280165497
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_win-64-13.1.80-h57928b3_0.conda
   sha256: 82bb6b753a354231ec8d0169f4e1cd3eac9c3786f0e32aaca0fc00862431f2dd
   md5: 5aa5bfd68d8f1f44db92b7d66f83a4e8
@@ -11584,6 +12201,17 @@ packages:
   purls: []
   size: 21662718
   timestamp: 1757021391692
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-impl-13.1.115-h4bc722e_0.conda
+  sha256: 12d84615684f1279799c023ce4ccc7c34f151bec2a90e0c8d04798a8c8af437c
+  md5: bf76661bc0de83a60537c4913f339fb3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=13.1,<13.2.0a0
+  - libgcc >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 21873791
+  timestamp: 1768280315627
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-impl-13.1.80-h4bc722e_0.conda
   sha256: 8bd043f9e78cf4629aa752c9a2c40ade42dda3b3aab0e1f3ee20fdd2039b83d5
   md5: 354de3693a5a44502c3d0f9e33b188c7
@@ -11642,6 +12270,17 @@ packages:
   purls: []
   size: 20784164
   timestamp: 1757021384178
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-impl-13.1.115-h7b14b0b_0.conda
+  sha256: d27caee8c6426ea736369907d70439383bb71ddb97f3a4b8e11b88867194dabc
+  md5: ecf7142519e1e19edf4c2ab867f6907f
+  depends:
+  - arm-variant * sbsa
+  - cuda-version >=13.1,<13.2.0a0
+  - libgcc >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 21022191
+  timestamp: 1768280105208
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-impl-13.1.80-h7b14b0b_0.conda
   sha256: 5b0716316c969e077dcf930618c71795501d8bee4695d02f616c965a94930e95
   md5: 379b6f7af10ce21879b04d3f565c81f8
@@ -11701,6 +12340,18 @@ packages:
   purls: []
   size: 32203
   timestamp: 1757021353790
+- conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvvm-impl-13.1.115-h2466b09_0.conda
+  sha256: 5393e988379c666a39ab754e435a6039c417d7a88e243781c2a6492e7375bd1a
+  md5: 591c7164b067570825a33f118b9d1371
+  depends:
+  - cuda-version >=13.1,<13.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 32322
+  timestamp: 1768280198879
 - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvvm-impl-13.1.80-h2466b09_0.conda
   sha256: 905a3fc74929d8055d02bc03df06a9f3d7039c6382ba02b52b8485e7c9fa716f
   md5: 50d68c863dfd1d3a2725c60828260a86
@@ -11758,6 +12409,17 @@ packages:
   purls: []
   size: 24519392
   timestamp: 1757021447444
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-tools-13.1.115-h4bc722e_0.conda
+  sha256: 51641c065fbb78af45e7040e19866404d217c26901734866218e9cee6a511a8e
+  md5: a9ec91462847137689ab1fa2c0652f05
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=13.1,<13.2.0a0
+  - libgcc >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 25639587
+  timestamp: 1768280358414
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-tools-13.1.80-h4bc722e_0.conda
   sha256: 9561b018769cfdb7ff4f86a45ccc74da43aab9de123e78eac882a89a33549608
   md5: ed8bad73e1220e00e81370914c970d79
@@ -11816,6 +12478,17 @@ packages:
   purls: []
   size: 23566779
   timestamp: 1757021431631
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-tools-13.1.115-h7b14b0b_0.conda
+  sha256: c75e60b49f451c3f107990e84036ee30a657af66fc545b060a2e141582046002
+  md5: 2878a252bae4afd35fc8ffb5d324ae90
+  depends:
+  - arm-variant * sbsa
+  - cuda-version >=13.1,<13.2.0a0
+  - libgcc >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 24677366
+  timestamp: 1768280141435
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-tools-13.1.80-h7b14b0b_0.conda
   sha256: fd47df66fadc9d13cab4edf74a925eec1f7b93f99e5383be22286c3732e48d56
   md5: 786f082b4325fc702c7195c603f93dbf
@@ -11875,6 +12548,18 @@ packages:
   purls: []
   size: 40795580
   timestamp: 1757021502689
+- conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvvm-tools-13.1.115-h2466b09_0.conda
+  sha256: bb27ecb40eb2a69fb62449abb3ec03f90cba1820251ae365f5d574a258f82945
+  md5: 0959ceb9a58bcf03aa31396e5006ce4c
+  depends:
+  - cuda-version >=13.1,<13.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 41660022
+  timestamp: 1768280258661
 - conda: https://conda.anaconda.org/conda-forge/win-64/cuda-nvvm-tools-13.1.80-h2466b09_0.conda
   sha256: d9f27e97dd20cea56e321a3d5b23fecb7ee296894e493d87d726fea81731d8f3
   md5: 270d2fa662685acddad5dce08129d188
@@ -15679,6 +16364,16 @@ packages:
   purls: []
   size: 27918
   timestamp: 1757021661262
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnvptxcompiler-dev-13.1.115-ha770c72_0.conda
+  sha256: 9af66ab3c0218f30bbf37e680545a4c37da855adbbd0d8ff119056ad775d07ea
+  md5: 825f9cb1309a5975f5b9c1879d3b3050
+  depends:
+  - cuda-version >=13.1,<13.2.0a0
+  - libnvptxcompiler-dev_linux-64 13.1.115 ha770c72_0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 28045
+  timestamp: 1768280548127
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvptxcompiler-dev-13.1.80-ha770c72_0.conda
   sha256: 7c172106b57118f8d018283d6ff78c7827539dd673a21c4c9550ac5c29759e04
   md5: dcb19c91c8ebd8d55cd3411311e231b2
@@ -15711,6 +16406,17 @@ packages:
   purls: []
   size: 27986
   timestamp: 1757021596258
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvptxcompiler-dev-13.1.115-h579c4fd_0.conda
+  sha256: 813cee152bf71d84363d3b50a398e2e983b4d492a58aa0a343998d3589759648
+  md5: 6192d6f0ccf1223e528b6ec46a9bbd4e
+  depends:
+  - arm-variant * sbsa
+  - cuda-version >=13.1,<13.2.0a0
+  - libnvptxcompiler-dev_linux-aarch64 13.1.115 h579c4fd_0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 28094
+  timestamp: 1768280288643
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvptxcompiler-dev-13.1.80-h579c4fd_0.conda
   sha256: 4c30176cb79a374bd828ed596d6db6db267c88f5417117473a406a5dbc36eeeb
   md5: baa70b64900fdd5d7cc0ab50ec1c2ab5
@@ -15742,6 +16448,16 @@ packages:
   purls: []
   size: 28275
   timestamp: 1757021683017
+- conda: https://conda.anaconda.org/conda-forge/win-64/libnvptxcompiler-dev-13.1.115-h57928b3_0.conda
+  sha256: 9c052998c020e7bef225dcdd660dd7d50aaa8ae14b171a4737d93c834922bbeb
+  md5: 460ab429c32ef02b0d824f451c3ebaa2
+  depends:
+  - cuda-version >=13.1,<13.2.0a0
+  - libnvptxcompiler-dev_win-64 13.1.115 h57928b3_0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 28322
+  timestamp: 1768280452792
 - conda: https://conda.anaconda.org/conda-forge/win-64/libnvptxcompiler-dev-13.1.80-h57928b3_0.conda
   sha256: 66b21ef244f0f56951ddf8ad1edb901ad77b7ef094b08812d3bcb26dbec36b41
   md5: 84043e9f2da61189b336fcfa01abc07c
@@ -15770,6 +16486,15 @@ packages:
   purls: []
   size: 15040180
   timestamp: 1757021509018
+- conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-64-13.1.115-ha770c72_0.conda
+  sha256: 98b1ed15bebeeae411785e211aae2d7f303c5124b88fe2433e9080d8fad2f3a9
+  md5: 8cbe7a9e462f1c0bd9e4bbdab1005337
+  depends:
+  - cuda-version >=13.1,<13.2.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 16510519
+  timestamp: 1768280407864
 - conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-64-13.1.80-ha770c72_0.conda
   sha256: 1609c21c74a416d26fb46164bf6d6f28439e7b86ce21541aa607842862751fb9
   md5: 3556d7d320bdf5e60f36f80035e9d299
@@ -15799,6 +16524,16 @@ packages:
   purls: []
   size: 14217893
   timestamp: 1757021478031
+- conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-aarch64-13.1.115-h579c4fd_0.conda
+  sha256: 6597b5ed7242289d31116f4358fbe3f43a079725fcda66a3830f296de455d97f
+  md5: 1542f255f31f58cd4585fc4cc07c8cca
+  depends:
+  - arm-variant * sbsa
+  - cuda-version >=13.1,<13.2.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 15945605
+  timestamp: 1768280179983
 - conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-aarch64-13.1.80-h579c4fd_0.conda
   sha256: 78902300cada642c79953d7ec23933289d63a4b4ba1e487caba9b1dfcb98f247
   md5: 722ac7efd580f415930dec0fcadb9e7d
@@ -15827,6 +16562,15 @@ packages:
   purls: []
   size: 32891899
   timestamp: 1757021572801
+- conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_win-64-13.1.115-h57928b3_0.conda
+  sha256: c722357f809e8afe59a5f9e07d8bbac7e5e50fd894623ebde837c1821423f27b
+  md5: 9302d010866507889330a68bd4520c8d
+  depends:
+  - cuda-version >=13.1,<13.2.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 35026918
+  timestamp: 1768280333011
 - conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_win-64-13.1.80-h57928b3_0.conda
   sha256: 8304b65cdbf914144b0671229370264d951c62c33f674b67173d0ddc36ab350c
   md5: 960eaad4ef9e6cd75518029249b5f5a4

--- a/pixi.toml
+++ b/pixi.toml
@@ -105,7 +105,7 @@ numpydoc = ">=1.9.0"
 nvidia-sphinx-theme = "*"
 
 [environments]
-default = { features = ["test"], solve-group = "default" }
+default = { features = ["cu-13-1", "test", "cu", "cu-13", "cu-rt", "nvvm", "py314"], solve-group = "default" }
 bench-against = { features = ["test"], no-default-feature = true }
 # CUDA 12
 cu-12-0-py310 = { features = [


### PR DESCRIPTION
# Summary

- Add pixi run test-par command to run the test suite in parallel using pytest-xdist

## Changes

### Parallel Testing
- Added new `test-par` task that uses `pytest -n auto` to automatically detect and utilize all available CPU cores
- Maintains same environment variables and build dependencies as the serial test task
- Provides significant speedup for running the full test suite (2m45s -> 36s on my machine)


## Usage

### Run tests in parallel:
`pixi run test-par`

### Run tests serially (existing):
`pixi run test`