### PR TITLE
Fix minor issues in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ into three categories:
 3. Comment on the issue saying you are going to work on it
 4. Code! Make sure to update unit tests!
 5. When done, [create your pull request](https://github.com/NVIDIA/numba-cuda/compare)
-6. Sign the [CLA](https://github.com/NVIDIA/numba-cuda/CLA.md)
+6. Sign the [CLA](https://github.com/NVIDIA/numba-cuda/blob/main/CLA.md)
 7. Verify that CI passes all [status checks](https://help.github.com/articles/about-status-checks/). Fix if needed
 8. Wait for other developers to review your code and update code as needed
 9. Once reviewed and approved, a Numba-CUDA developer will merge your pull request
@@ -44,11 +44,11 @@ These dependencies are listed under the `test-cu12` and `test-cu13` optional dep
 To install Numba-CUDA for development, run this in the root of the repository:
 
 ```shell
-pip install -e ".[test-cu12]"
+pip install -e . --group test-cu12
 ```
 or
 ```sh
-pip install -e ".[test-cu13]"
+pip install -e . --group test-cu13
 ```
 
 Numba-CUDA uses [`pre-commit`](https://pre-commit.com/) to run a number of style

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,18 @@ test = [
     "ml_dtypes",
     "statistics",
 ]
-test-cu12 = ["cuda-toolkit[curand,cublas]==12.*", { include-group = "test" }, "cupy-cuda12x !=14.0.0"]
-test-cu13 = ["cuda-toolkit[curand,cublas]==13.*", { include-group = "test" }, "cupy-cuda13x !=14.0.0"]
+test-cu12 = [
+    "cuda-bindings>=12.9.1,<13.0.0",
+    "cuda-toolkit[curand,cublas]==12.*",
+     { include-group = "test" },
+     "cupy-cuda12x !=14.0.0"
+]
+test-cu13 = [
+    "cuda-bindings==13.*",
+    "cuda-toolkit[curand,cublas]==13.*",
+    { include-group = "test" },
+    "cupy-cuda13x !=14.0.0"
+]
 
 [project.urls]
 Homepage = "https://nvidia.github.io/numba-cuda/"


### PR DESCRIPTION
Fixes #880 

* Modify the CLA hyperlink to point to the right URL

* Update 'pip install' commands to support dependency groups usage in pyproject.toml
   + test-cu12 and test-cu13 were moved from 'optional-dependencies' section to 'dependency-groups' section