### PR TITLE
Fix flaky test_max_pending_count by preventing premature GC

### DIFF
--- a/numba_cuda/numba/cuda/tests/cudadrv/test_deallocations.py
+++ b/numba_cuda/numba/cuda/tests/cudadrv/test_deallocations.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from contextlib import contextmanager
+import gc
 
 import numpy as np
 
@@ -24,12 +25,18 @@ class TestDeallocation(CUDATestCase):
         deallocs = cuda.current_context().memory_manager.deallocations
         deallocs.clear()
         self.assertEqual(len(deallocs), 0)
-        # deallocate to maximum count
+        # Allocate device arrays, keeping references to prevent GC from
+        # collecting them prematurely (which caused flaky counts).
+        arrays = [cuda.to_device(np.arange(1))
+                  for _ in range(config.CUDA_DEALLOCS_COUNT)]
+        # Delete arrays one by one and check pending count increments
         for i in range(config.CUDA_DEALLOCS_COUNT):
-            cuda.to_device(np.arange(1))
+            del arrays[i]
+            gc.collect()  # Ensure finalizers run
             self.assertEqual(len(deallocs), i + 1)
         # one more to trigger .clear()
         cuda.to_device(np.arange(1))
+        gc.collect()
         self.assertEqual(len(deallocs), 0)
 
     @skip_if_external_memmgr("Deallocation specific to Numba memory management")


### PR DESCRIPTION
## Problem

TestDeallocation.test_max_pending_count is flaky — intermittently fails with .

## Root Cause

The test creates DeviceNDArray objects without storing references:

```python
for i in range(config.CUDA_DEALLOCS_COUNT):
    cuda.to_device(np.arange(1))  # no reference stored
    self.assertEqual(len(deallocs), i + 1)
```

Each `cuda.to_device()` returns a DeviceNDArray → OwnedPointer → weakref.finalizer. When Python's GC non-deterministically collects these temporaries between loop iterations, their finalizers fire early and add deallocations to the pending queue. This makes `len(deallocs)` exceed the expected `i + 1`.

## Fix

1. Store all device arrays in a list during creation
2. Delete them one by one in a controlled loop
3. Call `gc.collect()` after each deletion to ensure finalizers fire

This makes deallocation timing fully deterministic.

## Reproduction

The flakiness depends on GC timing — it happens more frequently with high memory pressure or when running the full test suite (where previous tests accumulate GC-tracked objects).

Fixes #856