### PR TITLE
Fix int64 elements DWARF encoding in UniTuple types

### DIFF
--- a/numba_cuda/numba/cuda/debuginfo.py
+++ b/numba_cuda/numba/cuda/debuginfo.py
@@ -299,7 +299,8 @@ class DIBuilder(AbstractDIBuilder):
         elif isinstance(datamodel, UniTupleModel):
             element = lltype.element
             el_size = self.cgctx.get_abi_sizeof(element)
-            basetype = self._var_type(element, el_size)
+            element_model = next(iter(datamodel.inner_models()), None)
+            basetype = self._var_type(element, el_size, datamodel=element_model)
             name = f"{datamodel.fe_type} ({str(lltype)})"
             count = size // el_size
             mdrange = m.add_debug_info(

--- a/numba_cuda/numba/cuda/tests/cudapy/test_debuginfo_types.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_debuginfo_types.py
@@ -252,6 +252,7 @@ array_types: tuple[tuple[types.Type, str]] = (
         types.float32[::1],
         """
         CHECK: distinct !DICompileUnit
+        CHECK: [[INT64_TYPE:![0-9]+]] = !DIBasicType(encoding: DW_ATE_signed, name: "int64", size: 64)
         CHECK: distinct !DISubprogram
 
         CHECK-LLVMLITE-LE44: [[DBG127:.+]] = !DIBasicType(encoding: DW_ATE_unsigned, name: "i8", size: 8)
@@ -309,7 +310,7 @@ array_types: tuple[tuple[types.Type, str]] = (
         CHECK-LLVMLITE-LE44-SAME: size: 64
         CHECK-LLVMLITE-LE44-SAME: tag: DW_TAG_member
         CHECK-LLVMLITE-LE44-SAME: )
-        CHECK-LLVMLITE-LE44: [[DBG140:.+]] = !DIBasicType(encoding: DW_ATE_unsigned, name: "i64", size: 64)
+        CHECK-LLVMLITE-LE44: [[DBG140:.+]] = !DIBasicType(encoding: DW_ATE_signed, name: "int64", size: 64)
         CHECK-LLVMLITE-LE44: [[DBG141:.+]] = !DICompositeType(
         CHECK-LLVMLITE-LE44-SAME: baseType: [[DBG140]]
         CHECK-LLVMLITE-LE44-SAME: identifier: "[1 x i64]"
@@ -323,7 +324,7 @@ array_types: tuple[tuple[types.Type, str]] = (
         CHECK-LLVMLITE-LE44-SAME: size: 64
         CHECK-LLVMLITE-LE44-SAME: tag: DW_TAG_member
         CHECK-LLVMLITE-LE44-SAME: )
-        CHECK-LLVMLITE-LE44: [[DBG143:.+]] = !DIBasicType(encoding: DW_ATE_unsigned, name: "i64", size: 64)
+        CHECK-LLVMLITE-LE44: [[DBG143:.+]] = !DIBasicType(encoding: DW_ATE_signed, name: "int64", size: 64)
         CHECK-LLVMLITE-LE44: [[DBG144:.+]] = !DICompositeType(
         CHECK-LLVMLITE-LE44-SAME: baseType: [[DBG143]]
         CHECK-LLVMLITE-LE44-SAME: identifier: "[1 x i64]"
@@ -402,7 +403,7 @@ array_types: tuple[tuple[types.Type, str]] = (
         CHECK-LLVMLITE-GE45-SAME: tag: DW_TAG_member
         CHECK-LLVMLITE-GE45-SAME: )
         CHECK-LLVMLITE-GE45: [[DBG131:.+]] = !DICompositeType(
-        CHECK-LLVMLITE-GE45-SAME: baseType: [[DBG111:![0-9]+]]
+        CHECK-LLVMLITE-GE45-SAME: baseType: [[INT64_TYPE]]
         CHECK-LLVMLITE-GE45-SAME: elements: [[DBG113:![0-9]+]]
         CHECK-LLVMLITE-GE45-SAME: identifier: "[1 x i64]"
         CHECK-LLVMLITE-GE45-SAME: name: "UniTuple(int64 x 1) ([1 x i64])"
@@ -417,7 +418,7 @@ array_types: tuple[tuple[types.Type, str]] = (
         CHECK-LLVMLITE-GE45-SAME: tag: DW_TAG_member
         CHECK-LLVMLITE-GE45-SAME: )
         CHECK-LLVMLITE-GE45: [[DBG133:.+]] = !DICompositeType(
-        CHECK-LLVMLITE-GE45-SAME: baseType: [[DBG111]]
+        CHECK-LLVMLITE-GE45-SAME: baseType: [[INT64_TYPE]]
         CHECK-LLVMLITE-GE45-SAME: elements: [[DBG113]]
         CHECK-LLVMLITE-GE45-SAME: identifier: "[1 x i64]"
         CHECK-LLVMLITE-GE45-SAME: name: "UniTuple(int64 x 1) ([1 x i64])"


### PR DESCRIPTION
This change fixes incorrect DWARF type encoding for `int64` elements in UniTuple types. The element type was encoded as `DW_ATE_unsigned` with name `"i64"` instead of `DW_ATE_signed` with name `"int64"`.

The fix is to retrieve the element's data model and pass to the type creation methond.

Also updated `test_ditypes` with necessary changes.

Fixes another issue in nvbug5809146.