### PR TITLE
Add CUDA 13 maintenance notice and pixi build fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,17 @@
 The CUDA target for Numba. Please visit the [official
 documentation](https://nvidia.github.io/numba-cuda) to get started!
 
+## Maintenance notice
 
-To report issues or file feature requests, please use the [issue
+Numba-CUDA is in maintenance mode. Moving forward, we intend to support only
+security issues and critical bug fixes through the lifetime of CUDA 13. New
+feature development is targeted towards
+[Numba-CUDA-MLIR](https://github.com/NVIDIA/numba-cuda-mlir), and we recommend
+upgrading to Numba-CUDA-MLIR as soon as practical. For migration guidance, see
+[Migration from Numba /
+Numba-CUDA](https://github.com/NVIDIA/numba-cuda-mlir#migration-from-numba--numba-cuda).
+
+To report security issues or critical bugs, please use the [issue
 tracker](https://github.com/NVIDIA/numba-cuda/issues).
 
 To raise questions or initiate discussions, please use the [Numba Discourse

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,6 +20,20 @@ accelerated libraries like `RAPIDS <https://rapids.ai>`_.
   :ref:`writing-cuda-kernels`.
 * Browse the :ref:`numba-cuda-examples` to see a variety of use cases of Numba-CUDA.
 
+Maintenance Notice
+==================
+
+.. note::
+
+   Numba-CUDA is in maintenance mode. Moving forward, we intend to support only
+   security issues and critical bug fixes through the lifetime of CUDA 13. New
+   feature development is targeted towards `Numba-CUDA-MLIR
+   <https://nvidia.github.io/numba-cuda-mlir>`_, and we recommend upgrading to
+   Numba-CUDA-MLIR as soon as practical.
+
+   For migration guidance, see `Migration from Numba / Numba-CUDA
+   <https://github.com/NVIDIA/numba-cuda-mlir#migration-from-numba--numba-cuda>`_.
+
 Contents
 ========
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -293,7 +293,7 @@ config.compilers = ["cxx"]
 
 [package.build-dependencies]
 # this can't be in `config.compilers` otherwise CUDA_HOME isn't defined
-cuda-compiler = "*"
+cuda-nvcc = "*"
 
 [package.host-dependencies]
 python = "*"


### PR DESCRIPTION
## Summary
  - Add a maintenance notice to the README and docs landing page
  - Clarify that Numba-CUDA support is intended for security issues and critical bug fixes through CUDA 13
  - Point new feature development and migration guidance toward Numba-CUDA-MLIR
  - Replace the pixi package build dependency on cuda-compiler with cuda-nvcc to unblock docs environment solving

  ## Validation
  - pre-commit hooks passed
  - pixi run -e docs build-docs