### PR TITLE
add fma arg to disable compiling with FMA

### DIFF
--- a/numba_cuda/numba/cuda/compiler.py
+++ b/numba_cuda/numba/cuda/compiler.py
@@ -977,6 +977,7 @@ def compile_all(
     lineinfo=False,
     device=True,
     fastmath=False,
+    fma=True,
     cc=None,
     opt=None,
     abi="c",
@@ -1010,6 +1011,7 @@ def compile_all(
         lineinfo=lineinfo,
         device=device,
         fastmath=fastmath,
+        fma=fma,
         cc=cc,
         opt=opt,
         abi=abi,
@@ -1051,6 +1053,7 @@ def _compile_pyfunc_with_fixup(
     lineinfo=False,
     device=True,
     fastmath=False,
+    fma=True,
     cc=None,
     opt=None,
     abi="c",
@@ -1092,6 +1095,8 @@ def _compile_pyfunc_with_fixup(
     abi_info = abi_info or dict()
 
     nvvm_options = {"fastmath": fastmath, "opt": 3 if opt else 0}
+    if not fma:
+        nvvm_options["fma"] = False
 
     if debug:
         nvvm_options["g"] = None
@@ -1139,6 +1144,7 @@ def compile(
     lineinfo=False,
     device=True,
     fastmath=False,
+    fma=True,
     cc=None,
     opt=None,
     abi="c",
@@ -1218,6 +1224,7 @@ def compile(
         lineinfo=lineinfo,
         device=device,
         fastmath=fastmath,
+        fma=fma,
         cc=cc,
         opt=opt,
         abi=abi,
@@ -1248,6 +1255,7 @@ def compile_for_current_device(
     lineinfo=False,
     device=True,
     fastmath=False,
+    fma=True,
     opt=None,
     abi="c",
     abi_info=None,
@@ -1266,6 +1274,7 @@ def compile_for_current_device(
         lineinfo=lineinfo,
         device=device,
         fastmath=fastmath,
+        fma=fma,
         cc=cc,
         opt=opt,
         abi=abi,
@@ -1283,6 +1292,7 @@ def compile_ptx(
     lineinfo=False,
     device=False,
     fastmath=False,
+    fma=True,
     cc=None,
     opt=None,
     abi="numba",
@@ -1301,6 +1311,7 @@ def compile_ptx(
         lineinfo=lineinfo,
         device=device,
         fastmath=fastmath,
+        fma=fma,
         cc=cc,
         opt=opt,
         abi=abi,
@@ -1318,6 +1329,7 @@ def compile_ptx_for_current_device(
     lineinfo=False,
     device=False,
     fastmath=False,
+    fma=True,
     opt=None,
     abi="numba",
     abi_info=None,
@@ -1334,6 +1346,7 @@ def compile_ptx_for_current_device(
         lineinfo=lineinfo,
         device=device,
         fastmath=fastmath,
+        fma=fma,
         cc=cc,
         opt=opt,
         abi=abi,

--- a/numba_cuda/numba/cuda/dispatcher.py
+++ b/numba_cuda/numba/cuda/dispatcher.py
@@ -110,6 +110,7 @@ class _Kernel(serialize.ReduceMixin):
         inline=False,
         forceinline=False,
         fastmath=False,
+        fma=True,
         extensions=None,
         max_registers=None,
         lto=False,
@@ -145,7 +146,13 @@ class _Kernel(serialize.ReduceMixin):
         self.extensions = extensions or []
         self.launch_bounds = launch_bounds
 
-        nvvm_options = {"fastmath": fastmath, "opt": 3 if opt else 0}
+        nvvm_options = {
+            "fastmath": fastmath,
+            "opt": 3 if opt else 0,
+        }
+
+        if not fma:
+            nvvm_options["fma"] = False
 
         if debug:
             nvvm_options["g"] = None
@@ -1840,11 +1847,15 @@ class CUDADispatcher(serialize.ReduceMixin, _MemoMixin, _DispatcherBase):
                 forceinline = self.targetoptions.get("forceinline")
                 inline = self.targetoptions.get("inline", "never")
                 fastmath = self.targetoptions.get("fastmath")
+                fma = self.targetoptions.get("fma", True)
 
                 nvvm_options = {
                     "opt": 3 if self.targetoptions.get("opt") else 0,
                     "fastmath": fastmath,
                 }
+
+                if not fma:
+                    nvvm_options["fma"] = False
 
                 if debug:
                     nvvm_options["g"] = None

--- a/numba_cuda/numba/cuda/tests/cudapy/test_fma.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_fma.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+from typing import List
+from dataclasses import dataclass, field
+from numba import cuda, float32
+from numba.cuda.compiler import compile_ptx_for_current_device
+from numba.cuda.testing import CUDATestCase, skip_on_cudasim
+import unittest
+
+
+@dataclass
+class FMACriterion:
+    fma_expected: List[str] = field(default_factory=list)
+    fma_unexpected: List[str] = field(default_factory=list)
+    nofma_expected: List[str] = field(default_factory=list)
+    nofma_unexpected: List[str] = field(default_factory=list)
+
+    def check(self, test: CUDATestCase, fma_ptx: str, nofma_ptx: str):
+        test.assertTrue(all(i in fma_ptx for i in self.fma_expected))
+        test.assertTrue(all(i not in fma_ptx for i in self.fma_unexpected))
+        test.assertTrue(all(i in nofma_ptx for i in self.nofma_expected))
+        test.assertTrue(all(i not in nofma_ptx for i in self.nofma_unexpected))
+
+
+@skip_on_cudasim("FMA option and PTX inspection not available on cudasim")
+class TestFMAOption(CUDATestCase):
+    def _test_fma_common(self, pyfunc, sig, device, criterion):
+        # Test jit code path
+        fmaver = cuda.jit(sig, device=device)(pyfunc)
+        nofmaver = cuda.jit(sig, device=device, fma=False)(pyfunc)
+
+        criterion.check(
+            self, fmaver.inspect_asm(sig), nofmaver.inspect_asm(sig)
+        )
+
+        # Test compile_ptx code path
+        fmaptx, _ = compile_ptx_for_current_device(pyfunc, sig, device=device)
+        nofmaptx, _ = compile_ptx_for_current_device(
+            pyfunc, sig, device=device, fma=False
+        )
+
+        criterion.check(self, fmaptx, nofmaptx)
+
+    def _test_fma_unary(self, op, criterion):
+        def kernel(r, x):
+            r[0] = op(x)
+
+        def device_function(x):
+            return op(x)
+
+        self._test_fma_common(
+            kernel, (float32[::1], float32), device=False, criterion=criterion
+        )
+        self._test_fma_common(
+            device_function, (float32,), device=True, criterion=criterion
+        )
+
+    def test_muladd(self):
+        # x * y + z is the canonical FMA candidate: the compiler should
+        # contract it into a single fma.rn.f32 instruction by default.
+        def kernel(r, x, y, z):
+            r[0] = x * y + z
+
+        def device_function(x, y, z):
+            return x * y + z
+
+        criterion = FMACriterion(
+            fma_expected=["fma.rn.f32"],
+            nofma_unexpected=["fma.rn.f32"],
+        )
+
+        self._test_fma_common(
+            kernel,
+            (float32[::1], float32, float32, float32),
+            device=False,
+            criterion=criterion,
+        )
+        self._test_fma_common(
+            device_function,
+            (float32, float32, float32),
+            device=True,
+            criterion=criterion,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--

Thank you for contributing to numba-cuda :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
This PR adapts my changes in https://github.com/numba/numba/pull/10487 for this repo

closes https://github.com/NVIDIA/numba-cuda/issues/118 and https://github.com/numba/numba/issues/2834 and partially addresses https://github.com/numba/numba/issues/7719

This PR adds the fma flag to the cuda.jit decorator, which is passed onto nvvm options.

Setting this flag to False prevents the compiler from reordering operations to introduce FMAs. Very important for checking bitwise-reproducibility e.g. when comparing CPU and GPU results