### PR TITLE
Fix prologue debug line info pointing to decorator instead of def line

### DIFF
--- a/numba_cuda/numba/cuda/lowering.py
+++ b/numba_cuda/numba/cuda/lowering.py
@@ -138,6 +138,16 @@ class BaseLower(object):
                 warnings.warn(NumbaDebugInfoWarning(msg))
         return defn_loc
 
+    def _adjust_line_if_prologue(self, line):
+        """Adjust prologue line numbers to use the 'def' line.
+
+        The function prologue doesn't have corresponding source lines. These
+        instructions inherit line numbers from co_firstlineno, which points to
+        the decorator line when decorators are present. This method redirects
+        such lines to the 'def' line.
+        """
+        return self.defn_loc.line if line < self.defn_loc.line else line
+
     def pre_lower(self):
         """
         Called before lowering all blocks.
@@ -503,7 +513,9 @@ class Lower(BaseLower):
 
     def lower_inst(self, inst):
         # Set debug location for all subsequent LL instructions
-        self.debuginfo.mark_location(self.builder, self.loc.line)
+        self.debuginfo.mark_location(
+            self.builder, self._adjust_line_if_prologue(self.loc.line)
+        )
         self.notify_loc(self.loc)
         self.debug_print(str(inst))
         if isinstance(inst, ir.assign_types):
@@ -1659,7 +1671,7 @@ class Lower(BaseLower):
                     name=name,
                     lltype=lltype,
                     size=sizeof,
-                    line=self.loc.line,
+                    line=self._adjust_line_if_prologue(self.loc.line),
                     datamodel=datamodel,
                 )
         return aptr
@@ -1747,7 +1759,7 @@ class CUDALower(Lower):
             if isinstance(lltype, int_type + real_type):
                 sizeof = self.context.get_abi_sizeof(lltype)
                 datamodel = self.context.data_model_manager[fetype]
-                line = self.loc.line if argidx is None else self.defn_loc.line
+                line = self._adjust_line_if_prologue(self.loc.line)
                 if not name.startswith("$"):
                     # Emit debug value for user variable
                     src_name = name.split(".")[0]


### PR DESCRIPTION
Fixes nvbug5811746.

The root cause is that, when a kernel function has decorator, the code object's `co_firstlineno` points to the decorator line rather than the `def` line. During IR lowering, prologue code has no explicit source location, so `co_firstlineno` is used as the default line number. This caused prologue code to incorrectly reference the decorator line in DWARF debug information.

The problem can be reproduced with the following code example,
```
@cuda.jit("void(int64[:])", debug=True, opt=False)  # Line 270
def hybrid_loop_kernel(output):                     # Line 271
    idx = cuda.grid(1)                              # Line 272
```

This PR added `_adjust_line_if_prologue()` method in `lowering.py` that redirects any line number less than the `def` line to the `def` line. This ensures prologue instructions are associated with the function definition rather than decorators.

Before Fix - `.debug_line` table:
```
Address              Line
0x0000000000000000    271   ← def line
0x0000000000001c30    270   ← BUG: decorator line appears here
0x0000000000001f20    272   ← first statement
```

After Fix - `.debug_line` table:
```
Address              Line
0x0000000000000000    271   ← def line
0x0000000000001f20    272   ← first statement (no spurious 270!)
```

Also added a new test `test_prologue_line_number` which passes with the fix, fails without.