### PR TITLE
Fix cache invalidation logic.

### DIFF
--- a/numba_cuda/numba/cuda/core/caching.py
+++ b/numba_cuda/numba/cuda/core/caching.py
@@ -101,7 +101,9 @@ class IndexDataCacheFile:
         self._index_path = os.path.join(self._cache_path, self._index_name)
         self._data_name_pattern = "%s.{number:d}.nbc" % (filename_base,)
         self._source_stamp = source_stamp
-        self._version = (numba.__version__, numba_cuda.__version__)
+        # Keep the shared index header aligned with CPU Numba so CPU and CUDA
+        # targets can continue to share one `.nbi` file for the same function.
+        self._version = numba.__version__
 
     def flush(self):
         self._save_index({})
@@ -329,7 +331,9 @@ class Cache(_Cache):
         Compute index key for the given signature and codegen.
         It includes a description of the OS, target architecture and hashes of
         the bytecode for the function and, if the function has a __closure__,
-        a hash of the cell_contents.
+        a hash of the cell_contents. The numba-cuda version is included so CUDA
+        cache entries invalidate on package upgrade without breaking the shared
+        index header used by CPU caches.
         """
         codebytes = self._py_func.__code__.co_code
         if self._py_func.__closure__ is not None:
@@ -344,6 +348,7 @@ class Cache(_Cache):
         return (
             sig,
             codegen.magic_tuple(),
+            numba_cuda.__version__,
             (
                 hasher(codebytes),
                 hasher(cvarbytes),

--- a/numba_cuda/numba/cuda/tests/nocuda/test_cache_version.py
+++ b/numba_cuda/numba/cuda/tests/nocuda/test_cache_version.py
@@ -5,43 +5,67 @@ import os
 import pickle
 import tempfile
 import unittest
+from unittest import mock
 
 import numba
 import numba_cuda
 
+from numba.cuda.core.caching import Cache, IndexDataCacheFile
+
+
+def dummy_func(x):
+    return x
+
+
+class DummyCodegen:
+    def magic_tuple(self):
+        return ("dummy",)
+
 
 class TestCacheVersion(unittest.TestCase):
-    def test_cache_version_includes_numba_cuda(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            from numba.cuda.core.caching import IndexDataCacheFile
+    @staticmethod
+    def make_key(version=None):
+        cache = object.__new__(Cache)
+        cache._py_func = dummy_func
+        codegen = DummyCodegen()
+        if version is None:
+            return Cache._index_key(cache, ("sig",), codegen)
+        with mock.patch.object(numba_cuda, "__version__", version):
+            return Cache._index_key(cache, ("sig",), codegen)
 
+    def test_cache_index_version_matches_numba(self):
+        with tempfile.TemporaryDirectory() as tmp:
             cache = IndexDataCacheFile(
                 cache_path=tmp,
                 filename_base="cache_version",
                 source_stamp=("stamp", 1),
             )
-            cache.save(("sig",), ("payload",))
+            cache.save(self.make_key(), ("payload",))
 
             index_path = os.path.join(tmp, "cache_version.nbi")
             with open(index_path, "rb") as f:
                 version = pickle.load(f)
 
-        self.assertEqual(version, (numba.__version__, numba_cuda.__version__))
+        self.assertEqual(version, numba.__version__)
 
-    def test_cache_version_mismatch_invalidates(self):
+    def test_cache_key_includes_numba_cuda(self):
+        key = self.make_key()
+
+        self.assertEqual(key[2], numba_cuda.__version__)
+
+    def test_cache_key_version_mismatch_invalidates(self):
         with tempfile.TemporaryDirectory() as tmp:
-            from numba.cuda.core.caching import IndexDataCacheFile
-
             cache = IndexDataCacheFile(
                 cache_path=tmp,
                 filename_base="cache_version",
                 source_stamp=("stamp", 1),
             )
-            index_path = os.path.join(tmp, "cache_version.nbi")
-            with open(index_path, "wb") as f:
-                pickle.dump(("0.0.0", "0.0.0"), f, protocol=-1)
+            old_key = self.make_key("0.0.0")
+            new_key = self.make_key("9.9.9")
+            cache.save(old_key, ("payload",))
 
-            self.assertEqual(cache._load_index(), {})
+            self.assertEqual(cache.load(old_key), ("payload",))
+            self.assertIsNone(cache.load(new_key))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR incorporates the numba-cuda version into the cache key to ensure caches are invalidated when *either* numba or numba-cuda versions change.  (This is required by some upcoming `cuda.coop` changes, which will require cache invalidation upon numba-cuda version changing.)