### PR TITLE
Fix numpy 2.5 deprecation warnings

### DIFF
--- a/numba_cuda/numba/cuda/np/npdatetime_helpers.py
+++ b/numba_cuda/numba/cuda/np/npdatetime_helpers.py
@@ -28,7 +28,7 @@ DATETIME_UNITS = {
     "": 14,  # "generic", i.e. unit-less
 }
 
-NAT = np.timedelta64("nat").astype(np.int64)
+NAT = np.timedelta64("nat", "s").astype(np.int64)
 
 # NOTE: numpy has several inconsistent functions for timedelta casting:
 # - can_cast_timedelta64_{metadata,units}() disallows "safe" casting


### PR DESCRIPTION
Inherits a fix already on upstream that emits a warning for an deprecated method of datetime construction we're still using. This is strictly for numpy >= 2.5 environments. 