### PR TITLE
Fix CABI calling convention: skip env global and escape mangled names

### DIFF
--- a/numba_cuda/numba/cuda/core/callconv.py
+++ b/numba_cuda/numba/cuda/core/callconv.py
@@ -53,6 +53,8 @@ RETCODE_USEREXC = _const_int(FIRST_USEREXC)
 
 
 class BaseCallConv:
+    needs_env = True
+
     def __init__(self, context):
         self.context = context
 
@@ -398,7 +400,12 @@ class CUDACABICallConv(BaseCallConv):
         <Python return type> (<Python arguments>)
 
     Exceptions are unsupported in this convention.
+
+    No Numba environment pointer is needed because there is no error-status
+    channel to propagate exceptions through.
     """
+
+    needs_env = False
 
     def _make_call_helper(self, builder):
         # Call helpers are used to help report exceptions back to Python, so
@@ -501,10 +508,10 @@ class CUDACABICallConv(BaseCallConv):
         return self.context.data_model_manager[ty].get_return_type()
 
     def mangler(self, name, argtypes, *, abi_tags=None, uid=None):
+        escaped = itanium_mangler.escape_string(name.split(".")[-1])
         if name.startswith(".NumbaEnv."):
-            func_name = name.split(".")[-1]
-            return f"_ZN08NumbaEnv{func_name}"
-        return name.split(".")[-1]
+            return f"_ZN08NumbaEnv{escaped}"
+        return escaped
 
 
 class ErrorModel:

--- a/numba_cuda/numba/cuda/itanium_mangler.py
+++ b/numba_cuda/numba/cuda/itanium_mangler.py
@@ -62,25 +62,32 @@ N2CODE = {
 }
 
 
-def _escape_string(text):
+def escape_string(text):
     """Escape the given string so that it only contains ASCII characters
-    of [a-zA-Z0-9_$].
+    valid in mangled names: ``[a-zA-Z0-9_]``.
 
-    The dollar symbol ($) and other invalid characters are escaped into
-    the string sequence of "$xx" where "xx" is the hex codepoint of the char.
+    Invalid characters are hex-escaped as ``_xx`` where *xx* is the two-digit
+    hex code point.  Multibyte (non-ASCII) characters are first encoded to
+    UTF-8 and each byte is escaped individually.
 
-    Multibyte characters are encoded into utf8 and converted into the above
-    hex format.
+    Examples::
+
+        >>> escape_string("hello")
+        'hello'
+        >>> escape_string("<lambda>")
+        '_3clambda_3e'
     """
 
     def repl(m):
         return "".join(("_%02x" % ch) for ch in m.group(0).encode("utf8"))
 
     ret = re.sub(_re_invalid_char, repl, text)
-    # Return str if we got a unicode (for py2)
     if not isinstance(ret, str):
         return ret.encode("ascii")
     return ret
+
+
+_escape_string = escape_string
 
 
 def _fix_lead_digit(text):

--- a/numba_cuda/numba/cuda/lowering.py
+++ b/numba_cuda/numba/cuda/lowering.py
@@ -228,8 +228,10 @@ class BaseLower:
         self.context.declare_env_global(self.module, envname)
 
     def lower(self):
-        # Emit the Env into the module
-        self.emit_environment_object()
+        # Emit the Env into the module (only needed for calling conventions
+        # that use a Numba environment for error-status propagation).
+        if self.call_conv.needs_env:
+            self.emit_environment_object()
         if self.generator_info is None:
             self.genlower = None
             self.lower_normal_function(self.fndesc)

--- a/numba_cuda/numba/cuda/tests/core/test_itanium_mangler.py
+++ b/numba_cuda/numba/cuda/tests/core/test_itanium_mangler.py
@@ -8,6 +8,32 @@ from numba.cuda import itanium_mangler
 import unittest
 
 
+class TestEscapeString(unittest.TestCase):
+    def test_plain_ascii(self):
+        self.assertEqual(itanium_mangler.escape_string("hello"), "hello")
+
+    def test_underscores_and_digits(self):
+        self.assertEqual(
+            itanium_mangler.escape_string("my_func_2"), "my_func_2"
+        )
+
+    def test_angle_brackets(self):
+        self.assertEqual(
+            itanium_mangler.escape_string("<lambda>"), "_3clambda_3e"
+        )
+
+    def test_dot(self):
+        self.assertEqual(itanium_mangler.escape_string("a.b"), "a_2eb")
+
+    def test_empty_string(self):
+        self.assertEqual(itanium_mangler.escape_string(""), "")
+
+    def test_backward_compat_alias(self):
+        self.assertIs(
+            itanium_mangler._escape_string, itanium_mangler.escape_string
+        )
+
+
 class TestItaniumManager(unittest.TestCase):
     def test_ident(self):
         got = itanium_mangler.mangle_identifier("apple")

--- a/numba_cuda/numba/cuda/tests/cudapy/test_compiler.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_compiler.py
@@ -449,6 +449,55 @@ class TestCompile(unittest.TestCase):
             r"func_retval0\)\s+_Z4funcii\(",
         )
 
+    def test_c_abi_lambda_with_abi_name(self):
+        """Compiling a lambda with CABI + abi_name should produce valid IR.
+
+        Lambdas have ``<lambda>`` as their qualname; the angle brackets must be
+        escaped when mangling names for NVVM.
+        """
+        abi_info = {"abi_name": "blah"}
+
+        with self.subTest("compile_ptx"):
+            self._test_c_abi_lambda_with_abi_name(
+                compile_ptx,
+                {"device": True, "abi": "c", "abi_info": abi_info},
+            )
+
+        with self.subTest("compile_all"):
+            self._test_c_abi_lambda_with_abi_name(
+                compile_all,
+                {
+                    "device": True,
+                    "abi": "c",
+                    "abi_info": abi_info,
+                    "output": "ptx",
+                },
+            )
+
+    def _test_c_abi_lambda_with_abi_name(
+        self, compile_function, default_kwargs
+    ):
+        ret = compile_function(lambda x: x, int32(int32), **default_kwargs)
+        ptx, resty = self._handle_compile_result(ret, compile_function)
+
+        self.assertRegex(
+            ptx,
+            r"\.visible\s+\.func\s+\(\.param\s+\.b32\s+"
+            r"func_retval0\)\s+blah\(",
+        )
+
+    def test_c_abi_no_env_global(self):
+        """CABI functions should not emit a NumbaEnv global."""
+        ret = compile_ptx(lambda x: x, int32(int32), device=True, abi="c")
+        ptx, _ = self._handle_compile_result(ret, compile_ptx)
+        self.assertNotIn("NumbaEnv", ptx)
+
+    def test_numba_abi_has_env_global(self):
+        """Numba-ABI functions still require a NumbaEnv global."""
+        ret = compile_ptx(lambda x: x, int32(int32), device=True, abi="numba")
+        ptx, _ = self._handle_compile_result(ret, compile_ptx)
+        self.assertIn("NumbaEnv", ptx)
+
     def test_c_abi_boolean_return(self):
         """
         Tests that returning a raw boolean comparison (a == b) compiles correctly


### PR DESCRIPTION
## Summary

- **Skip emitting the `NumbaEnv` global for CABI functions.** The `CUDACABICallConv` has no error-status channel and never references the environment, yet the lowering pass unconditionally emitted it. A new `needs_env` class attribute on `BaseCallConv` (default `True`, overridden to `False` in `CUDACABICallConv`) now guards `emit_environment_object()`.
- **Fix `CUDACABICallConv.mangler` to escape special characters.** The mangler used a naive `name.split(".")[-1]` which passed raw `<lambda>` (with angle brackets) into LLVM global names, causing `ERROR_INVALID_IR` from NVVM. It now uses `itanium_mangler.escape_string()` to hex-escape invalid characters (e.g. `<` → `_3c`).
- **Promote `_escape_string` to public API** as `escape_string` with a backward-compatible alias.

## Test plan

- [x] New `TestEscapeString` tests in `test_itanium_mangler.py` (6 cases: plain ASCII, digits/underscores, angle brackets, dot, empty string, backward-compat alias)
- [x] New `test_c_abi_lambda_with_abi_name` in `test_compiler.py` -- compiles a lambda with `abi_info={"abi_name": "blah"}` via `compile_ptx` and `compile_all`, verifies PTX contains the correct function name
- [x] New `test_c_abi_no_env_global` -- verifies CABI PTX does not contain `NumbaEnv`
- [x] New `test_numba_abi_has_env_global` -- verifies Numba-ABI PTX still contains `NumbaEnv`
- [x] All existing `c_abi` tests pass without regression

Made with [Cursor](https://cursor.com)