### PR TITLE
fix: extract handle value in Event.query() call to match other driver calls

### DIFF
--- a/numba_cuda/numba/cuda/cudadrv/driver.py
+++ b/numba_cuda/numba/cuda/cudadrv/driver.py
@@ -2046,14 +2046,14 @@ class Event:
         otherwise, returns False.
         """
         try:
-            driver.cuEventQuery(self.handle)
+            handle = self.handle.value
+            driver.cuEventQuery(handle)
+            return True
         except CudaAPIError as e:
             if e.code == binding.CUresult.CUDA_ERROR_NOT_READY:
                 return False
             else:
                 raise
-        else:
-            return True
 
     def record(self, stream=0):
         """

--- a/numba_cuda/numba/cuda/tests/cudadrv/test_events.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_events.py
@@ -95,5 +95,6 @@ class TestCudaEvent(CUDATestCase):
         synced_query = evt.query()
         assert synced_query is True, "Query returned False after sync"
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/numba_cuda/numba/cuda/tests/cudadrv/test_events.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_events.py
@@ -69,7 +69,6 @@ class TestCudaEvent(CUDATestCase):
         evt.record(stream)
 
         # Query immediately.
-        # Query immediately.
         event_time = perf_counter() - t0
         while not evt.query():
             event_time = perf_counter() - t0
@@ -78,11 +77,11 @@ class TestCudaEvent(CUDATestCase):
         evt.synchronize()
         sync_time = perf_counter() - t0
 
-        assert event_time * 1000 > spin_ms * 0.9  # nanosleep isn't reliable
-        assert sync_time * 1000 > spin_ms * 0.9  # nanosleep isn't reliable
+        # If this assertion fails, it was nanosleep inaccuracy that caused it
+        assert sync_time * 1000 > spin_ms * 0.9
 
-        # Give a few ms overhead for the synchronize call to complete
-        assert sync_time - event_time < 2e-3
+        # If this assertion fails, the event query returned early
+        assert event_time * 1000 > spin_ms * 0.9
 
 
 if __name__ == "__main__":

--- a/numba_cuda/numba/cuda/tests/cudadrv/test_events.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_events.py
@@ -69,15 +69,17 @@ class TestCudaEvent(CUDATestCase):
         evt.record(stream)
 
         # Query immediately.
+        # Query immediately.
+        event_time = perf_counter() - t0
         while not evt.query():
             event_time = perf_counter() - t0
 
-        # Syncronize and capture stream-finished time.
+        # Synchronize and capture stream-finished time.
         evt.synchronize()
         sync_time = perf_counter() - t0
 
-        assert event_time * 1000 > spin_ms * 0.9  # nanosleep isnt reliable
-        assert sync_time * 1000 > spin_ms * 0.9  # nanosleep isnt reliable
+        assert event_time * 1000 > spin_ms * 0.9  # nanosleep isn't reliable
+        assert sync_time * 1000 > spin_ms * 0.9  # nanosleep isn't reliable
 
         # Give a few ms overhead for the synchronize call to complete
         assert sync_time - event_time < 2e-3

--- a/numba_cuda/numba/cuda/tests/cudadrv/test_events.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_events.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import numpy as np
-from numba import cuda
+from numba import cuda, int32
 from numba.cuda.testing import unittest, CUDATestCase
 from cuda.core import Device
 from numba.cuda.testing import skip_on_cudasim
@@ -47,6 +47,40 @@ class TestCudaEvent(CUDATestCase):
         evtend.synchronize()
         # Exercise the code path
         evtstart.elapsed_time(evtend)
+
+    def test_event_query(self):
+        from time import perf_counter
+
+        @cuda.jit
+        def spin(ms):
+            # Sleep for ms
+            for i in range(ms):
+                cuda.nanosleep(int32(1_000_000))  # 1 ms
+
+        stream = cuda.stream()
+        evt = cuda.event()
+
+        # Run once to compile
+        spin[1, 1, stream](1)
+
+        t0 = perf_counter()
+        spin_ms = 250
+        spin[1, 1, stream](250)
+        evt.record(stream)
+
+        # Query immediately.
+        while not evt.query():
+            event_time = perf_counter() - t0
+
+        # Syncronize and capture stream-finished time.
+        evt.synchronize()
+        sync_time = perf_counter() - t0
+
+        assert event_time * 1000 > spin_ms * 0.9  # nanosleep isnt reliable
+        assert sync_time * 1000 > spin_ms * 0.9  # nanosleep isnt reliable
+
+        # Give a few ms overhead for the synchronize call to complete
+        assert sync_time - event_time < 2e-3
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## PR Description

This PR extracts `value` from the Event's handle and passes it to the driver function, mirroring surrounding code.
 
It looks as if the `Event.query` method missed out on the update in 20a2e3b4. The method includes a try/except statement to catch CUDA_ERROR_NOT_READY, but with a non-integer argument the method raises a `TypeError`. In my library on 0.23, no TypeErrors were raised for some reason, the call just returned True. On the current main branch, evt.query() raises the appropriate TypeError, as shown by the regression test in the PR. Using the handle.value instead fixes this and follows the pattern from the surrounding code.

## MWE

```python
from numba import cuda, int32
from time import perf_counter

@cuda.jit
def spin(ms):
    # Sleep for ms
    for i in range(ms):
        cuda.nanosleep(int32(1_000_000))  # 1 ms

stream = cuda.stream()
evt = cuda.event()

# Run once to compile
spin[1, 1, stream](1)

t0 = perf_counter()
spin_ms = 250
spin[1, 1, stream](250)
evt.record(stream)

# Query immediately.
while not evt.query():
    event_time = perf_counter() - t0

# Syncronize and capture stream-finished time.
evt.synchronize()
sync_time = perf_counter() - t0

print(f"Event time: {event_time}s")
print(f"Sync time:  {sync_time}s")
```

