### PR TITLE
Temporarily pin `cupy` to `<14.0.0` in thirdparty `cudf` tests

### DIFF
--- a/ci/test_thirdparty_cudf.sh
+++ b/ci/test_thirdparty_cudf.sh
@@ -25,6 +25,7 @@ python -m pip install \
     "nvidia-nvjitlink-cu12" \
     --group test
 
+# Temporary until cupy 14.0.1 is released
 pip install "cupy-cuda${CUDA_VER_MAJOR}x<14.0.0"
 
 


### PR DESCRIPTION
Thirdparty cuDF tests are broken currently but the cupy 14 release, this PR unblocks CI. 