### PR TITLE
Add maintenance notice to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,15 @@ assignees: ''
 
 ---
 
+<!--
+Numba-CUDA is in maintenance mode. Moving forward, we intend to support only
+security issues and critical bug fixes through the lifetime of CUDA 13. New
+feature development is targeted towards Numba-CUDA-MLIR, and we recommend
+upgrading to Numba-CUDA-MLIR as soon as practical.
+
+See #902 for the public maintenance notice and migration guidance.
+-->
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/documentation-request.md
+++ b/.github/ISSUE_TEMPLATE/documentation-request.md
@@ -7,6 +7,15 @@ assignees: ''
 
 ---
 
+<!--
+Numba-CUDA is in maintenance mode. Moving forward, we intend to support only
+security issues and critical bug fixes through the lifetime of CUDA 13. New
+feature development is targeted towards Numba-CUDA-MLIR, and we recommend
+upgrading to Numba-CUDA-MLIR as soon as practical.
+
+See #902 for the public maintenance notice and migration guidance.
+-->
+
 ## Report incorrect documentation
 
 **Location of incorrect documentation**

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -7,6 +7,15 @@ assignees: ''
 
 ---
 
+<!--
+Numba-CUDA is in maintenance mode. Moving forward, we intend to support only
+security issues and critical bug fixes through the lifetime of CUDA 13. New
+feature development is targeted towards Numba-CUDA-MLIR, and we recommend
+upgrading to Numba-CUDA-MLIR as soon as practical.
+
+See #902 for the public maintenance notice and migration guidance.
+-->
+
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I wish I could use numba-cuda to do [...]
 

--- a/.github/ISSUE_TEMPLATE/submit-question.md
+++ b/.github/ISSUE_TEMPLATE/submit-question.md
@@ -7,4 +7,16 @@ assignees: ''
 
 ---
 
+<!--
+Numba-CUDA is in maintenance mode. Moving forward, we intend to support only
+security issues and critical bug fixes through the lifetime of CUDA 13. New
+feature development is targeted towards Numba-CUDA-MLIR, and we recommend
+upgrading to Numba-CUDA-MLIR as soon as practical.
+
+See #902 for the public maintenance notice and migration guidance.
+
+To raise questions or initiate discussions, please use the Numba Discourse
+forum: https://numba.discourse.group.
+-->
+
 **What is your question?**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,13 @@ Thank you for contributing to numba-cuda :)
 
 Here are some guidelines to help the review process go smoothly.
 
+Numba-CUDA is in maintenance mode. Moving forward, we intend to support only
+security issues and critical bug fixes through the lifetime of CUDA 13. New
+feature development is targeted towards Numba-CUDA-MLIR, and we recommend
+upgrading to Numba-CUDA-MLIR as soon as practical.
+
+See #902 for the public maintenance notice and migration guidance.
+
 1. Please write a description in this text box of the changes that are being
    made.
 


### PR DESCRIPTION
## Summary

- Add the Numba-CUDA maintenance-mode notice to all issue templates and the
  pull request template as HTML comments, so the guidance is visible while
  authoring but hidden in the posted issue or pull request body.
- Point users to the pinned public maintenance notice in #902.
- Direct general questions and discussions toward the Numba Discourse forum.

## Validation

- `git diff --check origin/main..HEAD`
- Pre-commit hooks run during commit.
