### PR TITLE
Guard np.row_stack overload for numpy < 2.5 (#907)

### DIFF
--- a/numba_cuda/numba/cuda/np/arrayobj.py
+++ b/numba_cuda/numba/cuda/np/arrayobj.py
@@ -6856,7 +6856,7 @@ def impl_np_vstack(tup):
         return impl
 
 
-if numpy_version >= (2, 0):
+if numpy_version >= (2, 0) and numpy_version < (2, 5):
     overload(np.row_stack)(impl_np_vstack)
 
 


### PR DESCRIPTION
## Summary
`numpy` 2.5 removes `np.row_stack`. The overload was registered unconditionally for `numpy_version >= (2, 0)`, so it breaks under numpy 2.5. This bounds it to `[2.0, 2.5)`, mirroring the upstream numba fix in numba/numba#10645 (as suggested by the reporter).

## Change
`numba_cuda/numba/cuda/np/arrayobj.py`:
```python
-if numpy_version >= (2, 0):
+if numpy_version >= (2, 0) and numpy_version < (2, 5):
     overload(np.row_stack)(impl_np_vstack)
```

Closes #907

cc @gmarkall