### PR TITLE
ci: adopt CCCL check_result aggregator for Check job status (fixes #900)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -294,6 +294,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     needs:
+      - should-skip
       - test-linux-64
       - test-linux-aarch64
       - test-windows
@@ -308,45 +309,41 @@ jobs:
     steps:
       - name: Exit
         run: |
-          # if any dependencies were cancelled or failed, that's a failure
-          #
-          # see https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#always
-          # and https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
-          # for why this cannot be encoded in the job-level `if:` field
-          #
-          # TL; DR: `$REASONS`
-          #
-          # The intersection of skipped-as-success and required status checks
-          # creates a scenario where if you DON'T `always()` run this job, the
-          # status check UI will block merging and if you DO `always()` run and
-          # a dependency is _cancelled_ (due to a critical failure, which is
-          # somehow not considered a failure ¯\_(ツ)_/¯) then the critically
-          # failing job(s) will timeout causing a cancellation here and the
-          # build to succeed which we don't want (originally this was just
-          # 'exit 0')
-          if ${{ needs.test-linux-64.result == 'cancelled' ||
-                 needs.test-linux-64.result == 'failure' ||
-                 needs.test-linux-aarch64.result == 'cancelled' ||
-                 needs.test-linux-aarch64.result == 'failure' ||
-                 needs.test-windows.result == 'cancelled' ||
-                 needs.test-windows.result == 'failure' ||
-                 needs.pre-commit.result == 'cancelled' ||
-                 needs.pre-commit.result == 'failure' ||
-                 needs.test-conda.result == 'cancelled' ||
-                 needs.test-conda.result == 'failure' ||
-                 needs.test-simulator.result == 'cancelled' ||
-                 needs.test-simulator.result == 'failure' ||
-                 needs.test-thirdparty-cudf.result == 'cancelled' ||
-                 needs.test-thirdparty-cudf.result == 'failure' ||
-                 needs.test-thirdparty-nvmath.result == 'cancelled' ||
-                 needs.test-thirdparty-nvmath.result == 'failure' ||
-                 needs.test-thirdparty-awkward.result == 'cancelled' ||
-                 needs.test-thirdparty-awkward.result == 'failure' ||
-                 needs.build-docs.result == 'cancelled' ||
-                 needs.build-docs.result == 'failure' ||
-                 needs.coverage-report.result == 'cancelled' ||
-                 needs.coverage-report.result == 'failure' }}; then
-            exit 1
-          else
+          # GitHub treats `result == 'skipped'` as success for required
+          # status checks (see CCCL gate comment + cccl#605). The previous
+          # `cancelled || failure` predicate let upstream build failures
+          # propagate as `skipped` on downstream test jobs and silently
+          # pass this aggregator. Adopt CCCL's `check_result` pattern:
+          # require an explicit `expected` status per dependency, where
+          # anything else (including `skipped` from a failed upstream)
+          # fails the gate. `if: always()` on the job still ensures this
+          # step runs even when needs are skipped.
+          if [[ "${{ needs.should-skip.outputs.skip }}" == "true" ]]; then
+            echo "[no-ci] - skipping aggregator checks"
             exit 0
           fi
+
+          status="success"
+          check_result() {
+            name=$1; expected=$2; result=$3
+            echo "Checking $name: result='$result' (expected '$expected')"
+            if [[ "$result" != "$expected" ]]; then
+              echo "::error::$name did not match expected result"
+              status="failed"
+            fi
+          }
+
+          check_result "should-skip"            "success" "${{ needs.should-skip.result }}"
+          check_result "test-linux-64"          "success" "${{ needs.test-linux-64.result }}"
+          check_result "test-linux-aarch64"     "success" "${{ needs.test-linux-aarch64.result }}"
+          check_result "test-windows"           "success" "${{ needs.test-windows.result }}"
+          check_result "pre-commit"             "success" "${{ needs.pre-commit.result }}"
+          check_result "test-conda"             "success" "${{ needs.test-conda.result }}"
+          check_result "test-simulator"         "success" "${{ needs.test-simulator.result }}"
+          check_result "test-thirdparty-cudf"   "success" "${{ needs.test-thirdparty-cudf.result }}"
+          check_result "test-thirdparty-nvmath" "success" "${{ needs.test-thirdparty-nvmath.result }}"
+          check_result "test-thirdparty-awkward" "success" "${{ needs.test-thirdparty-awkward.result }}"
+          check_result "build-docs"             "success" "${{ needs.build-docs.result }}"
+          check_result "coverage-report"        "success" "${{ needs.coverage-report.result }}"
+
+          [[ "$status" == "success" ]]


### PR DESCRIPTION
## Summary

Ports the gating-check fix from NVIDIA/cuda-python#2210 to this repo. Closes #900.

Root cause and design discussion live in NVIDIA/cuda-python#2208 — not repeating here. Bit us in this repo on 2026-07-03 when [`5f530b96`](https://github.com/NVIDIA/numba-cuda/commit/5f530b96) auto-merged with a silent Windows failure and had to be reverted in [`441882b2`](https://github.com/NVIDIA/numba-cuda/commit/441882b2).

## Change

One file, `.github/workflows/ci.yaml`, `checks:` job only:

- Replace the `cancelled || failure` predicate with CCCL's `check_result` pattern: per-dep `expected="success"`, `[no-ci]` short-circuit at the top.
- Add `should-skip` to `needs:` and check its result explicitly — a crash in the gating job can no longer masquerade as a green CI run.
- No `[doc-only]` machinery — this repo doesn't have that PR mode. If added later, mirror NVIDIA/numba-cuda-mlir#142.

## Verification

Local simulation of the new aggregator across 6 scenarios (normal-green, build-windows-fail-cascade, build-linux-64-fail-cascade, `[no-ci]`, pre-commit-fail, should-skip-itself-fails) — all behave as expected.

## Reference

- Tracking issue on this repo: #900
- Root cause: NVIDIA/cuda-python#2208
- Source-of-truth fix: NVIDIA/cuda-python#2210
- Sibling port to numba-cuda-mlir: NVIDIA/numba-cuda-mlir#142
- CCCL gate pattern: https://github.com/NVIDIA/cccl/blob/8c0e6cb1b6412d7bd0070f9ac3f55fa80231961a/.github/workflows/ci-workflow-pull-request.yml#L463-L526