### PR TITLE
Fix compatibility with NumPy 2.4: np.trapz and np.in1d removed

### DIFF
--- a/numba_cuda/numba/cuda/np/arraymath.py
+++ b/numba_cuda/numba/cuda/np/arraymath.py
@@ -2318,9 +2318,9 @@ def np_trapezoid(y, x=None, dx=1.0):
 
 # numpy 2.0 renamed np.trapz to np.trapezoid; np.trapz removed in numpy 2.4
 if numpy_version >= (2, 0):
-    overload(np.trapezoid)(np_trapz)
+    overload(np.trapezoid)(np_trapezoid)
 if numpy_version < (2, 4):
-    overload(np.trapz)(np_trapz)
+    overload(np.trapz)(np_trapezoid)
 
 
 @register_jitable


### PR DESCRIPTION
NumPy 2.4 removed `np.trapz` (deprecated in 2.0, replaced by `np.trapezoid`) and `np.in1d` (deprecated in 2.0, replaced by `np.isin`).

## Changes

- **`np.trapz` overload**: Only register when `numpy_version < (2, 4)`
- **`np.trapezoid` overload**: Keep registration for `numpy_version >= (2, 0)`
- **Add internal `_in1d_impl` helper function** using `@register_jitable`
- **`np.in1d` overload**: Only register when `numpy_version < (2, 4)`
- **Update `np.setdiff1d` and `np.isin`** to use `_in1d_impl` instead of `np.in1d`

This follows the same approach used in numba/numba commits [aa7cf35](https://github.com/numba/numba/commit/aa7cf35) and [c39d72e](https://github.com/numba/numba/commit/c39d72e).

Fixes #726