### PR TITLE
Remove Conflicting Lowering for FP8->Int8 Conversion

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -174,9 +174,11 @@ jobs:
 
       - name: Install latest rapidsai/sccache
         if: ${{ startsWith(inputs.host-platform, 'linux') }}
+        env:
+          SCCACHE_TAG: v0.14.0-rapids.3
         run: |
-          curl -fsSL "https://github.com/rapidsai/sccache/releases/latest/download/sccache-$(uname -m)-unknown-linux-musl.tar.gz" \
-            | sudo tar -C /usr/local/bin -xvzf - --wildcards --strip-components=1 -x '*/sccache'
+          # curl -fsSL "https://github.com/rapidsai/sccache/releases/latest/download/sccache-$(uname -m)-unknown-linux-musl.tar.gz" \
+          curl -fsSL "https://github.com/rapidsai/sccache/releases/download/${{ env.SCCACHE_TAG }}/sccache-${{ env.SCCACHE_TAG }}-$(uname -m)-unknown-linux-musl.tar.gz" \
           echo "SCCACHE_PATH=/usr/local/bin/sccache" >> "$GITHUB_ENV"
           echo "SCCACHE_GHA_USE_PREPROCESSOR_CACHE_MODE=true" >> "$GITHUB_ENV"
 

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -46,8 +46,11 @@ jobs:
 
       - name: Install latest rapidsai/sccache
         if: ${{ startsWith(inputs.host-platform, 'linux') }}
+        env:
+          SCCACHE_TAG: v0.14.0-rapids.3
         run: |
-          curl -fsSL "https://github.com/rapidsai/sccache/releases/latest/download/sccache-$(uname -m)-unknown-linux-musl.tar.gz" \
+          # curl -fsSL "https://github.com/rapidsai/sccache/releases/latest/download/sccache-$(uname -m)-unknown-linux-musl.tar.gz" \
+          curl -fsSL "https://github.com/rapidsai/sccache/releases/download/${{ env.SCCACHE_TAG }}/sccache-${{ env.SCCACHE_TAG }}-$(uname -m)-unknown-linux-musl.tar.gz" \
             | sudo tar -C /usr/local/bin -xvzf - --wildcards --strip-components=1 -x '*/sccache'
           echo "SCCACHE_PATH=/usr/local/bin/sccache" >> "$GITHUB_ENV"
           echo "SCCACHE_GHA_USE_PREPROCESSOR_CACHE_MODE=true" >> "$GITHUB_ENV"

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -179,6 +179,7 @@ jobs:
         run: |
           # curl -fsSL "https://github.com/rapidsai/sccache/releases/latest/download/sccache-$(uname -m)-unknown-linux-musl.tar.gz" \
           curl -fsSL "https://github.com/rapidsai/sccache/releases/download/${{ env.SCCACHE_TAG }}/sccache-${{ env.SCCACHE_TAG }}-$(uname -m)-unknown-linux-musl.tar.gz" \
+            | sudo tar -C /usr/local/bin -xvzf - --wildcards --strip-components=1 -x '*/sccache'
           echo "SCCACHE_PATH=/usr/local/bin/sccache" >> "$GITHUB_ENV"
           echo "SCCACHE_GHA_USE_PREPROCESSOR_CACHE_MODE=true" >> "$GITHUB_ENV"
 

--- a/numba_cuda/numba/cuda/_internal/cuda_fp8.py
+++ b/numba_cuda/numba/cuda/_internal/cuda_fp8.py
@@ -1823,30 +1823,6 @@ def _from___nv_fp8_e4m3_to_int8_lower(shim_stream, shim_obj):
 _from___nv_fp8_e4m3_to_int8_lower(shim_stream, shim_obj)
 
 
-def _from___nv_fp8_e4m3_to_int8_lower(shim_stream, shim_obj):
-    shim_raw_str = """
-    extern "C" __device__ int
-    _ZNK13__nv_fp8_e4m3cvcEv_nbst(char &retval, __nv_fp8_e4m3 *self) {
-        retval = self->operator char();
-        return 0;
-    }
-        """
-
-    @lower_cast(_type_fp8_e4m3, int8)
-    def impl(context, builder, fromty, toty, value):
-        context.active_code_library.add_linking_file(shim_obj)
-        callconv = FunctionCallConv(
-            itanium_mangled_name="_ZNK13__nv_fp8_e4m3cvcEv",
-            shim_writer=shim_writer,
-            shim_code=shim_raw_str,
-        )
-        sig = signature(toty, fromty)
-        return callconv(builder, context, sig, [value])
-
-
-_from___nv_fp8_e4m3_to_int8_lower(shim_stream, shim_obj)
-
-
 def _from___nv_fp8_e4m3_to_int16_lower(shim_stream, shim_obj):
     shim_raw_str = """
     extern "C" __device__ int
@@ -2855,30 +2831,6 @@ def _from___nv_fp8_e8m0_to_int8_lower(shim_stream, shim_obj):
         context.active_code_library.add_linking_file(shim_obj)
         callconv = FunctionCallConv(
             itanium_mangled_name="_ZNK13__nv_fp8_e8m0cvaEv",
-            shim_writer=shim_writer,
-            shim_code=shim_raw_str,
-        )
-        sig = signature(toty, fromty)
-        return callconv(builder, context, sig, [value])
-
-
-_from___nv_fp8_e8m0_to_int8_lower(shim_stream, shim_obj)
-
-
-def _from___nv_fp8_e8m0_to_int8_lower(shim_stream, shim_obj):
-    shim_raw_str = """
-    extern "C" __device__ int
-    _ZNK13__nv_fp8_e8m0cvcEv_nbst(char &retval, __nv_fp8_e8m0 *self) {
-        retval = self->operator char();
-        return 0;
-    }
-        """
-
-    @lower_cast(_type_fp8_e8m0, int8)
-    def impl(context, builder, fromty, toty, value):
-        context.active_code_library.add_linking_file(shim_obj)
-        callconv = FunctionCallConv(
-            itanium_mangled_name="_ZNK13__nv_fp8_e8m0cvcEv",
             shim_writer=shim_writer,
             shim_code=shim_raw_str,
         )


### PR DESCRIPTION
FP8 bindings lower casts are generated twice by Numbast. One time for `operator char()` and another time for `operator singed char()`. These C APIs are defined unambiguously for x86 and arm machines. But when registering both in the lowering registry, `operator char()` shadows the lowering for `signed char`. Therefore, in arm machines, when casting fp8 to int8, `operator char()` is always resolved to. Therefore on arm machine negative fp8 values are always truncated.

Closes #866 