### PR TITLE
Support cuda_bindings FastEnum

### DIFF
--- a/numba_cuda/numba/cuda/_internal/cuda_fp8.py
+++ b/numba_cuda/numba/cuda/_internal/cuda_fp8.py
@@ -20,6 +20,7 @@ from numba.cuda.extending import make_attribute_wrapper
 from numba.cuda.types import bool_
 from numba.cuda.types import uint64
 from llvmlite import ir
+from cuda.bindings.runtime import cudaRoundMode
 from numba.cuda.typing.templates import Registry as TypingRegistry
 from numba.cuda.types import uint32
 from numba.cuda.types import float32
@@ -227,13 +228,6 @@ class saturation_t(IntEnum):
 class fp8_interpretation_t(IntEnum):
     E4M3 = 0
     E5M2 = 1
-
-
-class cudaRoundMode(IntEnum):
-    cudaRoundNearest = 0
-    cudaRoundZero = 1
-    cudaRoundPosInf = 2
-    cudaRoundMinInf = 3
 
 
 # Structs:
@@ -3937,6 +3931,6 @@ _FUNCTION_SYMBOLS = [
 ]
 
 
-_ENUM_SYMBOLS = ["saturation_t", "fp8_interpretation_t", "cudaRoundMode"]
+_ENUM_SYMBOLS = ["saturation_t", "fp8_interpretation_t"]
 
 __all__ = _NBTYPE_SYMBOLS + _RECORD_SYMBOLS + _FUNCTION_SYMBOLS + _ENUM_SYMBOLS

--- a/numba_cuda/numba/cuda/tests/cudapy/test_fp8_bindings.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_fp8_bindings.py
@@ -46,8 +46,8 @@ if not config.ENABLE_CUDASIM:
         cvt_e8m0_to_bf16raw,
         saturation_t,
         fp8_interpretation_t,
-        cudaRoundMode,
     )
+    from cuda.bindings.runtime import cudaRoundMode
 
     FE8_TYPES = [fp8_e5m2, fp8_e4m3, fp8_e8m0]
 

--- a/numba_cuda/numba/cuda/typing/typeof.py
+++ b/numba_cuda/numba/cuda/typing/typeof.py
@@ -19,6 +19,14 @@ from numba.cuda.np import numpy_support
 from cuda.core import Buffer
 from cuda.core.utils import StridedMemoryView
 
+# As of cuda_bindings 13.2, it uses its own enum implementation and we need to
+# extend the type conversions to support them.
+
+try:
+    from cuda.bindings._internal import _fast_enum
+except ImportError:
+    _fast_enum = None
+
 
 # terminal color markup
 _termcolor = errors.termcolor()
@@ -240,6 +248,10 @@ def _typeof_enum(val, c):
     return clsty.member_type
 
 
+if _fast_enum is not None:
+    _typeof_enum = typeof_impl.register(_fast_enum.FastEnum)(_typeof_enum)
+
+
 @typeof_impl.register(enum.EnumMeta)
 def _typeof_enum_class(val, c):
     cls = val
@@ -254,9 +266,17 @@ def _typeof_enum_class(val, c):
         )
     if issubclass(val, enum.IntEnum):
         typecls = types.IntEnumClass
+    elif _fast_enum is not None and issubclass(val, _fast_enum.FastEnum):
+        typecls = types.IntEnumClass
     else:
         typecls = types.EnumClass
     return typecls(cls, dtypes.pop())
+
+
+if _fast_enum is not None:
+    _typeof_enum_class = typeof_impl.register(_fast_enum.FastEnumMetaclass)(
+        _typeof_enum_class
+    )
 
 
 @typeof_impl.register(np.dtype)


### PR DESCRIPTION
To support the new `FastEnum` class in `cuda_bindings` 13.2, this adds new type registrations to support them.  These instances are otherwise 100% API-compatible with `enum.IntEnum`, so there is no new logic.

This should hopefully be a more sustainable solution than overriding individual enums, so this also reverts https://github.com/NVIDIA/numba-cuda/pull/834.

