### PR TITLE
Add support for Numba 0.66

### DIFF
--- a/numba_cuda/numba/cuda/cgutils.py
+++ b/numba_cuda/numba/cuda/cgutils.py
@@ -22,6 +22,19 @@ int32_t = ir.IntType(32)
 intp_t = ir.IntType(utils.MACHINE_BITS)
 voidptr_t = int8_t.as_pointer()
 
+
+def add_no_capture_attribute(arg):
+    """Mark an LLVM function argument as not capturing pointers."""
+    try:
+        arg.add_attribute("nocapture")
+    except ValueError:
+        # llvmlite >= 0.48 only supports the newer ``captures(none)``
+        # spelling, but NVVM does not accept that syntax. The attribute is an
+        # optimization hint, so omit it when the legacy spelling is
+        # unavailable.
+        pass
+
+
 true_bit = bool_t(1)
 false_bit = bool_t(0)
 true_byte = int8_t(1)

--- a/numba_cuda/numba/cuda/core/ir_utils.py
+++ b/numba_cuda/numba/cuda/core/ir_utils.py
@@ -1040,7 +1040,8 @@ def is_immutable_type(var, typemap):
         typ,
         (
             types.Number,
-            types.scalars._NPDatetimeBase,
+            types.NPDatetime,
+            types.NPTimedelta,
             types.iterators.RangeType,
         ),
     ):

--- a/numba_cuda/numba/cuda/core/pythonapi.py
+++ b/numba_cuda/numba/cuda/core/pythonapi.py
@@ -1318,7 +1318,7 @@ class PythonAPI:
             self.pyobj, [self.voidptr, self.pyobj, intty, intty, self.pyobj]
         )
         fn = self._get_function(fnty, name="NRT_adapt_ndarray_to_python_acqref")
-        fn.args[0].add_attribute("nocapture")
+        cgutils.add_no_capture_attribute(fn.args[0])
 
         ndim = self.context.get_constant(types.int32, aryty.ndim)
         writable = self.context.get_constant(types.int32, int(aryty.mutable))
@@ -1350,8 +1350,8 @@ class PythonAPI:
             fnty,
             "NRT_meminfo_new_from_pyobject",
         )
-        fn.args[0].add_attribute("nocapture")
-        fn.args[1].add_attribute("nocapture")
+        cgutils.add_no_capture_attribute(fn.args[0])
+        cgutils.add_no_capture_attribute(fn.args[1])
         fn.return_value.add_attribute("noalias")
         return self.builder.call(fn, [data, pyobj])
 
@@ -1381,8 +1381,8 @@ class PythonAPI:
         assert self.context.enable_nrt
         fnty = ir.FunctionType(ir.IntType(32), [self.pyobj, self.voidptr])
         fn = self._get_function(fnty, name="NRT_adapt_ndarray_from_python")
-        fn.args[0].add_attribute("nocapture")
-        fn.args[1].add_attribute("nocapture")
+        cgutils.add_no_capture_attribute(fn.args[0])
+        cgutils.add_no_capture_attribute(fn.args[1])
         return self.builder.call(fn, (ary, ptr))
 
     def nrt_adapt_buffer_from_python(self, buf, ptr):
@@ -1391,8 +1391,8 @@ class PythonAPI:
             ir.VoidType(), [ir.PointerType(self.py_buffer_t), self.voidptr]
         )
         fn = self._get_function(fnty, name="NRT_adapt_buffer_from_python")
-        fn.args[0].add_attribute("nocapture")
-        fn.args[1].add_attribute("nocapture")
+        cgutils.add_no_capture_attribute(fn.args[0])
+        cgutils.add_no_capture_attribute(fn.args[1])
         return self.builder.call(fn, (buf, ptr))
 
     # ------ utils -----
@@ -1644,8 +1644,8 @@ class PythonAPI:
         assert not self.context.enable_nrt
         fnty = ir.FunctionType(ir.IntType(32), [self.pyobj, self.voidptr])
         fn = self._get_function(fnty, name="numba_adapt_ndarray")
-        fn.args[0].add_attribute("nocapture")
-        fn.args[1].add_attribute("nocapture")
+        cgutils.add_no_capture_attribute(fn.args[0])
+        cgutils.add_no_capture_attribute(fn.args[1])
         return self.builder.call(fn, (ary, ptr))
 
     def numba_buffer_adaptor(self, buf, ptr):
@@ -1653,8 +1653,8 @@ class PythonAPI:
             ir.VoidType(), [ir.PointerType(self.py_buffer_t), self.voidptr]
         )
         fn = self._get_function(fnty, name="numba_adapt_buffer")
-        fn.args[0].add_attribute("nocapture")
-        fn.args[1].add_attribute("nocapture")
+        cgutils.add_no_capture_attribute(fn.args[0])
+        cgutils.add_no_capture_attribute(fn.args[1])
         return self.builder.call(fn, (buf, ptr))
 
     def complex_adaptor(self, cobj, cmplx):

--- a/numba_cuda/numba/cuda/memory_management/nrt_context.py
+++ b/numba_cuda/numba/cuda/memory_management/nrt_context.py
@@ -388,7 +388,7 @@ class NRTContext:
             # XXX "nonnull" causes a crash in test_dyn_array: can this
             # function be called with a NULL pointer?
             fn.args[0].add_attribute("noalias")
-            fn.args[0].add_attribute("nocapture")
+            cgutils.add_no_capture_attribute(fn.args[0])
             builder.call(fn, [mi])
 
     def incref(self, builder, typ, value):

--- a/numba_cuda/numba/cuda/np/npyimpl.py
+++ b/numba_cuda/numba/cuda/np/npyimpl.py
@@ -387,7 +387,7 @@ def _prepare_argument(ctxt, bld, inp, tyinp, where="input operand"):
         )
     elif types.unliteral(tyinp) in types.number_domain | {
         types.boolean
-    } or isinstance(tyinp, types.scalars._NPDatetimeBase):
+    } or isinstance(tyinp, (types.NPDatetime, types.NPTimedelta)):
         return _ScalarHelper(ctxt, bld, inp, tyinp)
     else:
         raise NotImplementedError(

--- a/numba_cuda/numba/cuda/tests/nocuda/test_import.py
+++ b/numba_cuda/numba/cuda/tests/nocuda/test_import.py
@@ -6,6 +6,12 @@ import unittest
 
 
 class TestImport(unittest.TestCase):
+    def test_datetime_types(self):
+        from numba import cuda, types
+
+        self.assertIs(cuda.types.NPDatetime, types.NPDatetime)
+        self.assertIs(cuda.types.NPTimedelta, types.NPTimedelta)
+
     def test_no_impl_import(self):
         """
         Tests that importing cuda doesn't trigger the import of modules

--- a/numba_cuda/numba/cuda/types/__init__.py
+++ b/numba_cuda/numba/cuda/types/__init__.py
@@ -16,6 +16,13 @@ from .scalars import *
 from .function_type import *
 from .ext_types import bfloat16, dim3, grid_group, GridGroup, Dim3
 
+try:
+    from numba.np.types import NPDatetime, NPTimedelta
+except ImportError:
+    # Numba < 0.66 defines these in numba.core.types.scalars, from which they
+    # are imported above.
+    pass
+
 numpy_version = tuple(map(int, np.__version__.split(".")[:2]))
 
 # Short names


### PR DESCRIPTION
Numba 0.66 moved `NPDatetime` and `NPTimedelta` from
`numba.core.types.scalars` to `numba.np.types`. This updates numba-cuda to
re-export the types from their new public location while preserving the
existing behavior with older Numba releases. It also replaces the remaining
uses of the old private `_NPDatetimeBase` path with the public concrete types.

xref: https://github.com/NVIDIA/numba-cuda-mlir/issues/172
xref: https://github.com/rapidsai/build-planning/issues/301

Tests:

- `pre-commit run --files ...`
- Numba 0.66.0 / Python 3.14: no-CUDA import tests (2 passed)
- Numba 0.66.0 / Python 3.14 on an NVIDIA GeForce RTX 2070 SUPER: datetime tests (7 passed)
- Numba 0.60.0 / Python 3.12: no-CUDA import tests (2 passed)
- Numba 0.60.0 / Python 3.12 on an NVIDIA GeForce RTX 2070 SUPER: datetime tests (7 passed)
