### PR TITLE
Fix CABI return type mismatch when calling Numba-ABI subroutines

### DIFF
--- a/numba_cuda/numba/cuda/core/imputils.py
+++ b/numba_cuda/numba/cuda/core/imputils.py
@@ -222,7 +222,9 @@ def user_function(fndesc, libs):
 
         if status is not None:
             with cgutils.if_unlikely(builder, status.is_error):
-                fndesc.call_conv.return_status_propagate(builder, status)
+                context.fndesc.call_conv.return_status_propagate(
+                    builder, status
+                )
 
         assert sig.return_type == fndesc.restype
 

--- a/numba_cuda/numba/cuda/tests/cudapy/test_compiler.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_compiler.py
@@ -837,7 +837,7 @@ class TestCompile(unittest.TestCase):
             wrapper_func, types.int32(types.int32), output="ltoir", abi="c"
         )
 
-    def test_compile_CABI_calling_overloaded_function(self):
+    def test_compile_cabi_calling_overloaded_function(self):
         # Reproducer from gh-841
         # https://github.com/NVIDIA/numba-cuda/issues/841
         #

--- a/numba_cuda/numba/cuda/tests/cudapy/test_compiler.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_compiler.py
@@ -817,7 +817,7 @@ class TestCompile(unittest.TestCase):
 
         cuda.compile(wrapper, wrapper_sig.args, output="ltoir")
 
-    def test_compile_CABI_calling_device_function_returning_optional(self):
+    def test_compile_cabi_calling_device_function_returning_optional(self):
         # Exercise a CABI caller invoking a Numba ABI callee that can return
         # None through Optional[int32]
         def maybe_none(x):

--- a/numba_cuda/numba/cuda/tests/cudapy/test_compiler.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_compiler.py
@@ -4,7 +4,7 @@
 import os
 from math import sqrt
 from numba import cuda
-from numba.core.extending import intrinsic
+from numba.core.extending import intrinsic, overload
 
 from numba.cuda import float32, int16, int32, int64, types, uint32, void
 from numba.cuda import (
@@ -836,6 +836,34 @@ class TestCompile(unittest.TestCase):
         cuda.compile(
             wrapper_func, types.int32(types.int32), output="ltoir", abi="c"
         )
+
+    def test_compile_CABI_calling_overloaded_function(self):
+        # Reproducer from gh-841
+        # https://github.com/NVIDIA/numba-cuda/issues/841
+        #
+        # When a CABI function calls an overloaded function (compiled as a
+        # Numba-ABI subroutine), the error-status return path must use the
+        # caller's calling convention. Previously the callee's Numba-ABI
+        # convention was used, emitting `ret i32` (the status code) inside a
+        # function whose declared return type did not match, producing invalid
+        # LLVM IR.
+
+        def _my_func(x):
+            pass
+
+        @overload(_my_func)
+        def _ov_my_func(x):
+            if isinstance(x, types.IntegerLiteral):
+
+                def impl(x):
+                    return int32(0)
+
+                return impl
+
+        def caller():
+            _my_func(0)
+
+        cuda.compile(caller, (), abi_info={"abi_name": "caller"}, abi="c")
 
     def test_compile_complex_div_c_abi(self):
         # Reproducer from gh-789

--- a/numba_cuda/numba/cuda/tests/cudapy/test_device_func.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_device_func.py
@@ -557,6 +557,34 @@ class TestDeclareDeviceCABI(CUDATestCase):
         kernel[1, 32](r, x)
         np.testing.assert_equal(r, x * 2)
 
+    def test_declare_device_cabi_propagate(self):
+        # Ensures that a device function calling a C ABI function correctly
+        # propoagates the error status to its caller. No error status is
+        # provided by the C ABI function, so the device function that calls it
+        # should return status 0 (no error).
+        times2 = cuda.declare_device(
+            "times2", "int32(int32)", link=times2_cabi_cu, abi="c"
+        )
+
+        @cuda.jit
+        def device_func(x):
+            return times2(x)
+
+        @cuda.jit
+        def kernel(r, x):
+            i = cuda.grid(1)
+            if i < len(r):
+                r[i] = device_func(x[i])
+
+        x = np.arange(10, dtype=np.int32)
+        r = np.empty_like(x)
+        kernel[1, 32](r, x)
+        np.testing.assert_equal(r, x * 2)
+
+        compile_result = device_func.overloads[device_func.signatures[0]]
+        device_func_ir = compile_result.library.get_llvm_str()
+        self.assertIn("ret i32 0", device_func_ir)
+
     def test_declare_device_cabi_zero_args(self):
         const42 = cuda.declare_device(
             "const42", "int32()", link=const42_cabi_cu, abi="c"


### PR DESCRIPTION
## Summary

- Fix `user_function` in `imputils.py` to use the **caller's** calling convention (`context.fndesc.call_conv`) for `return_status_propagate`, instead of the **callee's** (`fndesc.call_conv`). When a CABI function called a Numba-ABI subroutine (e.g. an overloaded function), the callee's `MinimalCallConv.return_status_propagate` emitted `ret i32 <status_code>` inside a function whose declared return type was the user type (e.g. `i8*` for `NoneType`), producing invalid LLVM IR.
- Add regression test `test_compile_CABI_calling_overloaded_function` that compiles a C ABI function calling an `@overload`-ed Numba-ABI subroutine.

Closes #841

## Test plan

- [x] New test `test_compile_CABI_calling_overloaded_function` passes
- [x] Full `test_compiler.py` suite passes (34 passed, 3 skipped)
- [x] Full `test_device_func.py` suite passes (30 passed, 1 skipped)

Made with [Cursor](https://cursor.com)