### PR TITLE
Fix incorrect DWARF type encodings for i8 and discriminator types

### DIFF
--- a/numba_cuda/numba/cuda/debuginfo.py
+++ b/numba_cuda/numba/cuda/debuginfo.py
@@ -654,11 +654,7 @@ class CUDADIBuilder(DIBuilder):
         m = self.module
 
         if isinstance(lltype, ir.IntType):
-            if datamodel is None:
-                if size == 1:
-                    name = str(lltype)
-                    is_bool = True
-            else:
+            if datamodel is not None:
                 name = str(datamodel.fe_type)
                 if isinstance(datamodel.fe_type, types.Boolean):
                     is_bool = True
@@ -766,7 +762,7 @@ class CUDADIBuilder(DIBuilder):
                         "baseType": m.add_debug_info(
                             "DIBasicType",
                             {
-                                "name": "int",
+                                "name": "uint8",
                                 "size": _BYTE_SIZE,
                                 "encoding": ir.DIToken("DW_ATE_unsigned"),
                             },

--- a/numba_cuda/numba/cuda/tests/cudapy/test_debuginfo_types.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_debuginfo_types.py
@@ -83,8 +83,7 @@ scalar_types: tuple[tuple[types.Type, str]] = (
         types.uint8,
         """
         CHECK-LLVMLITE-LE44: distinct !DISubprogram
-        CHECK: [[DBG86:.+]] = !DIBasicType(encoding: DW_ATE_unsigned
-        CHECK-SAME: name: "uint8", size: 8)
+        CHECK: [[DBG86:.+]] = !DIBasicType(encoding: DW_ATE_unsigned, name: "uint8", size: 8)
         CHECK: !DILocalVariable(
         CHECK-SAME: name: "a"
         CHECK-SAME: type: [[DBG86]]
@@ -255,7 +254,7 @@ array_types: tuple[tuple[types.Type, str]] = (
         CHECK: distinct !DICompileUnit
         CHECK: distinct !DISubprogram
 
-        CHECK-LLVMLITE-LE44: [[DBG127:.+]] = !DIBasicType(encoding: DW_ATE_boolean, name: "i8", size: 8)
+        CHECK-LLVMLITE-LE44: [[DBG127:.+]] = !DIBasicType(encoding: DW_ATE_unsigned, name: "i8", size: 8)
         CHECK-LLVMLITE-LE44: [[DBG128:.+]] = !DIDerivedType(
         CHECK-LLVMLITE-LE44-SAME: baseType: [[DBG127]]
         CHECK-LLVMLITE-LE44-SAME: size: 64
@@ -268,7 +267,7 @@ array_types: tuple[tuple[types.Type, str]] = (
         CHECK-LLVMLITE-LE44-SAME: size: 64
         CHECK-LLVMLITE-LE44-SAME: tag: DW_TAG_member
         CHECK-LLVMLITE-LE44-SAME: )
-        CHECK-LLVMLITE-LE44: [[DBG130:.+]] = !DIBasicType(encoding: DW_ATE_boolean, name: "i8", size: 8)
+        CHECK-LLVMLITE-LE44: [[DBG130:.+]] = !DIBasicType(encoding: DW_ATE_unsigned, name: "i8", size: 8)
         CHECK-LLVMLITE-LE44: [[DBG131:.+]] = !DIDerivedType(
         CHECK-LLVMLITE-LE44-SAME: baseType: [[DBG130]]
         CHECK-LLVMLITE-LE44-SAME: size: 64


### PR DESCRIPTION
This change fixes incorrect DWARF type encodings in debug info generation:

1. `i8` types without a datamodel (e.g., `i8*` pointers for `meminfo` and `parent` fields in array structs) were incorrectly encoded as `DW_ATE_boolean`, now encoded as `DW_ATE_unsigned`.

2. The discriminator field in polymorphic variant types was named `"int"` but had a size of 8 bits (1 byte), renamed to `"uint8"` to accurately reflect the type without confusion.

3. Updated `test_ditypes` wiyh corresponding type encoding and type name changes.

Fixes nvbug5809146.