### PR TITLE
Fix RMM EMM plugin module path

### DIFF
--- a/docs/source/user/external-memory.rst
+++ b/docs/source/user/external-memory.rst
@@ -282,7 +282,7 @@ Numba test suite with an EMM Plugin, e.g.:
 
 .. code::
 
-   $ NUMBA_CUDA_MEMORY_MANAGER=rmm pytest --pyargs numba.cuda.tests -v
+   $ NUMBA_CUDA_MEMORY_MANAGER=rmm.allocators.numba pytest --pyargs numba.cuda.tests -v
 
 
 Function


### PR DESCRIPTION
## Summary
Updates the RMM EMM plugin example to use the module that exposes `_numba_memory_manager`.