### PR TITLE
Fix Windows path parsing in generate_raw_ltoir.py

### DIFF
--- a/testing/generate_raw_ltoir.py
+++ b/testing/generate_raw_ltoir.py
@@ -5,6 +5,7 @@ import argparse
 import os
 import pathlib
 import platform
+import shlex
 import subprocess
 import sys
 
@@ -77,7 +78,9 @@ def determine_include_flags():
     # Parse out the arguments following "INCLUDES=" - these are a space
     # separated list of strings that are potentially quoted.
 
-    quoted_flags = includes_lines[0].split("INCLUDES=")[1].strip().split()
+    quoted_flags = shlex.split(
+        includes_lines[0].split("INCLUDES=")[1].strip(), posix=False
+    )
     include_flags = [flag.strip('"') for flag in quoted_flags]
     cccl_include_flags = [flag + os.path.sep + "cccl" for flag in include_flags]
     include_flags += cccl_include_flags


### PR DESCRIPTION
This is to fix path parsing issue in generate_raw_ltoir.py on Windows platform. 

Build failed:
make -j%NUMBER_OF_PROCESSORS% "NVCC_FLAGS=-O3 -rdc true -std=c++17 -Xcompiler=/Zc:preprocessor"
...
Using CUDA include flags: ['-IC:\\Program', 'Files\\NVIDIA', 'GPU', 'Computing', 'Toolkit\\CUDA\\v13.2\\bin/../include', '-IC:\\Program', 'Files\\NVIDIA', 'GPU', 'Computing', 'Toolkit\\CUDA\\v13.2\\bin/../include/cccl', '-IC:\\Program\\cccl', 'Files\\NVIDIA\\cccl', 'GPU\\cccl', 'Computing\\cccl', 'Toolkit\\CUDA\\v13.2\\bin/../include\\cccl', '-IC:\\Program\\cccl', 'Files\\NVIDIA\\cccl', 'GPU\\cccl', 'Computing\\cccl', 'Toolkit\\CUDA\\v13.2\\bin/../include/cccl\\cccl']
NVRTC error, code 5: NVRTC_ERROR_INVALID_OPTION
make: *** [Makefile:84: test_device_functions.ltoir] Error 1
make: *** Waiting for unfinished jobs....
make: *** [Makefile:117: nrt_extern.ltoir] Error 1
...

On Windows, CUDA typically lives under C:\Program Files\..., so the INCLUDES= line  include flags with spaces inside double quotes, e.g. -I"C:\Program Files\NVIDIA GPU Computing Toolkit\...\include". The str.split() splits on whitespace and doesn't know about quotes, so it splits the path in half. shlex.split could treat quoted substrings as a single token, so paths with spaces could be split correctly on Windows.

After the fix, build on Windows could pass.