### PR TITLE
Unpin nvjitlink from ctk version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ cu12 = [
     "cuda-bindings>=12.9.1,<13.0.0",
     "cuda-pathfinder>=1.3.4,<2.0.0",
     # install nvcc for libNVVM
-    "cuda-toolkit[cudart,nvcc,nvrtc,nvjitlink,cccl]==12.*",
+    "cuda-toolkit[cudart,nvcc,nvrtc,cccl]==12.*",
 
     # Older nvjitlink is not supported by cuda-bindings. It is okay to be out
     #  of sync with cuda-toolkit here, as long as the version compatibilty rules


### PR DESCRIPTION
Older nvjitlink are not supported by cuda-bindings: https://github.com/NVIDIA/cuda-python/blob/main/cuda_core/cuda/core/_linker.py#L66

However numba is committed to support all minor versions for the last two major releases: https://nvidia.github.io/numba-cuda/user/installation.html#supported-cuda-toolkits

nvjitlink is compatible accross different ctk versions as long as major version matched: https://docs.nvidia.com/cuda/archive/12.9.1/nvjitlink/index.html#compatibility

This allows using ltoir with ctk pre 12.3 by allowing newer nvjitlink being installed.

The only downgrade is that we can't enforce `nvjitlink>=cuda-toolkit` at pyproject level