### PR TITLE
Move cuda-pathfinder dependency to core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,13 @@ dependencies = [
     "numba>=0.60.0",
     "cuda-bindings>=12.9.1,<14.0.0",
     "cuda-core>=0.5.1,<1.0.0",
+    "cuda-pathfinder>=1.3.4,<2.0.0",
     "packaging",
 ]
 
 [project.optional-dependencies]
 cu12 = [
     "cuda-bindings>=12.9.1,<13.0.0",
-    "cuda-pathfinder>=1.3.4,<2.0.0",
     # install nvcc for libNVVM
     "cuda-toolkit[cudart,nvcc,nvrtc,cccl]==12.*",
 
@@ -42,7 +42,6 @@ cu12 = [
 ]
 cu13 = [
     "cuda-bindings==13.*",
-    "cuda-pathfinder>=1.3.4,<2.0.0",
     "cuda-toolkit[cudart,nvvm,nvrtc,cccl]==13.*",
 
     # It is okay to be out of sync with cuda-toolkit here, as long as the


### PR DESCRIPTION
Seems like `cuda-pathfinder` is required for both pypi base and system base ctk installation. It does not bring extra dependencies, so there should not be any problem.

Currently it is an issue when user installs `numba-cuda` without subpackages and provides ctk path. They will end up in the env that is missing (or out dated) required `cuda-pathfinder` package.