### PR TITLE
fix(ci): cudaRoundMode typing failure in FP8 test

### DIFF
--- a/numba_cuda/numba/cuda/_internal/cuda_fp8.py
+++ b/numba_cuda/numba/cuda/_internal/cuda_fp8.py
@@ -20,7 +20,6 @@ from numba.cuda.extending import make_attribute_wrapper
 from numba.cuda.types import bool_
 from numba.cuda.types import uint64
 from llvmlite import ir
-from cuda.bindings.runtime import cudaRoundMode
 from numba.cuda.typing.templates import Registry as TypingRegistry
 from numba.cuda.types import uint32
 from numba.cuda.types import float32
@@ -228,6 +227,13 @@ class saturation_t(IntEnum):
 class fp8_interpretation_t(IntEnum):
     E4M3 = 0
     E5M2 = 1
+
+
+class cudaRoundMode(IntEnum):
+    cudaRoundNearest = 0
+    cudaRoundZero = 1
+    cudaRoundPosInf = 2
+    cudaRoundMinInf = 3
 
 
 # Structs:
@@ -3931,6 +3937,6 @@ _FUNCTION_SYMBOLS = [
 ]
 
 
-_ENUM_SYMBOLS = ["saturation_t", "fp8_interpretation_t"]
+_ENUM_SYMBOLS = ["saturation_t", "fp8_interpretation_t", "cudaRoundMode"]
 
 __all__ = _NBTYPE_SYMBOLS + _RECORD_SYMBOLS + _FUNCTION_SYMBOLS + _ENUM_SYMBOLS

--- a/numba_cuda/numba/cuda/tests/cudapy/test_fp8_bindings.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_fp8_bindings.py
@@ -46,8 +46,8 @@ if not config.ENABLE_CUDASIM:
         cvt_e8m0_to_bf16raw,
         saturation_t,
         fp8_interpretation_t,
+        cudaRoundMode,
     )
-    from cuda.bindings.runtime import cudaRoundMode
 
     FE8_TYPES = [fp8_e5m2, fp8_e4m3, fp8_e8m0]
 


### PR DESCRIPTION
Attempt to fix this [issue](https://github.com/NVIDIA/numba-cuda/issues/833).

cuda-bindings `13.2.0` changed `cudaRoundMode` from a standard Python `IntEnum` to a `FastEnumMetaclass` type. Numba's type inference cannot resolve FastEnumMetaclass types, causing three FP8 tests to fail ([ref](https://github.com/NVIDIA/cuda-python/pull/1581)). 

This PR replaces adds local IntEnum in `cuda_fp8.py`, matching the pattern already used for `saturation_t` and `fp8_interpretation_t.

If this works, let file a issue on the Numbast side (if needed).