### PR TITLE
Fix CallStack.register orphan lock if exception fires before try/finally

### DIFF
--- a/numba_cuda/numba/cuda/tests/nocuda/test_callstack_register_orphan_lock.py
+++ b/numba_cuda/numba/cuda/tests/nocuda/test_callstack_register_orphan_lock.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Regression test for CallStack.register orphan-lock defect.
+
+If an exception fires after `CallStack._lock` is acquired but before
+the surrounding `try/finally` is entered (e.g. raised by
+`CallFrame.__init__`, an OOM, or an asynchronously-injected interrupt),
+the lock must still be released.  A bug in the previous implementation
+called `self._lock.acquire()` outside the try-block, so any such
+exception would orphan the lock and cause subsequent registrations on
+the same `CallStack` to block forever.
+"""
+
+import threading
+import unittest
+from unittest import mock
+
+from numba.cuda.typing import context as typing_context
+
+
+class _BoomError(RuntimeError):
+    pass
+
+
+class _FakeFuncId:
+    """Minimal stand-in for FunctionIdentity used by CallStack.register."""
+
+    def __init__(self):
+        # `func` only needs to be something `self.match` can compare by
+        # identity.  A bare object suffices: an empty CallStack will not
+        # match anything regardless.
+        self.func = object()
+
+
+class TestCallStackRegisterOrphanLock(unittest.TestCase):
+    def test_lock_released_when_callframe_construction_raises(self):
+        """register() must release its lock if CallFrame() raises."""
+        stack = typing_context.CallStack()
+        func_id = _FakeFuncId()
+
+        with mock.patch.object(
+            typing_context,
+            "CallFrame",
+            side_effect=_BoomError("simulated failure"),
+        ):
+            with self.assertRaises(_BoomError):
+                with stack.register(
+                    target=None,
+                    typeinfer=None,
+                    func_id=func_id,
+                    args=(),
+                ):
+                    # Should never enter the body: CallFrame() raised first.
+                    self.fail("register body should not have executed")
+
+        # The lock must be free.  Use a non-blocking acquire with a
+        # background thread to prove no thread holds it (RLock would
+        # let the same thread re-enter, masking the bug).
+        acquired = [False]
+
+        def _try_acquire():
+            acquired[0] = stack._lock.acquire(blocking=False)
+            if acquired[0]:
+                stack._lock.release()
+
+        thread = threading.Thread(target=_try_acquire)
+        thread.start()
+        thread.join(timeout=5.0)
+        self.assertFalse(
+            thread.is_alive(), "background thread blocked on orphaned lock"
+        )
+        self.assertTrue(
+            acquired[0],
+            "CallStack._lock was orphaned after CallFrame() raised",
+        )
+        # Stack must remain empty since the append never happened.
+        self.assertEqual(len(stack), 0)
+
+    def test_lock_released_on_normal_exit(self):
+        """Sanity check: happy path still releases the lock and pops."""
+        stack = typing_context.CallStack()
+        func_id = _FakeFuncId()
+
+        with mock.patch.object(
+            typing_context, "CallFrame", autospec=False
+        ) as fake_frame:
+            fake_frame.return_value = mock.MagicMock(func_id=func_id, args=())
+            with stack.register(
+                target=None,
+                typeinfer=None,
+                func_id=func_id,
+                args=(),
+            ):
+                self.assertEqual(len(stack), 1)
+
+        self.assertEqual(len(stack), 0)
+        # Lock free in a fresh thread.
+        acquired = [False]
+
+        def _try_acquire():
+            acquired[0] = stack._lock.acquire(blocking=False)
+            if acquired[0]:
+                stack._lock.release()
+
+        thread = threading.Thread(target=_try_acquire)
+        thread.start()
+        thread.join(timeout=5.0)
+        self.assertFalse(thread.is_alive())
+        self.assertTrue(acquired[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/numba_cuda/numba/cuda/typing/context.py
+++ b/numba_cuda/numba/cuda/typing/context.py
@@ -67,13 +67,15 @@ class CallStack(Sequence):
         if self.match(func_id.func, args):
             msg = "compiler re-entrant to the same function signature"
             raise errors.NumbaRuntimeError(msg)
-        self._lock.acquire()
-        self._stack.append(CallFrame(target, typeinfer, func_id, args))
-        try:
-            yield
-        finally:
-            self._stack.pop()
-            self._lock.release()
+        # Use `with self._lock:` so an exception between acquire and the
+        # try-block (e.g. raised by CallFrame.__init__, an OOM, or an
+        # asynchronously-injected interrupt) cannot orphan the lock.
+        with self._lock:
+            self._stack.append(CallFrame(target, typeinfer, func_id, args))
+            try:
+                yield
+            finally:
+                self._stack.pop()
 
     def finditer(self, py_func):
         """


### PR DESCRIPTION
# Fix `CallStack.register` orphan-lock when an exception fires before the `try/finally`

## Summary

`numba_cuda.numba.cuda.typing.context.CallStack.register` acquires
`self._lock` and appends a `CallFrame` to `self._stack` **outside** the
`try/finally` block that releases the lock. Any exception raised between
the `acquire()` call and entry into the `try` block leaves the lock held
forever; subsequent threads (or re-entrant compiles on the same
thread, after enough nesting) deadlock waiting for it.

This PR restructures `register` to use `with self._lock:` so release is
unconditional, and adds a regression test that simulates a failure
inside `CallFrame.__init__` and asserts the lock is no longer held.

No behavior change on the happy path.

## The defect

Current code (`numba_cuda/numba/cuda/typing/context.py`, lines 64-76):

```python
@contextlib.contextmanager
def register(self, target, typeinfer, func_id, args):
    # guard compiling the same function with the same signature
    if self.match(func_id.func, args):
        msg = "compiler re-entrant to the same function signature"
        raise errors.NumbaRuntimeError(msg)
    self._lock.acquire()                                           # (A)
    self._stack.append(CallFrame(target, typeinfer, func_id, args))# (B)
    try:
        yield
    finally:
        self._stack.pop()
        self._lock.release()
```

If anything raises between (A) and entry into the `try` block, the
lock is leaked. Concrete ways that can happen in practice:

* `CallFrame.__init__` itself raises (e.g. an attribute lookup on a
  pathological `func_id`, or a downstream-supplied `target` whose
  initialisation has side effects).
* The Python interpreter raises an `MemoryError` between the
  bytecode that returns from `acquire()` and the bytecode that
  pushes the `try` frame.
* An asynchronous interrupt is delivered to this thread between
  those same two points -- e.g. a `KeyboardInterrupt`, or a
  `PyThreadState_SetAsyncExc` injected by another thread to
  forcibly cancel a long compile.

In any of those cases the lock is held by no live frame, the
context manager never runs, and the next caller of `register` blocks
indefinitely on `self._lock.acquire()`. Because `_lock` is an
`RLock`, a single-threaded reproducer needs nested registrations to
deadlock, but in the multi-threaded compile case any other thread
attempting to register is stuck.

## The fix

```python
@contextlib.contextmanager
def register(self, target, typeinfer, func_id, args):
    if self.match(func_id.func, args):
        msg = "compiler re-entrant to the same function signature"
        raise errors.NumbaRuntimeError(msg)
    # Use `with self._lock:` so an exception between acquire and the
    # try-block (e.g. raised by CallFrame.__init__, an OOM, or an
    # asynchronously-injected interrupt) cannot orphan the lock.
    with self._lock:
        self._stack.append(CallFrame(target, typeinfer, func_id, args))
        try:
            yield
        finally:
            self._stack.pop()
```

`with self._lock:` is the idiomatic Python lock pattern. The release
happens unconditionally, regardless of where inside the block the
exception fires, including during the `CallFrame(...)` constructor
expression. No behavior change on the happy path.

## Reproducer test

Added at
`numba_cuda/numba/cuda/tests/nocuda/test_callstack_register_orphan_lock.py`.

The test patches `CallFrame` to raise on construction, calls
`CallStack.register(...)` inside an `assertRaises`, and then proves
the lock is free by attempting `_lock.acquire(blocking=False)` from a
**different thread** (so `RLock` re-entrancy can't mask the bug).

Behavior on the two code paths:

* Against the current upstream code, the test **fails** with
  `AssertionError: CallStack._lock was orphaned after CallFrame() raised`.
* Against this PR, the test **passes**.

A `test_lock_released_on_normal_exit` sanity test also verifies the
happy path still releases the lock and pops the stack.

The test lives under `tests/nocuda/` because it exercises only the
pure-Python typing scaffolding, with no CUDA runtime required.

## Downstream context

We hit this surface in the FactFiber `ovid` project, an
ovid/Numba-CUDA-based JIT pipeline that supports forcible cancellation
of long-running compiles. When a compile is cancelled mid-flight via
`PyThreadState_SetAsyncExc`, the asynchronous exception can land
between `_lock.acquire()` and entry into the `try` block, orphaning the
lock and wedging the next compile attempt indefinitely. We are
shipping a defensive monkey-patch on top of `numba_cuda` (tracked
internally as `ovid-j4oj`) that applies essentially the change
proposed here. Landing this fix upstream lets us retire the
monkey-patch.

We do not believe the defect requires our cancellation use case to be
real -- any path that can raise between (A) and (B) suffices. We are
just the use case that surfaced it consistently.

## Checklist

- [x] Bug fix scoped to a single defect.
- [x] Regression test added (and verified to fail on the previous code).
- [x] No behavior change on the happy path.
- [x] `ruff check` and `ruff format --check` pass on the touched files
      (using the repo's pinned `ruff==0.11.2`).
- [x] SPDX headers on the new test file; existing header preserved on
      `context.py`.
- [ ] CLA signed (see `CLA.md`) -- pending; not signed in this
      branch.

## Notes for reviewers

- I could not run the full numba-cuda test suite locally without a
  CUDA-capable build matrix; I exercised the affected test directly
  via `python tests/nocuda/test_callstack_register_orphan_lock.py`.
  The `nocuda` test directory is by design CPU-only, so CI should be
  able to run it without GPU resources.
- Happy to expand the test (e.g. add a multi-thread deadlock-detector
  case) if the reviewers prefer; the minimal form here keeps the
  signal clean.
