### PR TITLE
Fix FP8 uint64 cast flake on Windows

### DIFF
--- a/numba_cuda/numba/cuda/_internal/cuda_fp8.py
+++ b/numba_cuda/numba/cuda/_internal/cuda_fp8.py
@@ -760,8 +760,8 @@ _from___nv_fp8_e5m2_to_uint32_lower(shim_stream, shim_obj)
 def _from___nv_fp8_e5m2_to_uint64_lower(shim_stream, shim_obj):
     shim_raw_str = """
     extern "C" __device__ int
-    _ZNK13__nv_fp8_e5m2cvmEv_nbst(unsigned long &retval, __nv_fp8_e5m2 *self) {
-        retval = self->operator unsigned long();
+    _ZNK13__nv_fp8_e5m2cvyEv_nbst(unsigned long long &retval, __nv_fp8_e5m2 *self) {
+        retval = self->operator unsigned long long();
         return 0;
     }
         """
@@ -770,7 +770,7 @@ def _from___nv_fp8_e5m2_to_uint64_lower(shim_stream, shim_obj):
     def impl(context, builder, fromty, toty, value):
         context.active_code_library.add_linking_file(shim_obj)
         callconv = FunctionCallConv(
-            itanium_mangled_name="_ZNK13__nv_fp8_e5m2cvmEv",
+            itanium_mangled_name="_ZNK13__nv_fp8_e5m2cvyEv",
             shim_writer=shim_writer,
             shim_code=shim_raw_str,
         )

--- a/numba_cuda/numba/cuda/tests/cudapy/test_fp8_bindings.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_fp8_bindings.py
@@ -218,7 +218,6 @@ class FP8ConversionTests(CUDATestCase):
                         )
                     )
 
-    @unittest.skip("flaky test - needs investigation (NVIDIA/numba-cuda#819)")
     def test_fp8_to_unsigned_integers(self):
         """Test FP8 conversion to unsigned integer types."""
 


### PR DESCRIPTION
Closes #819.

## Summary
- Use the `unsigned long long` (`cvy`) conversion overload for `fp8_e5m2 -> uint64` in generated FP8 bindings.
- Avoid ABI-width mismatch on Windows where `unsigned long` is 32-bit, which could produce incorrect `uint64` values.
- Re-enable `FP8ConversionTests.test_fp8_to_unsigned_integers` now that conversion is stable.

## Test plan
- [x] `pixi run pytest testing --pyargs numba.cuda.tests.cudapy.test_fp8_bindings -k fp8_to_unsigned_integers -q`
- [x] `pixi run pytest testing --pyargs numba.cuda.tests.cudapy.test_fp8_bindings -q`
- [x] `nix run 'nixpkgs#pre-commit' -- run --files numba_cuda/numba/cuda/_internal/cuda_fp8.py numba_cuda/numba/cuda/tests/cudapy/test_fp8_bindings.py`


Made with [Cursor](https://cursor.com)