### PR TITLE
Eliminate duplicate DWARF entries for boolean kernel parameters

### DIFF
--- a/numba_cuda/numba/cuda/lowering.py
+++ b/numba_cuda/numba/cuda/lowering.py
@@ -1786,10 +1786,9 @@ class CUDALower(Lower):
                             # Not yet covered by the dbg.value range
                             and src_name not in self.dbg_val_names
                         ):
-                            for index, item in enumerate(self.fnargs):
-                                if item.name == src_name:
-                                    argidx = index + 1
-                                    break
+                            # Use fndesc.args to get correct argidx for func args
+                            if src_name in self.fndesc.args:
+                                argidx = self.fndesc.args.index(src_name) + 1
                             # Insert the llvm.dbg.value intrinsic call
                             self.debuginfo.update_variable(
                                 self.builder,

--- a/numba_cuda/numba/cuda/tests/cudapy/test_debuginfo.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_debuginfo.py
@@ -1144,6 +1144,29 @@ class TestCudaDebugInfo(CUDATestCase):
         """
         self.assertFileCheckMatches(llvm_ir, check_pattern)
 
+    def test_bool_param_ref_only(self):
+        """Test that boolean parameters (ref-only) have single DILocalVariable.
+
+        When a boolean parameter is only referenced (not reassigned), it should
+        have exactly one DILocalVariable entry as a formal parameter (arg: N).
+
+        See nvbug5805171.
+        """
+        sig = (types.boolean, types.boolean)
+
+        @cuda.jit(sig, debug=True, opt=False)
+        def foo(flag1, flag2):
+            result = flag1 and flag2  # noqa: F841
+
+        llvm_ir = foo.inspect_llvm(sig)
+
+        # Each ref-only boolean parameter should have exactly one entry of
+        # DILocalVariable as a formal parameter
+        check_pattern = r"""
+            CHECK-COUNT-1: !DILocalVariable(arg: 1{{.*}}name: "flag1"
+            CHECK-COUNT-1: !DILocalVariable(arg: 2{{.*}}name: "flag2"""
+        self.assertFileCheckMatches(llvm_ir, check_pattern)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes NVBug#5805171.

Ref-only boolean parameters were generating duplicate DWARF entries (both `DW_TAG_formal_parameter` and `DW_TAG_variable`). This occurs in the code path that extends `dbg.value` coverage per basic block to accommodate NVVM. The debug info emission used LLVM-level argument names (`fnargs`) which differ from source-level names after calling convention transformation, causing the `argidx` lookup to fail and default to 0. This created a new `DILocalVariable` with `arg: 0` instead of reusing the existing formal parameter metadata.

The fix uses source-level argument names (`fndesc.args`) to get the correct `argidx`, allowing LLVM to deduplicate the metadata.

Added test `test_bool_param_ref_only`.