### PR TITLE
Clear `rtsys` during context reset

### DIFF
--- a/numba_cuda/numba/cuda/cudadrv/driver.py
+++ b/numba_cuda/numba/cuda/cudadrv/driver.py
@@ -1066,6 +1066,11 @@ class Context:
         self.modules.clear()
         # Clear trash
         self.deallocations.clear()
+        # Reset NRT runtime so it does not hold a dangling weakref to a
+        # module that was just removed from self.modules
+        from numba.cuda.memory_management.nrt import rtsys
+
+        rtsys.close()
 
     def get_memory_info(self):
         """Returns (free, total) memory in bytes in the context."""


### PR DESCRIPTION
This PR fixes an issue that intermittently surfaces in CI where the `rtsys` singleton remains valid after the context containing it's module has been reset. 

This fixes the immediate problem when running tests while leaving some wider questions from https://github.com/NVIDIA/numba-cuda/issues/573 open. 