### PR TITLE
Fix TypeManager null dereference in _typeconv.select_overload

### DIFF
--- a/numba_cuda/numba/cuda/cext/_typeconv.cpp
+++ b/numba_cuda/numba/cuda/cext/_typeconv.cpp
@@ -90,6 +90,7 @@ select_overload(PyObject* self, PyObject* args)
     TypeManager *tm = unwrap_TypeManager(tmcap);
     if (!tm) {
         BAD_TM_ARGUMENT;
+        return NULL;
     }
 
     Py_ssize_t sigsz = PySequence_Size(sigtup);

--- a/numba_cuda/numba/cuda/tests/cudapy/test_typeconv.py
+++ b/numba_cuda/numba/cuda/tests/cudapy/test_typeconv.py
@@ -4,6 +4,7 @@
 import itertools
 
 from numba.cuda import types
+from numba.cuda.cext import _typeconv
 from numba.cuda.typeconv.typeconv import TypeManager, TypeCastingRules
 from numba.cuda.typeconv import rules
 from numba.cuda.typeconv import castgraph, Conversion
@@ -93,6 +94,10 @@ class TestTypeConv(CompatibilityTestMixin, unittest.TestCase):
         # allow_unsafe = False => no overload available
         with self.assertRaises(TypeError):
             sel = tm.select_overload(sig, ovs, False, False)
+
+    def test_select_overload_bad_type_manager(self):
+        with self.assertRaises(TypeError):
+            _typeconv.select_overload(None, (), (), True, False)
 
     def test_default_rules(self):
         tm = rules.default_type_manager


### PR DESCRIPTION
## Summary
- Guard `select_overload()` after `unwrap_TypeManager()` failure to return `NULL` immediately with `TypeError`.
- Add regression test `test_select_overload_bad_type_manager` to ensure invalid capsule input fails safely.